### PR TITLE
Polls for creative creation before showing the WebView

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/creatives/Creative.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/creatives/Creative.java
@@ -26,13 +26,17 @@ public class Creative {
             "            }\n" +
             "        },\n" +
             "    false);\n" +
-            "\n" +
-            "    setTimeout(function(){\n" +
-            "        e=document.querySelector('iframe');\n" +
-            "        if(e && e.id === 'attentive_creative') {" +
-            "           CREATIVE_LISTENER.postMessage('OPEN')}" +
-            "        },\n" +
-            "    1000);\n" +
+            "    const interval = setInterval(function() {\n" +
+            "        e =document.querySelector('iframe');\n" +
+            "        if(e && e.id === 'attentive_creative') {\n" +
+            "           clearInterval(interval);\n" +
+            "           CREATIVE_LISTENER.postMessage('OPEN');\n" +
+            "        }\n" +
+            "    }, 100);\n" +
+            "    setTimeout(function() {\n" +
+            "        clearInterval(interval);\n" +
+            "        CREATIVE_LISTENER.postMessage('TIMED OUT');\n" +
+            "    }, 5000);\n" +
             "\n" +
             "})()";
 
@@ -126,6 +130,7 @@ public class Creative {
                 super.onPageFinished(view, url);
 
                 if (view.getProgress() == 100) {
+                    Log.i(this.getClass().getName(), "Page finished loading");
                     view.loadUrl(CREATIVE_LISTENER_JS);
                 }
             }
@@ -155,6 +160,8 @@ public class Creative {
                     handler.post(() -> webView.setVisibility(View.INVISIBLE));
                 } else if (messageData.equalsIgnoreCase("OPEN")) {
                     handler.post(() -> webView.setVisibility(View.VISIBLE));
+                } else if (messageData.equalsIgnoreCase("TIMED OUT")) {
+                    Log.e(this.getClass().getName(), "Creative timed out. Not showing WebView.");
                 }
             }
         };


### PR DESCRIPTION
After the index.html is loaded, this JS polls every 0.1 seconds for 5 seconds to see if the creative is loaded yet. If the creative doesn't show in 5 seconds then we log an error and never show creative even if it eventually loads.

Testing:
Ran through the following steps 10 times on two different emulators:
1. **Success scenario:** Start Example app. Click "Push me for next activity" button. Click "Push me for creative". Result: Creative shows.
2. **Failure scenario** I changed the 5 second timeout to 0.05 seconds timeout. This is to test what happens if the Creative doesn't load in time. Steps: Start Example app. Click "Push me for next activity" button. Click "Push me for creative". Result: Creative never shows. An error is logged in Logcat: `Creative timed out. Not showing WebView.`. (Note: this error does not have any negative effect on the running app)