### PR TITLE
Revert "Okim/remove gh creds (#42)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 The Attentive Android SDK provides the functionality to render Attentive creative units in Android mobile applications.
 
 ## Installation
+Follow the [GitHub documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry#using-a-published-package)
+on using a GitHub Package to set up your Personal Access Token.
+
 Add the Attentive Android SDK GitHub Package maven repository to your `build.gradle` `buildscript` or
 `settings.gradle` `dependencyResolutionManagement`:
 ```groovy
@@ -9,6 +12,10 @@ repositories {
     // ...
     maven {
         url = uri("https://maven.pkg.github.com/attentive-mobile/attentive-android-sdk")
+        credentials {
+            username = properties.findProperty("gpr.user") ?: System.getenv("USERNAME")
+            password = properties.findProperty("gpr.key") ?: System.getenv("TOKEN")
+        }
     }
 }
 ```

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,10 @@ dependencyResolutionManagement {
         mavenCentral()
         maven {
             url = uri("https://maven.pkg.github.com/attentive-mobile/attentive-android-sdk")
+            credentials {
+                username = ghProperties.getProperty('gpr.user', System.getenv("GH_USERNAME"))
+                password = ghProperties.getProperty('gpr.key', System.getenv("GH_TOKEN"))
+            }
         }
     }
 }


### PR DESCRIPTION
This reverts commit 56e6aa50e9fc055eb67462a1c0cf8fc66f81a52e.

I thought that we wouldn't need these creds bc this is a public repo but github does not currently support unauthorized reads even on public packages. When i was testing this out earlier it must have used a cached version / I may not have cleared the cache properly