### PR TITLE
NATV-54 Fix notifications without deep links not opening the app when…

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
@@ -782,7 +782,7 @@ class AttentiveApi(private val httpClient: OkHttpClient) {
         const val ATTENTIVE_EVENTS_ENDPOINT_HOST: String = "events.attentivemobile.com"
         const val ATTENTIVE_DTAG_URL: String = "https://cdn.attn.tv/%s/dtag.js"
         const val ATTENTIVE_MOBILE_ENDPOINT_HOST: String = "mobile.attentivemobile.com"
-        const val ATTENTIVE_DEV_MOBILE_ENDPOINT: String = "dev.mobile.attentivemobile.com"
+//        const val ATTENTIVE_DEV_MOBILE_ENDPOINT: String = "mobile.dev.attentivemobile.com"
 
         private fun getProductViewMetadataDto(item: Item): ProductViewMetadataDto {
             val productViewMetadata = ProductViewMetadataDto()

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/push/AttentivePush.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/push/AttentivePush.kt
@@ -162,10 +162,11 @@ internal class AttentivePush {
     fun buildLaunchIntent(context: Context, dataMap: Map<String, String>): Intent? {
         val deepLink = dataMap.getOrElse(ATTENTIVE_DEEP_LINK_KEY) { null }
         var launchIntent: Intent? = null
-        if (deepLink != null) {
+        if (deepLink?.isNotBlank() == true) {
             Timber.d("Building launch intent from deep link: $deepLink")
             launchIntent = Intent(Intent.ACTION_VIEW, deepLink.toUri())
         } else {
+            Timber.d("Using launcher activity for package: ${context.packageName}")
             launchIntent =
                 context.packageManager.getLaunchIntentForPackage(context.packageName)?.apply {
                     flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentivePushTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentivePushTest.kt
@@ -1,0 +1,42 @@
+package com.attentive.androidsdk
+
+import android.content.Context
+import android.content.pm.PackageManager
+import com.attentive.androidsdk.push.AttentivePush
+import com.attentive.androidsdk.tracking.AppLaunchTracker
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class AttentivePushTest {
+
+    @Mock
+    private val context: Context = mock()
+
+    @Mock
+    private val pmMock: PackageManager = mock()
+
+    @Mock
+    private val packageName = "com.example.app"
+
+    @Test
+    fun testBuildLaunchIntentWithoutDeepLink(){
+        whenever(context.packageManager).thenReturn(pmMock)
+        whenever(context.packageName).thenReturn(packageName)
+        val intent = AttentivePush.getInstance().buildLaunchIntent(context, mapOf())
+        val launchedFromNotification = intent?.extras?.getBoolean(AppLaunchTracker.LAUNCHED_FROM_NOTIFICATION)
+        Assert.assertEquals(launchedFromNotification, null)
+    }
+
+    @Test
+    fun testBuildLaunchIntentWithDeepLink(){
+        whenever(context.packageManager).thenReturn(pmMock)
+        whenever(context.packageName).thenReturn(packageName)
+        val intent = AttentivePush.getInstance().buildLaunchIntent(context, mapOf())
+        Mockito.verify(pmMock, Mockito.times(1)).getLaunchIntentForPackage(packageName)
+    }
+}

--- a/example2/src/main/java/com/attentive/example2/settings/SettingsScreenComposables.kt
+++ b/example2/src/main/java/com/attentive/example2/settings/SettingsScreenComposables.kt
@@ -100,7 +100,8 @@ fun SettingsList(creative: Creative, navHostController: NavHostController) {
 
     val context = LocalContext.current
     val deepLinkSettings = mutableListOf<Pair<String, () -> Unit>>()
-    deepLinkSettings.add("Trigger Cart Deep Link Notification" to {triggerMockDeepLinkNotification(context)})
+    deepLinkSettings.add("Trigger Cart Deep Link Notification" to {triggerMockDeepLinkNotification(context, withDeepLink = true)})
+    deepLinkSettings.add("Trigger No Deep Link Notification" to {triggerMockDeepLinkNotification(context, withDeepLink = false)})
 
     Text(
         "Settings",
@@ -132,8 +133,14 @@ suspend fun getCurrentToken() {
     }
 }
 
-fun triggerMockDeepLinkNotification(context: Context) {
-    Timber.d("Triggering mock deep link notification")
+fun triggerMockDeepLinkNotification(context: Context, withDeepLink: Boolean) {
+    Timber.d("Triggering mock notification with deep link: $withDeepLink")
+    var dataMap: Map<String, String>
+    if(withDeepLink){
+        dataMap = mapOf("attentive_open_action_url" to "bonni://cart")
+    } else {
+        dataMap = mapOf("attentive_open_action_url" to "")
+    }
     if(AttentiveSdk.isPushPermissionGranted(context).not()){
         Timber.w("Push permission not granted, cannot send mock notification")
         Toast.makeText(context, "Push permission not granted", Toast.LENGTH_SHORT).show()
@@ -142,7 +149,7 @@ fun triggerMockDeepLinkNotification(context: Context) {
         AttentiveSdk.sendMockNotification(
             "Bonni Cart",
             "Your cart is ready!",
-            mapOf("attentive_open_action_url" to "bonni://cart"),
+            dataMap,
             BonniApp.getInstance()
         )
     }


### PR DESCRIPTION
… tapped

[NATV-54](https://attentivemobile.atlassian.net/browse/NATV-54)

[NATV-54]: https://attentivemobile.atlassian.net/browse/NATV-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

This originally assumed there would be no key for a deeplink in the data map if a deep link wasn't present. Now it can correctly handle a key with a blank value.