### PR TITLE
NATV-6 Update Android Gradle Plugin to 8.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           GH_TOKEN: "fake_token"
 
       - name: Upload Unit Tests Results
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: unit-tests-results
           path: attentive-android-sdk/build/reports/tests/testDebugUnitTest/index.html
@@ -58,14 +58,14 @@ jobs:
           GH_TOKEN: "fake_token"
 
       - name: Upload Lint results - SDK
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: lint-results-sdk
           path: build/reports/checkstyle/checkSdk.html
         if: ${{ always() }}
 
       - name: Upload Lint results - Example
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: lint-results-example
           path: build/reports/checkstyle/checkExample.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
       
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 

--- a/attentive-android-sdk/build.gradle
+++ b/attentive-android-sdk/build.gradle
@@ -33,8 +33,21 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_9
-        targetCompatibility JavaVersion.VERSION_1_9
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_21.toString()
+    }
+
+    kotlin {
+        jvmToolchain(21)
+    }
+
+    java {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
 
     testFixtures {
@@ -72,7 +85,7 @@ dependencies {
 
     // 'api' instead of 'implementation' because we allow the host app to pass in an okhttp object,
     // so we want to expose the okhttp object
-    api 'com.squareup.okhttp3:okhttp:4.10.0'
+    api 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'androidx.activity:activity:1.8.0'
 
     testImplementation 'junit:junit:4.13.2'

--- a/attentive-android-sdk/build.gradle
+++ b/attentive-android-sdk/build.gradle
@@ -10,6 +10,8 @@ def versionName = properties["VERSION_NAME"]
 android {
     namespace = 'com.attentive.androidsdk'
 
+    android.buildFeatures.buildConfig true
+
     compileSdk 34
 
     defaultConfig {
@@ -21,6 +23,7 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
     }
+
 
     buildTypes {
         release {

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.4.2' apply false
-    id 'com.android.library' version '7.4.2' apply false
+    id 'com.android.application' version '8.8.0' apply false
+    id 'com.android.library' version '8.8.0' apply false
     id 'checkstyle'
-    id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
+    id 'org.jetbrains.kotlin.android' version '2.0.0' apply false
     id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Aug 08 15:53:32 EDT 2022
+#Fri Feb 07 13:27:12 PST 2025
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/scripts/publish-module.gradle
+++ b/scripts/publish-module.gradle
@@ -19,7 +19,7 @@ task javadoc(type: Javadoc) {
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
+    archiveClassifier.set('javadoc')
     from javadoc.destinationDir
 }
 


### PR DESCRIPTION
[NATV-6](https://attentivemobile.atlassian.net/browse/NATV-6)

Developers building our sdk will have to update the gradle plugin to get it to build with the current version of Android Studio (also, i can't build it without this change either). We should update it ourselves to the latest version 8.10.2

This also updates github's runner's java version so CI will continue to run.

[NATV-6]: https://attentivemobile.atlassian.net/browse/NATV-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ