### PR TITLE
[APP-2882]: Add log levels to sdk and override from settings service

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ AttentiveConfig attentiveConfig = new AttentiveConfig.Builder()
         .context(getApplicationContext())
         .domain("YOUR_ATTENTIVE_DOMAIN")
         .mode(AttentiveConfig.Mode.PRODUCTION)
+        .logLevel(AttentiveLogLevel.VERBOSE)
         .build();
 
 // Alternatively, enable the SDK in debug mode for more information about your creative and filtering rules
@@ -39,6 +40,7 @@ AttentiveConfig attentiveConfig = new AttentiveConfig.Builder()
         .context(getApplicationContext())
         .domain("YOUR_ATTENTIVE_DOMAIN")
         .mode(AttentiveConfig.Mode.DEBUG)
+        .logLevel(AttentiveLogLevel.VERBOSE)
         .build();
 ```
 ### In Kotlin:
@@ -183,6 +185,19 @@ allIdentifiers.getKlaviyoId(); // == 777
 // If the user logs out then the current user identifiers should be deleted
 attentiveConfig.clearUser();
 // When/if a user logs back in, `identify` should be called again with the logged in user's identfiers
+```
+
+### Log Level
+We currently support 3 log levels. Each level is more verbose than the next one.
+You can configure the log level on the Builder for the AttentiveConfig. Please keep 
+in mind that this configuration only works for debuggable builds.
+```java
+    VERBOSE(1),
+    STANDARD(2),
+    LIGHT(3);
+
+    // To set it on the builder
+    .logLevel(AttentiveLogLevel.LIGHT)
 ```
 
 ## Minimum Version Support

--- a/attentive-android-sdk/build.gradle
+++ b/attentive-android-sdk/build.gradle
@@ -64,6 +64,8 @@ dependencies {
     implementation 'androidx.webkit:webkit:1.5.0'
     // 2.14.* does not support Android API Level < 26 https://github.com/FasterXML/jackson-databind/issues/3412
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+    // Timber for logging - Upgrading to 5.+ versions causes compilation errors
+    implementation 'com.jakewharton.timber:timber:4.7.1'
 
     // 'api' instead of 'implementation' because we allow the host app to pass in an okhttp object,
     // so we want to expose the okhttp object

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveConfig.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveConfig.java
@@ -1,11 +1,18 @@
 package com.attentive.androidsdk;
 
+import static com.attentive.androidsdk.internal.util.AppInfo.isDebuggable;
+
 import android.content.Context;
-import android.util.Log;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.attentive.androidsdk.internal.events.InfoEvent;
+import com.attentive.androidsdk.internal.util.LightTree;
+import com.attentive.androidsdk.internal.util.StandardTree;
+import com.attentive.androidsdk.internal.util.VerboseTree;
 import java.util.Objects;
 import okhttp3.OkHttpClient;
+import org.jetbrains.annotations.NotNull;
+import timber.log.Timber;
 
 public class AttentiveConfig {
     public enum Mode {
@@ -23,10 +30,13 @@ public class AttentiveConfig {
 
     private AttentiveConfig(@NonNull Builder builder) {
         Context context = builder.context;
+        this.settingsService = ClassFactory.buildSettingsService(ClassFactory.buildPersistentStorage(context));
+        configureLogging(builder.logLevel, settingsService, context);
+
+        Timber.d("Initializing AttentiveConfig with configuration: %s", builder);
         this.mode = builder.mode;
         this.domain = builder.domain;
         this.visitorService = ClassFactory.buildVisitorService(ClassFactory.buildPersistentStorage(context));
-        this.settingsService = ClassFactory.buildSettingsService(ClassFactory.buildPersistentStorage(context));
         this.userIdentifiers = new UserIdentifiers.Builder().withVisitorId(visitorService.getVisitorId()).build();
         OkHttpClient okHttpClient = builder.okHttpClient;
         if (okHttpClient == null) {
@@ -51,6 +61,9 @@ public class AttentiveConfig {
      */
     @Deprecated(since = "0.4.6", forRemoval = true)
     public AttentiveConfig(@NonNull String domain, @NonNull Mode mode, @NonNull Context context, @NonNull OkHttpClient okHttpClient) {
+        this.settingsService = ClassFactory.buildSettingsService(ClassFactory.buildPersistentStorage(context));
+        configureLogging(AttentiveLogLevel.VERBOSE, settingsService, context);
+        Timber.d("Initializing AttentiveConfig with the following configuration: domain=%s, mode=%s, okHttpClient=%s", domain, mode, okHttpClient);
         ParameterValidation.verifyNotEmpty(domain, "domain");
         ParameterValidation.verifyNotNull(mode, "mode");
         ParameterValidation.verifyNotNull(context, "context");
@@ -59,7 +72,6 @@ public class AttentiveConfig {
         this.domain = domain;
         this.mode = mode;
         this.visitorService = ClassFactory.buildVisitorService(ClassFactory.buildPersistentStorage(context));
-        this.settingsService = ClassFactory.buildSettingsService(ClassFactory.buildPersistentStorage(context));
         this.attentiveApi = ClassFactory.buildAttentiveApi(okHttpClient, ClassFactory.buildObjectMapper());
 
         this.userIdentifiers = new UserIdentifiers.Builder().withVisitorId(visitorService.getVisitorId()).build();
@@ -88,6 +100,7 @@ public class AttentiveConfig {
     }
 
     public boolean skipFatigueOnCreatives() {
+        Timber.d("skipFatigueOnCreatives called");
         if (this.settingsService != null) {
             Boolean skipFatigueOnCreatives = this.settingsService.isSkipFatigueEnabled();
             return Objects.requireNonNullElseGet(skipFatigueOnCreatives, () -> this.skipFatigueOnCreatives);
@@ -101,6 +114,7 @@ public class AttentiveConfig {
      */
     @Deprecated
     public void identify(@NonNull String clientUserId) {
+        Timber.d("identify called with clientUserId: %s", clientUserId);
         ParameterValidation.verifyNotEmpty(clientUserId, "clientUserId");
 
         identify(new UserIdentifiers.Builder().withClientUserId(clientUserId).build());
@@ -111,6 +125,7 @@ public class AttentiveConfig {
      * @param userIdentifiers {@link UserIdentifiers} that have the user information to be used.
      */
     public void identify(@NonNull UserIdentifiers userIdentifiers) {
+        Timber.d("identify called with userIdentifiers: %s", userIdentifiers);
         ParameterValidation.verifyNotNull(userIdentifiers, "userIdentifiers");
 
         this.userIdentifiers = UserIdentifiers.merge(this.userIdentifiers, userIdentifiers);
@@ -123,22 +138,36 @@ public class AttentiveConfig {
      * following events/actions.
      */
     public void clearUser() {
+        Timber.d("clearUser called");
         String newVisitorId = visitorService.createNewVisitorId();
         this.userIdentifiers = new UserIdentifiers.Builder().withVisitorId(newVisitorId).build();
     }
 
+    @NonNull
+    @Override
+    public String toString() {
+        return "AttentiveConfig{" +
+                "mode=" + mode +
+                ", domain='" + domain + '\'' +
+                ", visitorService=" + visitorService +
+                ", userIdentifiers=" + userIdentifiers +
+                ", attentiveApi=" + attentiveApi +
+                ", skipFatigueOnCreatives=" + skipFatigueOnCreatives +
+                ", settingsService=" + settingsService +
+                '}';
+    }
+
     private void sendUserIdentifiersCollectedEvent() {
         attentiveApi.sendUserIdentifiersCollectedEvent(getDomain(), getUserIdentifiers(), new AttentiveApiCallback() {
-            private static final String tag = "AttentiveConfig";
 
             @Override
             public void onFailure(String message) {
-                Log.e(tag, "Could not send the user identifiers. Error: " + message);
+                Timber.e("Could not send the user identifiers. Error: %s", message);
             }
 
             @Override
             public void onSuccess() {
-                Log.i(tag, "Successfully sent the user identifiers");
+                Timber.i("Successfully sent the user identifiers");
             }
         });
     }
@@ -148,12 +177,42 @@ public class AttentiveConfig {
         attentiveApi.sendEvent(new InfoEvent(), getUserIdentifiers(), getDomain());
     }
 
+    private static void configureLogging(@Nullable AttentiveLogLevel logLevel, @NotNull SettingsService settingsService, @NotNull Context context) {
+        if (!isDebuggable(context)) {
+            Timber.plant(new LightTree());
+            return;
+        }
+        AttentiveLogLevel settingsLogLevel = settingsService.getLogLevel();
+        if (settingsLogLevel != null) {
+            setLogLevel(settingsLogLevel);
+            return;
+        }
+        if (logLevel != null) {
+            setLogLevel(logLevel);
+            return;
+        }
+        if (isDebuggable(context)) {
+            setLogLevel(AttentiveLogLevel.VERBOSE);
+        }
+    }
+
+    private static void setLogLevel(@NotNull AttentiveLogLevel logLevel) {
+        if (logLevel == AttentiveLogLevel.VERBOSE) {
+            Timber.plant(new VerboseTree());
+        } else if (logLevel == AttentiveLogLevel.STANDARD) {
+            Timber.plant(new StandardTree());
+        } else if (logLevel == AttentiveLogLevel.LIGHT) {
+            Timber.plant(new LightTree());
+        }
+    }
+
     public static class Builder {
         private Context context;
         private Mode mode;
         private String domain;
         private OkHttpClient okHttpClient;
         private boolean skipFatigueOnCreatives;
+        private AttentiveLogLevel logLevel;
 
         public Builder context(@NonNull Context context) {
             ParameterValidation.verifyNotNull(context, "context");
@@ -184,6 +243,11 @@ public class AttentiveConfig {
             return this;
         }
 
+        public Builder logLevel(AttentiveLogLevel logLevel) {
+            this.logLevel = logLevel;
+            return this;
+        }
+
         public AttentiveConfig build() {
             if (this.mode == null) {
                 throw new IllegalStateException("A valid mode must be provided.");
@@ -195,6 +259,19 @@ public class AttentiveConfig {
                 throw new IllegalStateException("A valid context must be provided.");
             }
             return new AttentiveConfig(this);
+        }
+
+        @Override
+        @NonNull
+        public String toString() {
+            return "Builder{" +
+                    "context=" + context +
+                    ", mode=" + mode +
+                    ", domain='" + domain + '\'' +
+                    ", okHttpClient=" + okHttpClient +
+                    ", skipFatigueOnCreatives=" + skipFatigueOnCreatives +
+                    ", logLevel=" + logLevel +
+                    '}';
         }
     }
 }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveEventTracker.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveEventTracker.java
@@ -1,8 +1,7 @@
 package com.attentive.androidsdk;
 
-import android.util.Log;
 import com.attentive.androidsdk.events.Event;
-
+import timber.log.Timber;
 
 public class AttentiveEventTracker {
     private static AttentiveEventTracker INSTANCE;
@@ -24,11 +23,11 @@ public class AttentiveEventTracker {
 
     public void initialize(AttentiveConfig config) {
         ParameterValidation.verifyNotNull(config, "config");
-        Log.i(this.getClass().getName(), String.format("Initializing Attentive SDK with attn domain %s and mode %s", config.getDomain(), config.getMode()));
+        Timber.i("Initializing Attentive SDK with attn domain %s and mode %s", config.getDomain(), config.getMode());
 
         synchronized (AttentiveEventTracker.class) {
             if (this.config != null) {
-                Log.w(this.getClass().getName(), "Attempted to re-initialize AttentiveEventTracker - please initialize once per runtime");
+                Timber.w("Attempted to re-initialize AttentiveEventTracker - please initialize once per runtime");
             }
 
             this.config = config;
@@ -45,7 +44,7 @@ public class AttentiveEventTracker {
     private void verifyInitialized() {
         synchronized (AttentiveEventTracker.class) {
             if (INSTANCE == null) {
-                Log.e(this.getClass().getName(), "AttentiveEventTracker must be initialized before use.");
+                Timber.e("AttentiveEventTracker must be initialized before use.");
             }
         }
     }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveLogLevel.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveLogLevel.java
@@ -1,0 +1,30 @@
+package com.attentive.androidsdk;
+
+import androidx.annotation.Nullable;
+
+public enum AttentiveLogLevel {
+    VERBOSE(1),
+    STANDARD(2),
+    LIGHT(3);
+
+    private final int id;
+
+    AttentiveLogLevel(int id) {
+        this.id = id;
+    }
+
+    @Nullable
+    public static AttentiveLogLevel fromId(int logLevelId) {
+         AttentiveLogLevel[] values = values();
+         for (AttentiveLogLevel value : values) {
+             if (value.id == logLevelId) {
+                 return value;
+             }
+         }
+         return null;
+    }
+
+    int getId() {
+        return id;
+    }
+}

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSettingsService.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSettingsService.java
@@ -9,53 +9,78 @@ import android.os.IBinder;
 import android.util.Log;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+import com.attentive.androidsdk.internal.util.LightTree;
+import timber.log.Timber;
 
 public class AttentiveSettingsService extends Service {
 
     public static final String EXTRA_SET_SKIP_FATIGUE = "setSkipFatigue";
     public static final String EXTRA_RESET_SETTINGS = "resetSettings";
-    private static final String TAG = AttentiveSettingsService.class.getSimpleName();
+    public static final String EXTRA_SET_LOG_LEVEL = "setLogLevel";
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         if (!isDebuggable(this)) {
-            Log.e(TAG, "onCreate: not in debug mode");
-            return Service.START_NOT_STICKY;
+            Timber.e("onCreate: not in debug mode");
+            return Service.START_STICKY;
         }
         final Bundle extras = intent.getExtras();
         if (extras == null) {
-            Log.d(TAG, "onCreate: extras is null");
-            return Service.START_NOT_STICKY;
+            Timber.d("onCreate: extras is null");
+            return Service.START_STICKY;
         }
 
         final SettingsService settingsService = ClassFactory.buildSettingsService(ClassFactory.buildPersistentStorage(getApplicationContext()));
         handleSkipFatigueExtra(extras, settingsService);
         handleResetSettingsExtra(extras, settingsService);
-        return Service.START_NOT_STICKY;
+        handleSetLogLevelExtra(extras, settingsService);
+        stopSelf();
+        return Service.START_STICKY;
     }
 
     @Nullable
     @Override
     public IBinder onBind(Intent intent) {
+        if (isDebuggable(this)) {
+            Timber.plant(new Timber.DebugTree());
+        } else {
+            Timber.plant(new LightTree());
+        }
         return null;
     }
 
     @VisibleForTesting
     public static void handleSkipFatigueExtra(Bundle extras, SettingsService settingsService) {
         if (extras.containsKey(EXTRA_SET_SKIP_FATIGUE)) {
-            Log.d(TAG, "Setting skip fatigue...");
+            Timber.d("Setting skip fatigue...");
             boolean skipFatigue = extras.getBoolean(EXTRA_SET_SKIP_FATIGUE);
             settingsService.setSkipFatigueEnabled(extras.getBoolean(EXTRA_SET_SKIP_FATIGUE, false));
-            Log.i(TAG, "skipFatigue set to: " + skipFatigue);
+            Timber.i("skipFatigue set to: %s", skipFatigue);
         }
     }
 
     @VisibleForTesting
     public static void handleResetSettingsExtra(Bundle extras, SettingsService settingsService) {
         if (extras.containsKey(EXTRA_RESET_SETTINGS) && extras.getBoolean(EXTRA_RESET_SETTINGS, false)) {
-            Log.d(TAG, "Resetting settings...");
+            Timber.d("Resetting settings...");
             settingsService.resetSettings();
-            Log.i(TAG, "Settings reset");
+            Timber.i("Settings reset");
+        }
+    }
+
+    @VisibleForTesting
+    public static void handleSetLogLevelExtra(Bundle extras, SettingsService settingsService) {
+        if (extras.containsKey(EXTRA_SET_LOG_LEVEL)) {
+            Timber.d("Setting log level...");
+            int logLevel = extras.getInt(EXTRA_SET_LOG_LEVEL, -1);
+            AttentiveLogLevel attentiveLogLevel = AttentiveLogLevel.fromId(logLevel);
+            if (attentiveLogLevel == null) {
+                Timber.w("Log level should be one of: %s", (Object[]) AttentiveLogLevel.values());
+                Timber.i("Log level not set");
+                return;
+            }
+            settingsService.setLogLevel(attentiveLogLevel);
+            Timber.i("log level set to: %s", attentiveLogLevel);
         }
     }
 }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/PersistentStorage.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/PersistentStorage.java
@@ -4,17 +4,18 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
+import org.jetbrains.annotations.NotNull;
 
+@RestrictTo(RestrictTo.Scope.LIBRARY)
 public class PersistentStorage {
     static final String SHARED_PREFERENCES_NAME = "com.attentive.androidsdk.PERSISTENT_STORAGE";
 
-    private final Context context;
     private final SharedPreferences sharedPreferences;
 
     public PersistentStorage(Context context) {
-        this.context = context;
 
-        this.sharedPreferences = this.context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
+        this.sharedPreferences = context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
     }
 
     public void save(String key, String value) {
@@ -24,21 +25,58 @@ public class PersistentStorage {
         sharedPreferences.edit().putString(key, value).apply();
     }
 
-    public void save(@NonNull String key, @Nullable Boolean value) {
+    /**
+     * Method to save a boolean value in local storage
+     * @param key The key of the value
+     * @param value The boolean value
+     */
+    public void save(@NonNull String key, @NotNull Boolean value) {
         sharedPreferences.edit().putBoolean(key, value).apply();
     }
 
+    /**
+     * Method to save an int value in local storage
+     * @param key The key of the value
+     * @param value The int value
+     */
+    public void save(@NonNull String key, int value) {
+        sharedPreferences.edit().putInt(key, value).apply();
+    }
+
+    /**
+     * Method to read a string value from local storage
+     * @param key The key of the value
+     * @return The string value, null if the key does not exist
+     */
     @Nullable
     public String read(String key) {
         return sharedPreferences.getString(key, null);
     }
 
-    @Nullable
+    /**
+     * Method to read a boolean value from local storage
+     * @param key The key of the value
+     * @return The boolean value, false if the key does not exist
+     */
+    @NotNull
     public Boolean readBoolean(@NonNull String key) {
         if (sharedPreferences.contains(key)) {
             return sharedPreferences.getBoolean(key, false);
         }
-        return null;
+        return false;
+    }
+
+    /**
+     * Method to read an int value from local storage
+     * @param key The key of the value
+     * @return The int value, -1 if the key does not exist
+     */
+    @NotNull
+    public Integer readInt(@NonNull String key) {
+        if (sharedPreferences.contains(key)) {
+            return sharedPreferences.getInt(key, -1);
+        }
+        return -1;
     }
 
     public void delete(String key) {

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/SettingsService.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/SettingsService.java
@@ -6,9 +6,9 @@ import androidx.annotation.RestrictTo;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class SettingsService {
-    private static final String TAG = SettingsService.class.getSimpleName();
     private static final String SKIP_FATIGUE = "skipFatigue";
-    private static final String[] SETTINGS = { SKIP_FATIGUE };
+    private static final String LOG_LEVEL = "logLevel";
+    private static final String[] SETTINGS = { SKIP_FATIGUE, LOG_LEVEL };
 
     private final PersistentStorage persistentStorage;
 
@@ -23,6 +23,19 @@ public class SettingsService {
 
     public void setSkipFatigueEnabled(@NonNull Boolean enabled) {
         persistentStorage.save(SKIP_FATIGUE, enabled);
+    }
+
+    public void setLogLevel(AttentiveLogLevel attentiveLogLevel) {
+        if (attentiveLogLevel == null) {
+            return;
+        }
+        persistentStorage.save(LOG_LEVEL, attentiveLogLevel.getId());
+    }
+
+    @Nullable
+    public AttentiveLogLevel getLogLevel() {
+        int logLevelId = persistentStorage.readInt(LOG_LEVEL);
+        return AttentiveLogLevel.fromId(logLevelId);
     }
 
     public void resetSettings() {

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/UserIdentifiers.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/UserIdentifiers.java
@@ -147,4 +147,18 @@ public class UserIdentifiers {
             return null;
         }
     }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "UserIdentifiers{" +
+                "visitorId='" + visitorId + '\'' +
+                ", clientUserId='" + clientUserId + '\'' +
+                ", phone='" + phone + '\'' +
+                ", email='" + email + '\'' +
+                ", shopifyId='" + shopifyId + '\'' +
+                ", klaviyoId='" + klaviyoId + '\'' +
+                ", customIdentifiers=" + customIdentifiers +
+                '}';
+    }
 }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/creatives/CreativeActivityCallbacks.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/creatives/CreativeActivityCallbacks.java
@@ -7,6 +7,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 import org.jetbrains.annotations.NotNull;
+import timber.log.Timber;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 class CreativeActivityCallbacks implements Application.ActivityLifecycleCallbacks {
@@ -51,6 +52,7 @@ class CreativeActivityCallbacks implements Application.ActivityLifecycleCallback
     @Override
     public void onActivityDestroyed(@NonNull Activity activity) {
         if (creative != null) {
+            Timber.d("onActivityDestroyed called");
             creative.destroy();
         }
         creative = null;

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/util/CreativeUrlFormatter.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/util/CreativeUrlFormatter.java
@@ -1,7 +1,6 @@
 package com.attentive.androidsdk.internal.util;
 
 import android.net.Uri;
-import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
@@ -9,6 +8,7 @@ import com.attentive.androidsdk.AttentiveConfig;
 import com.attentive.androidsdk.UserIdentifiers;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import timber.log.Timber;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class CreativeUrlFormatter {
@@ -71,7 +71,7 @@ public class CreativeUrlFormatter {
         if (userIdentifiers.getVisitorId() != null) {
             builder.appendQueryParameter("vid", userIdentifiers.getVisitorId());
         } else {
-            Log.e(this.getClass().getName(), "No VisitorId found. This should not happen.");
+            Timber.e("No VisitorId found. This should not happen.");
         }
 
         if (userIdentifiers.getClientUserId() != null) {
@@ -99,7 +99,7 @@ public class CreativeUrlFormatter {
         try {
             return objectMapper.writeValueAsString(userIdentifiers.getCustomIdentifiers());
         } catch (JsonProcessingException e) {
-            Log.e(this.getClass().getName(), "Could not serialize the custom identifiers. Message: " + e.getMessage());
+            Timber.e("Could not serialize the custom identifiers. Message: %s", e.getMessage());
             return "{}";
         }
     }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/util/LightTree.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/util/LightTree.java
@@ -1,0 +1,19 @@
+package com.attentive.androidsdk.internal.util;
+
+import android.annotation.SuppressLint;
+import android.util.Log;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import timber.log.Timber;
+
+public class LightTree extends Timber.Tree {
+    @SuppressLint("LogNotTimber")
+    @Override
+    protected void log(int priority, @Nullable String tag, @NonNull String message, @Nullable Throwable t) {
+        if (priority == Log.ERROR) {
+            Log.e(tag, message, t);
+        } else if (priority == Log.WARN) {
+            Log.w(tag, message, t);
+        }
+    }
+}

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/util/ObjectToRawJsonStringConverter.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/util/ObjectToRawJsonStringConverter.java
@@ -3,6 +3,7 @@ package com.attentive.androidsdk.internal.util;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.util.StdConverter;
+import timber.log.Timber;
 
 
 public class ObjectToRawJsonStringConverter extends StdConverter<Object, String> {
@@ -13,6 +14,7 @@ public class ObjectToRawJsonStringConverter extends StdConverter<Object, String>
         try {
             return objectMapper.writeValueAsString(value);
         } catch (JsonProcessingException e) {
+            Timber.e(e, "Failed to convert object to JSON string");
             throw new RuntimeException(e);
         }
     }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/util/StandardTree.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/util/StandardTree.java
@@ -1,0 +1,21 @@
+package com.attentive.androidsdk.internal.util;
+
+import android.annotation.SuppressLint;
+import android.util.Log;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import timber.log.Timber;
+
+public class StandardTree extends Timber.Tree {
+    @SuppressLint("LogNotTimber")
+    @Override
+    protected void log(int priority, @Nullable String tag, @NonNull String message, @Nullable Throwable t) {
+        if (priority == Log.ERROR) {
+            Log.e(tag, message, t);
+        } else if (priority == Log.WARN) {
+            Log.w(tag, message, t);
+        } else if (priority == Log.INFO) {
+            Log.i(tag, message, t);
+        }
+    }
+}

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/util/VerboseTree.java
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/util/VerboseTree.java
@@ -1,0 +1,27 @@
+package com.attentive.androidsdk.internal.util;
+
+import android.annotation.SuppressLint;
+import android.util.Log;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import timber.log.Timber;
+
+public class VerboseTree extends Timber.Tree {
+    @SuppressLint("LogNotTimber")
+    @Override
+    protected void log(int priority, @Nullable String tag, @NonNull String message, @Nullable Throwable t) {
+        if (priority == Log.ERROR) {
+            Log.e(tag, message, t);
+        } else if (priority == Log.WARN) {
+            Log.w(tag, message, t);
+        } else if (priority == Log.INFO) {
+            Log.i(tag, message, t);
+        } else if (priority == Log.DEBUG) {
+            Log.d(tag, message, t);
+        } else if (priority == Log.VERBOSE) {
+            Log.v(tag, message, t);
+        } else if (priority == Log.ASSERT) {
+            Log.wtf(tag, message, t);
+        }
+    }
+}

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveConfigTest.java
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveConfigTest.java
@@ -10,15 +10,20 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 import android.content.Context;
 import com.attentive.androidsdk.internal.events.InfoEvent;
+import com.attentive.androidsdk.internal.util.AppInfo;
 import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class AttentiveConfigTest {
     private static final String DOMAIN = "DOMAINValue";
@@ -27,6 +32,7 @@ public class AttentiveConfigTest {
     private static final String NEW_VISITOR_ID = "newVisitorIdValue";
 
     private FactoryMocks factoryMocks;
+    private static MockedStatic<AppInfo> mockedAppInfo;
 
     @Before
     public void setup() {
@@ -34,11 +40,14 @@ public class AttentiveConfigTest {
 
         doReturn(VISITOR_ID).when(factoryMocks.getVisitorService()).getVisitorId();
         doReturn(NEW_VISITOR_ID).when(factoryMocks.getVisitorService()).createNewVisitorId();
+        mockedAppInfo = Mockito.mockStatic(AppInfo.class);
+        when(AppInfo.isDebuggable(any())).thenReturn(false);
     }
 
     @After
     public void cleanup() {
         factoryMocks.close();
+        mockedAppInfo.close();
     }
 
     @Test

--- a/example-kotlin/src/main/java/com/attentive/example_kotlin/ExampleKotlinApp.kt
+++ b/example-kotlin/src/main/java/com/attentive/example_kotlin/ExampleKotlinApp.kt
@@ -3,6 +3,7 @@ package com.attentive.example_kotlin
 import android.app.Application
 import com.attentive.androidsdk.AttentiveConfig
 import com.attentive.androidsdk.AttentiveEventTracker
+import com.attentive.androidsdk.AttentiveLogLevel
 import com.attentive.androidsdk.UserIdentifiers
 
 class ExampleKotlinApp : Application() {
@@ -21,6 +22,7 @@ class ExampleKotlinApp : Application() {
                 .domain(attentiveDomain)
                 .mode(mode)
                 .context(this)
+                .logLevel(AttentiveLogLevel.VERBOSE)
                 .build()
 
         // AttentiveEventTracker's "initialize" must be called before the AttentiveEventTracker can

--- a/example/src/main/java/com/attentive/example/ExampleApp.java
+++ b/example/src/main/java/com/attentive/example/ExampleApp.java
@@ -3,6 +3,7 @@ package com.attentive.example;
 import android.app.Application;
 import com.attentive.androidsdk.AttentiveConfig;
 import com.attentive.androidsdk.AttentiveEventTracker;
+import com.attentive.androidsdk.AttentiveLogLevel;
 import com.attentive.androidsdk.UserIdentifiers;
 import java.util.Map;
 
@@ -23,6 +24,7 @@ public class ExampleApp extends Application {
                 .context(getApplicationContext())
                 .domain(ATTENTIVE_DOMAIN)
                 .mode(MODE)
+                .logLevel(AttentiveLogLevel.LIGHT)
                 .build();
 
         // AttentiveEventTracker's "initialize" must be called before the AttentiveEventTracker can be used to send

--- a/example/src/main/java/com/attentive/example/activities/LoadCreativeActivity.java
+++ b/example/src/main/java/com/attentive/example/activities/LoadCreativeActivity.java
@@ -2,7 +2,6 @@ package com.attentive.example.activities;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Handler;
 import android.util.Log;
 import android.view.View;
 import android.webkit.CookieManager;
@@ -12,7 +11,6 @@ import com.attentive.androidsdk.creatives.Creative;
 import com.attentive.androidsdk.creatives.CreativeTriggerCallback;
 import com.attentive.example.ExampleApp;
 import com.attentive.example.R;
-
 
 public class LoadCreativeActivity extends AppCompatActivity {
     private Creative creative;


### PR DESCRIPTION
# Overview
* This PR aims to add log levels to the SDK, also it increases the general level of logs on the code base to be able to debug better what could be happening when something is not working correctly.
* This PR also includes a new setting that the user can put on the AttentiveConfig to set the log level depending on the needs. By default it will be set to the less verbose level and when the app is not debuggable it will also set it to the less verbose regardless of the parameter passed to the config.
* The last change included on this PR is to add the log level setting in the settings service so it can be overrided via intent. This override takes precedence over any other setting except the app being non-debuggable.

## New configuration on code:
`
                .logLevel(AttentiveLogLevel.LIGHT)
`

## Log Levels
`
    VERBOSE(1),
    STANDARD(2),
    LIGHT(3)
`

## Override commands
### To Light
`adb shell am startservice -n com.attentive.example/com.attentive.androidsdk.AttentiveSettingsService --ei "setLogLevel" 3`

### To Standard
`adb shell am startservice -n com.attentive.example/com.attentive.androidsdk.AttentiveSettingsService --ei "setLogLevel" 2`

### To Verbose
`adb shell am startservice -n com.attentive.example/com.attentive.androidsdk.AttentiveSettingsService --ei "setLogLevel" 1`

*** NOTE: It is important to note that the `resetSettings` intent now also deletes this configuration ***

## Screenshots / Video

https://github.com/attentive-mobile/attentive-android-sdk/assets/169667919/35ccb7ef-f0ab-495c-9199-44c49b7d0eea

