### PR TITLE
Dont log timeout when creative loads

### DIFF
--- a/attentive-android-sdk/build.gradle
+++ b/attentive-android-sdk/build.gradle
@@ -74,7 +74,7 @@ afterEvaluate {
 
                 groupId 'com.attentive'
                 artifactId 'attentive-android-sdk'
-                version '0.1.1'
+                version '0.1.2'
             }
         }
 

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/creatives/Creative.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/creatives/Creative.java
@@ -26,14 +26,18 @@ public class Creative {
             "            }\n" +
             "        },\n" +
             "    false);\n" +
+            "    var timeoutHandle = null;\n" +
             "    const interval = setInterval(function() {\n" +
             "        e =document.querySelector('iframe');\n" +
             "        if(e && e.id === 'attentive_creative') {\n" +
             "           clearInterval(interval);\n" +
             "           CREATIVE_LISTENER.postMessage('OPEN');\n" +
+            "           if (timeoutHandle != null) {\n" +
+            "               clearTimeout(timeoutHandle);\n" +
+            "           }\n" +
             "        }\n" +
             "    }, 100);\n" +
-            "    setTimeout(function() {\n" +
+            "    timeoutHandle = setTimeout(function() {\n" +
             "        clearInterval(interval);\n" +
             "        CREATIVE_LISTENER.postMessage('TIMED OUT');\n" +
             "    }, 5000);\n" +


### PR DESCRIPTION
1. Clear the creative timeout timer if the creative successfully loads so we don't log that the creative timed out.
2. Bumps package version