### PR TITLE
[APP-3157]: Update consumer-rules.pro to avoid having minification issues on app implementing the sdk

### DIFF
--- a/attentive-android-sdk/consumer-rules.pro
+++ b/attentive-android-sdk/consumer-rules.pro
@@ -1,1 +1,3 @@
 -keep class com.attentive.androidsdk.internal.util.** { *; }
+-keep class com.attentive.androidsdk.internal.network.** { *; }
+-keep class com.attentive.androidsdk.internal.events.** { *; }


### PR DESCRIPTION
There were some issues with one client that sent the events but we were receiving incomplete data either from the event or user identifiers. We narrowed down the cause to proguard and upon further testing we discovered it was due to minification of network and events. This PR adds the exclusion of those folders so they don't get minified by proguard.