### PR TITLE
Fix NPE in Creative

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/creatives/Creative.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/creatives/Creative.java
@@ -148,9 +148,13 @@ public class Creative {
         if (parentView != null && webView != null) {
             ((ViewGroup) parentView).removeView(webView);
         }
+        // TODO: better thread-safety when destroying. Lock?
         if (webView != null) {
-            webView.destroy();
+            // set the webView member variable to null BEFORE we destroy it so other code on other threads that check if
+            // webView isn't null doesn't try to use it after it is destroyed
+            WebView webViewToDestroy = webView;
             webView = null;
+            webViewToDestroy.destroy();
         }
     }
 

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/creatives/Creative.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/creatives/Creative.java
@@ -215,9 +215,25 @@ public class Creative {
             String messageData = message.getData();
             if (messageData != null) {
                 if (messageData.equalsIgnoreCase("CLOSE")) {
-                    handler.post(() -> webView.setVisibility(View.INVISIBLE));
+                    handler.post(() -> {
+                        if (webView != null) {
+                            webView.setVisibility(View.INVISIBLE);
+                        } else {
+                            Log.w(this.getClass().getName(), "The user closed the creative but the webview is null. Ignoring.");
+                        }
+                    });
                 } else if (messageData.equalsIgnoreCase("OPEN")) {
-                    handler.post(() -> webView.setVisibility(View.VISIBLE));
+                    handler.post(() -> {
+                        // Host apps have reported webView NPEs here. The current thinking is that destroy gets
+                        // called just before this callback is executed. If destroy was previously called then it's
+                        // okay to ignore these callbacks since the host app has told us the creative should no longer
+                        // be displayed.
+                        if (webView != null) {
+                            webView.setVisibility(View.VISIBLE);
+                        } else {
+                            Log.w(this.getClass().getName(), "The creative loaded but the webview is null. Ignoring.");
+                        }
+                    });
                 } else if (messageData.equalsIgnoreCase("TIMED OUT")) {
                     Log.e(this.getClass().getName(), "Creative timed out. Not showing WebView.");
                 }


### PR DESCRIPTION
The cause of this bug is still not known. The thinking is that there's a race condition: `Creative.destroy()` is called, which sets the `webView` to null. Next, the `WebViewCompat.WebMessageListener` callback is executed. That callback needs a non-null WebView.

If the `webView` is null then `destroy` was called. In this case, we can safely ignore any callbacks because the Creative is not in use anymore.