### PR TITLE
NATV-136 Fix switch user call not firing

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
@@ -117,6 +117,7 @@ class AttentiveApi(private var httpClient: OkHttpClient, private val domain: Str
     val api: RetrofitApiService = retrofit.create(RetrofitApiService::class.java)
 
     internal suspend fun sendUserUpdate(domain: String, email: String?, phoneNumber: String?) {
+        AttentiveEventTracker.instance.config.clearUser()
 
         val visitorId = AttentiveEventTracker.instance.config.userIdentifiers.visitorId
         if (visitorId == null) {
@@ -138,7 +139,6 @@ class AttentiveApi(private var httpClient: OkHttpClient, private val domain: Str
             }
         }
 
-        AttentiveEventTracker.instance.config.clearUser()
         val builder = UserIdentifiers.Builder()
         email?.let {
             builder.withEmail(it)


### PR DESCRIPTION
[NATV-136](https://attentivemobile.atlassian.net/browse/NATV-136)


Once we added clearUser, a visitorId was not available anymore. This fixes the order of the calls so a visitorId is available.

[NATV-136]: https://attentivemobile.atlassian.net/browse/NATV-136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ