### PR TITLE
NATV-14 Make Order.Builder conform to the other Builder standards.

### DIFF
--- a/attentive-android-sdk/src/androidTest/java/com/attentive/androidsdk/AttentiveApiTestIT.kt
+++ b/attentive-android-sdk/src/androidTest/java/com/attentive/androidsdk/AttentiveApiTestIT.kt
@@ -309,7 +309,7 @@ class AttentiveApiTestIT {
         private fun buildPurchaseEventWithAllFields(): PurchaseEvent {
             return PurchaseEvent.Builder(
                 listOf(buildItemWithAllFields()),
-                Order.Builder("5555").build()
+                Order.Builder().orderId("5555").build()
             )
                 .cart(Cart.Builder().cartCoupon("cartCoupon").cartId("cartId").build())
                 .build()

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Order.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Order.kt
@@ -12,11 +12,11 @@ data class Order(
     }
 
     @Serializable
-    class Builder(
-        private val orderId: String
-    ) {
-        init {
-            ParameterValidation.verifyNotEmpty(orderId, "orderId")
+    class Builder {
+        private lateinit var orderId: String
+        fun orderId(orderId: String): Builder {
+            this.orderId = orderId
+            return this
         }
 
         fun build(): Order {

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveApiTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveApiTest.kt
@@ -405,7 +405,7 @@ class AttentiveApiTest {
                 Item.Builder(
                     "11", "22", Price.Builder().price(BigDecimal("15.99")).currency(Currency.getInstance("USD")).build()
                 ).build()
-            ), Order.Builder("5555").build()
+            ), Order.Builder().orderId("5555").build()
         ).build()
     }
 
@@ -423,14 +423,14 @@ class AttentiveApiTest {
                     Price.Builder().price(BigDecimal("20.00")).currency(Currency.getInstance("USD")).build()
                 ).build()
             ),
-            Order.Builder("5555").build()
+            Order.Builder().orderId("5555").build()
         ).build()
     }
 
     private fun buildPurchaseEventWithAllFields(): PurchaseEvent {
         return PurchaseEvent.Builder(
             listOf(buildItemWithAllFields()),
-            Order.Builder("5555").build()
+            Order.Builder().orderId("5555").build()
         ).cart(
             Cart.Builder().cartCoupon("cartCoupon").cartId("cartId").build()
         ).build()


### PR DESCRIPTION
[NATV-14
](https://attentivemobile.atlassian.net/browse/NATV-14)
The Order.Builder class takes an orderId as a parameter to the Builder object.

`val order = Order.Builder(“someOrderId”).build()
`
Every other bulider uses bulider methods and doesn’t accept parameters into the builder object. The Order.Builder class should do the same.

`val order = Order.Builder().orderId(“someOrderId”).build()`