### PR TITLE
Send identifiers to server when identify called

### DIFF
--- a/attentive-android-sdk/build.gradle
+++ b/attentive-android-sdk/build.gradle
@@ -55,6 +55,11 @@ dependencies {
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.webkit:webkit:1.5.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
+
+    // 'api' instead of 'implementation' because we allow the host app to pass in an okhttp object,
+    // so we want to expose the okhttp object
+    api 'com.squareup.okhttp3:okhttp:4.10.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:4.9.0'

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.java
@@ -1,0 +1,194 @@
+package com.attentive.androidsdk;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+class AttentiveApi {
+    private static final String ATTENTIVE_EVENTS_ENDPOINT_HOST = "events.attentivemobile.com";
+    private static final String ATTENTIVE_DTAG_URL = "https://cdn.attn.tv/%s/dtag.js";
+
+    private final OkHttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    public AttentiveApi(OkHttpClient httpClient, ObjectMapper objectMapper) {
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+    }
+
+    public void sendUserIdentifiersCollectedEvent(String domain, UserIdentifiers userIdentifiers, AttentiveApiCallback callback) {
+        // first get the geo-adjusted domain, and then call the events endpoint
+        final String url = String.format(ATTENTIVE_DTAG_URL, domain);
+        Request request = new Request.Builder().url(url).build();
+        httpClient.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(@NonNull Call call, @NonNull IOException e) {
+                callback.onFailure("Getting geo-adjusted domain failed: " + e.getMessage());
+            }
+
+            @Override
+            public void onResponse(@NonNull Call call, @NonNull Response response) throws IOException {
+                // Check explicitly for 200 (instead of response.isSuccessful()) because the response only has the tag in the body when its code is 200
+                if (response.code() != 200) {
+                    callback.onFailure(String.format("Getting geo-adjusted domain returned invalid code: '%d', message: '%s'", response.code(), response.message()));
+                    return;
+                }
+
+                ResponseBody body = response.body();
+
+                if (body == null) {
+                    callback.onFailure("Getting geo-adjusted domain returned no body");
+                    return;
+                }
+
+                String fullTag = response.body().string();
+                String geoAdjustedDomain = parseAttentiveDomainFromTag(fullTag);
+
+                if (geoAdjustedDomain == null) {
+                    callback.onFailure("Could not parse the domain from the full tag");
+                    return;
+                }
+
+                internalSendUserIdentifiersCollectedEventAsync(geoAdjustedDomain, userIdentifiers, callback);
+            }
+        });
+    }
+
+    private void internalSendUserIdentifiersCollectedEventAsync(String geoAdjustedDomain, UserIdentifiers userIdentifiers, AttentiveApiCallback callback) {
+        String externalVendorIdsJson = null;
+        try {
+            List<ExternalVendorId> externalVendorIds = buildExternalVendorIds(userIdentifiers);
+            externalVendorIdsJson = objectMapper.writeValueAsString(externalVendorIds);
+        } catch (JsonProcessingException e) {
+            callback.onFailure(String.format("Could not serialize the UserIdentifiers. Message: '%s'", e.getMessage()));
+            return;
+        }
+
+        String metadataJson = null;
+        try {
+            Metadata metadata = buildMetadata(userIdentifiers);
+            metadataJson = objectMapper.writeValueAsString(metadata);
+        } catch (JsonProcessingException e) {
+            callback.onFailure(String.format("Could not serialize metadata. Message: '%s'", e.getMessage()));
+            return;
+        }
+
+        HttpUrl.Builder urlBuilder = getHttpUrlEventsEndpointBuilder()
+            .addQueryParameter("v", "mobile-app")
+            .addQueryParameter("c", geoAdjustedDomain)
+            .addQueryParameter("t", "idn")
+            .addQueryParameter("evs", externalVendorIdsJson)
+            .addQueryParameter("m", metadataJson);
+
+        if (userIdentifiers.getVisitorId() != null) {
+            urlBuilder.addQueryParameter("u", userIdentifiers.getVisitorId());
+        }
+
+        HttpUrl url = urlBuilder.build();
+
+        Request request = new Request.Builder().url(url).build();
+        httpClient.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(@NonNull Call call, @NonNull IOException e) {
+                callback.onFailure(String.format("Error when calling the event endpoint: '%s'", e.getMessage()));
+            }
+
+            @Override
+            public void onResponse(@NonNull Call call, @NonNull Response response) {
+                if (!response.isSuccessful()) {
+                    callback.onFailure(String.format("Invalid response code when calling the event endpoint: '%d', message: '%s'", response.code(), response.message()));
+                    return;
+                }
+
+                callback.onSuccess();
+            }
+        });
+    }
+
+    private HttpUrl.Builder getHttpUrlEventsEndpointBuilder() {
+        return new HttpUrl.Builder()
+                .scheme("https")
+                .host(ATTENTIVE_EVENTS_ENDPOINT_HOST)
+                .addPathSegment("e");
+    }
+
+    @Nullable
+    private String parseAttentiveDomainFromTag(String tag) {
+        Pattern pattern = Pattern.compile("window.__attentive_domain='(.*?).attn.tv'");
+        Matcher matcher = pattern.matcher(tag);
+        if (matcher.find()) {
+            if (matcher.groupCount() == 1) {
+                return matcher.group(1);
+            }
+        }
+
+        return null;
+    }
+
+    private Metadata buildMetadata(UserIdentifiers userIdentifiers) {
+        Metadata metadata = new Metadata();
+
+        if (userIdentifiers.getPhone() != null) {
+            metadata.setPhone(userIdentifiers.getPhone());
+        }
+
+        if (userIdentifiers.getEmail() != null) {
+            metadata.setEmail(userIdentifiers.getEmail());
+        }
+
+        return metadata;
+    }
+
+    private List<ExternalVendorId> buildExternalVendorIds(UserIdentifiers userIdentifiers) {
+        List<ExternalVendorId> externalVendorIdList = new ArrayList<>();
+
+        if (userIdentifiers.getClientUserId() != null) {
+            externalVendorIdList.add(
+                new ExternalVendorId() {{
+                    setVendor(Vendor.CLIENT_USER);
+                    setId(userIdentifiers.getClientUserId());
+                }});
+        }
+
+        if (userIdentifiers.getShopifyId() != null) {
+            externalVendorIdList.add(new ExternalVendorId() {{
+                setVendor(Vendor.SHOPIFY);
+                setId(userIdentifiers.getShopifyId());
+            }});
+        }
+
+        if (userIdentifiers.getKlaviyoId() != null) {
+            externalVendorIdList.add(new ExternalVendorId() {{
+                setVendor(Vendor.KLAVIYO);
+                setId(userIdentifiers.getKlaviyoId());
+            }});
+        }
+
+        for (Map.Entry<String, String> customIdentifier : userIdentifiers.getCustomIdentifiers().entrySet()) {
+            externalVendorIdList.add(new ExternalVendorId() {{
+                setVendor(Vendor.CUSTOM_USER);
+                setId(customIdentifier.getKey());
+                setName(customIdentifier.getValue());
+            }});
+        }
+
+        return externalVendorIdList;
+    }
+}

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApiCallback.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApiCallback.java
@@ -1,0 +1,7 @@
+package com.attentive.androidsdk;
+
+interface AttentiveApiCallback {
+    void onFailure(String message);
+
+    void onSuccess();
+}

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/ClassFactory.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/ClassFactory.java
@@ -1,6 +1,8 @@
 package com.attentive.androidsdk;
 
 import android.content.Context;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
 
 public class ClassFactory {
     public static PersistentStorage buildPersistentStorage(Context context) {
@@ -9,5 +11,17 @@ public class ClassFactory {
 
     public static VisitorService buildVisitorService(PersistentStorage persistentStorage) {
         return new VisitorService(persistentStorage);
+    }
+
+    public static ObjectMapper buildObjectMapper() {
+        return new ObjectMapper();
+    }
+
+    public static OkHttpClient buildOkHttpClient() {
+        return new OkHttpClient.Builder().build();
+    }
+
+    public static AttentiveApi buildAttentiveApi(OkHttpClient okHttpClient, ObjectMapper objectMapper) {
+        return new AttentiveApi(okHttpClient, objectMapper);
     }
 }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/ExternalVendorId.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/ExternalVendorId.java
@@ -1,0 +1,53 @@
+package com.attentive.androidsdk;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class ExternalVendorId {
+    private Vendor vendor;
+    private String id;
+    private String name;
+
+    public Vendor getVendor() {
+        return vendor;
+    }
+
+    public void setVendor(Vendor vendor) {
+        this.vendor = vendor;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public enum Vendor {
+        SHOPIFY("0"),
+        KLAVIYO("1"),
+        CLIENT_USER("2"),
+        CUSTOM_USER("6");
+
+        private final String id;
+
+        Vendor(String id) {
+            this.id = id;
+        }
+
+        @JsonValue
+        String getVendorId() {
+            return id;
+        }
+    }
+}

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/Metadata.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/Metadata.java
@@ -1,0 +1,34 @@
+package com.attentive.androidsdk;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class Metadata {
+    private String phone;
+    private String email;
+    private String source = "msdk";
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+}

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/FactoryMocks.java
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/FactoryMocks.java
@@ -1,7 +1,10 @@
 package com.attentive.androidsdk;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -9,13 +12,20 @@ public class FactoryMocks implements AutoCloseable {
     private final MockedStatic<ClassFactory> classFactoryMockedStatic;
     private final PersistentStorage persistentStorage;
     private final VisitorService visitorService;
+    private final OkHttpClient okHttpClient;
+    private final AttentiveApi attentiveApi;
+    private final ObjectMapper objectMapper;
 
     private FactoryMocks(MockedStatic<ClassFactory> classFactoryMockedStatic,
                          PersistentStorage persistentStorage,
-                         VisitorService visitorService) {
+                         VisitorService visitorService, OkHttpClient okHttpClient,
+                         AttentiveApi attentiveApi, ObjectMapper objectMapper) {
         this.classFactoryMockedStatic = classFactoryMockedStatic;
         this.persistentStorage = persistentStorage;
         this.visitorService = visitorService;
+        this.okHttpClient = okHttpClient;
+        this.attentiveApi = attentiveApi;
+        this.objectMapper = objectMapper;
     }
 
     public static FactoryMocks mockFactoryObjects() {
@@ -27,7 +37,17 @@ public class FactoryMocks implements AutoCloseable {
         VisitorService visitorService = Mockito.mock(VisitorService.class);
         classFactoryMockedStatic.when(() -> ClassFactory.buildVisitorService(any())).thenReturn(visitorService);
 
-        return new FactoryMocks(classFactoryMockedStatic, persistentStorage, visitorService);
+        ObjectMapper objectMapper = spy(new ObjectMapper());
+        classFactoryMockedStatic.when(ClassFactory::buildObjectMapper).thenReturn(objectMapper);
+
+        OkHttpClient okHttpClient = Mockito.mock(OkHttpClient.class);
+        classFactoryMockedStatic.when(ClassFactory::buildOkHttpClient).thenReturn(okHttpClient);
+
+        AttentiveApi attentiveApi = Mockito.mock(AttentiveApi.class);
+        classFactoryMockedStatic.when(() -> ClassFactory.buildAttentiveApi(any(), any())).thenReturn(attentiveApi);
+
+        return new FactoryMocks(classFactoryMockedStatic, persistentStorage, visitorService, okHttpClient, attentiveApi,
+            objectMapper);
     }
 
     public PersistentStorage getPersistentStorage() {
@@ -36,6 +56,18 @@ public class FactoryMocks implements AutoCloseable {
 
     public VisitorService getVisitorService() {
         return this.visitorService;
+    }
+
+    public OkHttpClient getOkHttpClient() {
+        return okHttpClient;
+    }
+
+    public AttentiveApi getAttentiveApi() {
+        return attentiveApi;
+    }
+
+    public ObjectMapper getObjectMapper() {
+        return objectMapper;
     }
 
     @Override


### PR DESCRIPTION
* When `AttentiveConfig.identify` is called, sends the given UserIdentifiers to the Attentive `events` endpoint