### PR TITLE
[APP-2873] Capture back event on activity to close creative instead of activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ The more identifiers that are passed to `identify`, the better the SDK will func
 ```java
 // Create a new creative and attach it to a parent View. This will not render the creative.
 Creative creative = new Creative(attentiveConfig, parentView);
+
+// A variation to create the creative, only difference is that it will
+// attach the creative lifecycle to the activity lifecycle to
+// automatically clear up resources. Recommended implementation if
+// targeting only users above Build.VERSION_CODES.Q.
+Creative creative = new Creative(attentiveConfig, parentView, activity);
 ```
 
 #### 2. Trigger the Creative
@@ -126,7 +132,8 @@ See [CreativeTriggerCallback.java](https://github.com/attentive-mobile/attentive
 // Destroy the creative and it's associated WebView.
 creative.destroy();
 ```
-__*** NOTE: You must call the destroy method when the creative is no longer in use to properly clean up the WebView and it's resources ***__
+__*** NOTE 1: You must call the destroy method when the creative is no longer in use to properly clean up the WebView and it's resources.***__
+__*** NOTE 2: Starting from Build.VERSION_CODES.Q this will be called on the destroy lifecycle callback of the activity if the activity is provided to automatically clear up resources and avoid memory leaks.***__
 
 
 ### Record user events

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/creatives/CreativeActivityCallbacks.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/creatives/CreativeActivityCallbacks.java
@@ -1,0 +1,58 @@
+package com.attentive.androidsdk.creatives;
+
+import android.app.Activity;
+import android.app.Application;
+import android.os.Bundle;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
+import org.jetbrains.annotations.NotNull;
+
+@RestrictTo(RestrictTo.Scope.LIBRARY)
+class CreativeActivityCallbacks implements Application.ActivityLifecycleCallbacks {
+
+    @Nullable
+    private Creative creative;
+
+    public CreativeActivityCallbacks(@NotNull Creative creative) {
+        this.creative = creative;
+    }
+
+    @Override
+    public void onActivityCreated(@NonNull Activity activity, @Nullable Bundle savedInstanceState) {
+        // No-op
+    }
+
+    @Override
+    public void onActivityStarted(@NonNull Activity activity) {
+        // No-op
+    }
+
+    @Override
+    public void onActivityResumed(@NonNull Activity activity) {
+        // No-op
+    }
+
+    @Override
+    public void onActivityPaused(@NonNull Activity activity) {
+        // No-op
+    }
+
+    @Override
+    public void onActivityStopped(@NonNull Activity activity) {
+        // No-op
+    }
+
+    @Override
+    public void onActivitySaveInstanceState(@NonNull Activity activity, @NonNull Bundle outState) {
+        // No-op
+    }
+
+    @Override
+    public void onActivityDestroyed(@NonNull Activity activity) {
+        if (creative != null) {
+            creative.destroy();
+        }
+        creative = null;
+    }
+}

--- a/example-kotlin/src/main/java/com/attentive/example_kotlin/activities/LoadCreativeActivity.kt
+++ b/example-kotlin/src/main/java/com/attentive/example_kotlin/activities/LoadCreativeActivity.kt
@@ -1,6 +1,8 @@
 package com.attentive.example_kotlin.activities
 
+import android.content.Intent
 import android.os.Bundle
+import android.os.Handler
 import android.view.View
 import android.webkit.CookieManager
 import androidx.appcompat.app.AppCompatActivity
@@ -19,7 +21,7 @@ class LoadCreativeActivity : AppCompatActivity() {
 
         // Attach the creative to the provided parentView
         val parentView = findViewById<View>(R.id.loadCreative).parent as View
-        this.creative = Creative(attentiveConfig, parentView)
+        this.creative = Creative(attentiveConfig, parentView, this)
     }
 
     override fun onDestroy() {
@@ -36,6 +38,14 @@ class LoadCreativeActivity : AppCompatActivity() {
 
         // Display the creative
         creative.trigger()
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun onBackPressed() {
+        val creativeClosed = creative.onBackPressed()
+        if (!creativeClosed) {
+            super.onBackPressed()
+        }
     }
 
     private fun clearCookies() {

--- a/example/src/main/java/com/attentive/example/activities/LoadCreativeActivity.java
+++ b/example/src/main/java/com/attentive/example/activities/LoadCreativeActivity.java
@@ -2,6 +2,7 @@ package com.attentive.example.activities;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Handler;
 import android.util.Log;
 import android.view.View;
 import android.webkit.CookieManager;
@@ -26,7 +27,7 @@ public class LoadCreativeActivity extends AppCompatActivity {
 
         // Attach the creative to the provided parentView
         View parentView = (View) findViewById(R.id.loadCreative).getParent();
-        this.creative = new Creative(((ExampleApp) getApplication()).getAttentiveConfig(), parentView);
+        this.creative = new Creative(((ExampleApp) getApplication()).getAttentiveConfig(), parentView, this);
     }
 
     @Override
@@ -65,6 +66,14 @@ public class LoadCreativeActivity extends AppCompatActivity {
                 Log.i(this.getClass().getName(), "Closed the creative!");
             }
         });
+    }
+
+    @Override
+    public void onBackPressed() {
+        boolean creativeClosed = creative.onBackPressed();
+        if (!creativeClosed) {
+            super.onBackPressed();
+        }
     }
 
     private void clearCookies() {


### PR DESCRIPTION
# Links
[JIRA Card](https://attentivemobile.atlassian.net/browse/APP-2874)

# Overview
Add public method to allow developers override default behavior that closes the activity the user is in when the user taps on back button. Now the developer has more choice about what to do in case he wants to handle back behavior differently depending on the implementation:
* Activity navigation
* Fragment navigation
* Compose navigation
* Hardware navigation

# Screenshots 

https://github.com/attentive-mobile/attentive-android-sdk/assets/169667919/ba0ce811-d7c7-4293-9ce7-0f821a5ddc4a

https://github.com/attentive-mobile/attentive-android-sdk/assets/169667919/058ca9e4-5de6-4d80-ba89-98b7719a116b


https://github.com/attentive-mobile/attentive-android-sdk/assets/169667919/0181c7c8-fbe8-47af-ba60-2b550ef56d30


