### PR TITLE
NATV-193 update README to match ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ The SDK provides three methods for managing user identity:
 - **`clearUser()`** – Clear all identifiers for the current user (used on logout)
 - **`updateUser()`** – Switch to a different user (automatically calls `clearUser()` first)
 
+- Warning: Avoid using hardcoded identifiers like email/phone number in your application's distributed test builds. This will cause every new device to associate a new push token with the same user info on our backend.
+
 #### Common Use Cases:
 
 **1. Anonymous user (default state)**


### PR DESCRIPTION
[NATV-193
](https://attentivemobile.atlassian.net/browse/NATV-193)
  ## Summary

  This PR addresses documentation parity issues between the Android and iOS SDKs. Several features and implementation patterns that were documented in the iOS SDK README were either missing or insufficiently documented in the Android SDK README.

  ## Changes

  ### 1. **Managing User Identity Use Cases**
  - **iOS SDK**: Has comprehensive "Managing User Identity" section with 4 clear use case scenarios
  - **Android SDK (before)**: Methods documented separately without usage guidance
  - **Added**: Dedicated section explaining when to use `identify()`, `clearUser()`, and `updateUser()` with practical scenarios

  ### 2. **Skip Fatigue on Creative**
  - **iOS SDK**: Fully documented with code examples
  - **Android SDK (before)**: Feature exists in code (`AttentiveConfig.Builder.skipFatigueOnCreatives()`) but completely undocumented
  - **Added**: Documentation with Kotlin and Java examples showing how to enable this debug feature
