### PR TITLE
Update regex to be more flexible for dtag compilation variation

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.java
@@ -202,7 +202,7 @@ class AttentiveApi {
 
     @Nullable
     private String parseAttentiveDomainFromTag(String tag) {
-        Pattern pattern = Pattern.compile("window.__attentive_domain='(.*?).attn.tv'");
+        Pattern pattern = Pattern.compile("='([a-z|0-9|/-]+).attn.tv'");
         Matcher matcher = pattern.matcher(tag);
         if (matcher.find()) {
             if (matcher.groupCount() == 1) {

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.java
@@ -202,7 +202,7 @@ class AttentiveApi {
 
     @Nullable
     private String parseAttentiveDomainFromTag(String tag) {
-        Pattern pattern = Pattern.compile("='([a-z|0-9|/-]+).attn.tv'");
+        Pattern pattern = Pattern.compile("='([a-z0-9-]+).attn.tv'");
         Matcher matcher = pattern.matcher(tag);
         if (matcher.find()) {
             if (matcher.groupCount() == 1) {

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.java
@@ -202,7 +202,7 @@ class AttentiveApi {
 
     @Nullable
     private String parseAttentiveDomainFromTag(String tag) {
-        Pattern pattern = Pattern.compile("='([a-z0-9-]+).attn.tv'");
+        Pattern pattern = Pattern.compile("='([a-z0-9-]+)[.]attn[.]tv'");
         Matcher matcher = pattern.matcher(tag);
         if (matcher.find()) {
             if (matcher.groupCount() == 1) {

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveApiTest.java
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveApiTest.java
@@ -54,7 +54,7 @@ import org.mockito.stubbing.Answer;
 
 public class AttentiveApiTest {
     private static final String DOMAIN = "adj";
-    private static final String GEO_ADJUSTED_DOMAIN = "domainAdj";
+    private static final String GEO_ADJUSTED_DOMAIN = "domain-adj";
     private static final String DTAG_URL = String.format(AttentiveApi.ATTENTIVE_DTAG_URL, DOMAIN);
     private static final UserIdentifiers ALL_USER_IDENTIFIERS = buildAllUserIdentifiers();
 


### PR DESCRIPTION
Update regex to account for dtags that are compiled with the attn domain set to a variable, instead of directly on the window.

Dtags come from compiled JS, so when we update the compilation, the naming of the attn domain variable might change. We need to insulate our matching against this.

will extract domain successfully from:
- legacy dtag `<sampleDtagContent>,window.__attentive_domain='test-company-ca.attn.tv',`
- manually edited dtag `a='testcompany.attn.tv',<sampleDtagContent>,window.__attentive_domain='testcompany.attn.tv',`
- modern dtag `<sampleDtagContent>,a='test-company.attn.tv',`