### PR TITLE
NATV-11 Introduce intermediate creative state

### DIFF
--- a/attentive-android-sdk/src/test/java/android/util/Log.java
+++ b/attentive-android-sdk/src/test/java/android/util/Log.java
@@ -1,5 +1,7 @@
 package android.util;
 
+import net.bytebuddy.implementation.bytecode.Throw;
+
 public class Log {
     @SuppressWarnings("checkstyle:methodname")
     public static int d(String tag, String msg) {
@@ -22,6 +24,12 @@ public class Log {
     @SuppressWarnings("checkstyle:methodname")
     public static int e(String tag, String msg) {
         System.out.println("ERROR: " + tag + ": " + msg);
+        return 0;
+    }
+
+    @SuppressWarnings("checkstyle:methodname")
+    public static int e(String tag, String message, Throwable t) {
+        System.out.println("ERROR: " + tag + ": " + message);
         return 0;
     }
 }

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/CreativeStateTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/CreativeStateTest.kt
@@ -1,0 +1,70 @@
+package com.attentive.androidsdk.creatives
+
+import android.view.View
+import android.webkit.WebView
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.whenever
+
+class CreativeStateTest {
+
+    @Mock
+    private lateinit var parentView: View
+
+    @Mock
+    private lateinit var webView: WebView
+
+    @Mock
+    private lateinit var creative: Creative
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        whenever(parentView.context).thenReturn(mock(android.content.Context::class.java))
+        whenever(creative.createWebView(any())).thenReturn(webView)
+        creative = mock(Creative::class.java)
+        whenever(creative.destroy()).thenCallRealMethod()
+        whenever(creative.trigger()).thenCallRealMethod()
+        whenever(creative.trigger(anyOrNull(), anyOrNull())).thenCallRealMethod()
+    }
+
+    @Test
+    fun testCreativeIsInitiallyClosed() {
+        assertFalse(Creative.isCreativeOpen())
+        assertFalse(Creative.isCreativeOpen())
+        assertFalse(Creative.isCreativeOpening())
+        assertFalse(Creative.isCreativeDestroyed())
+    }
+
+    @Test
+    fun testCreativeOpensCorrectly() {
+        creative.trigger()
+        assertFalse(Creative.isCreativeOpen())
+        assertFalse(Creative.isCreativeDestroyed())
+    }
+
+    @Test
+    fun testCreativeClosesCorrectly() {
+        creative.trigger()
+        creative.closeCreative()
+        assertFalse(Creative.isCreativeOpen())
+        assertFalse(Creative.isCreativeOpening())
+        assertFalse(Creative.isCreativeDestroyed())
+    }
+
+    @Test
+    fun testCreativeDestroysCorrectly() {
+        creative.destroy()
+        assertFalse(Creative.isCreativeOpen())
+        assertFalse(Creative.isCreativeOpening())
+        assertTrue(Creative.isCreativeDestroyed())
+    }
+
+}

--- a/example-kotlin/src/main/java/com/attentive/example_kotlin/ExampleKotlinApp.kt
+++ b/example-kotlin/src/main/java/com/attentive/example_kotlin/ExampleKotlinApp.kt
@@ -9,7 +9,7 @@ import com.example.example_kotlin.R
 
 class ExampleKotlinApp : Application() {
     // The mode in which to run the Attentive Android SDK
-    private val mode = AttentiveConfig.Mode.PRODUCTION
+    private val mode = AttentiveConfig.Mode.DEBUG
 
     lateinit var attentiveConfig: AttentiveConfig
 


### PR DESCRIPTION
[NATV-11](https://attentivemobile.atlassian.net/jira/software/c/projects/NATV/boards/2485?selectedIssue=NATV-11)

[NATV-11]: https://attentivemobile.atlassian.net/browse/NATV-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



## PR Type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Tests


[Jira Link](https://attentivemobile.atlassian.net/browse/NATV-1)

## What's new?
Added an intermediate state for when a creative is opening, and is neither OPEN nor DESTROYED. This is an effort to preemptively address an issue seen only on iOS right now where multiple creatives open at once.

## Testing
Added tests

## Screenshots
No UI changes
