### PR TITLE
MSDK-93: Add lint warning for SDK initialization outside Application.onCreate()

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,33 +29,29 @@ __*** NOTE: Please refrain from using any private or undocumented classes or met
 
 ## Step 1 - SDK initialization
 
-__*** NOTE: To function properly, the SDK must be initialized as soon as possible after application startup. This is required for us to properly track metrics (app open events, etc) ***__
+> **Important:** The SDK **must** be initialized in your `Application.onCreate()` method — this is the earliest point in the Android lifecycle and ensures the SDK can properly track app open events, deep links, and push notification launches. Initializing later (e.g., in an Activity) may cause missed events and inconsistent behavior.
+>
+> The SDK includes a lint check that will warn you if `AttentiveSdk.initialize()` is called outside of an `Application` subclass.
 
 ```kotlin
-// Create an AttentiveConfig with your attentive domain, in production mode, with an Application context
-val attentiveConfig = AttentiveConfig.Builder()
-        .applicationContext(getApplicationContext())
-        .domain("YOUR_ATTENTIVE_DOMAIN")
-        .mode(AttentiveConfig.Mode.PRODUCTION)
-        // Add a notification icon drawable id if using push
-        .notificationIconId(R.drawable.your_notification_icon)
-        .build()
+class MyApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
 
+        val attentiveConfig = AttentiveConfig.Builder()
+            .applicationContext(this)
+            .domain("YOUR_ATTENTIVE_DOMAIN")
+            .mode(AttentiveConfig.Mode.PRODUCTION)
+            // Add a notification icon drawable id if using push
+            .notificationIconId(R.drawable.your_notification_icon)
+            .build()
 
-
-// Alternatively, enable the SDK in debug mode for more information about your creative and filtering rules
-val attentiveConfig = AttentiveConfig.Builder()
-        .applicationContext(getApplicationContext())
-        .domain("YOUR_ATTENTIVE_DOMAIN")
-        .mode(AttentiveConfig.Mode.DEBUG)
-        .build()
+        AttentiveSdk.initialize(attentiveConfig)
+    }
+}
 ```
 
-### Initialize the SDK
-```kotlin
-// Right after defining the config, initialize the SDK in order to send ecommerce and identification events
-AttentiveSdk.initialize(attentiveConfig)
-```
+For debugging, use `AttentiveConfig.Mode.DEBUG` for more information about your creative and filtering rules.
 
 ## Step 2 - Identify the current user
 

--- a/attentive-android-sdk/build.gradle
+++ b/attentive-android-sdk/build.gradle
@@ -78,6 +78,9 @@ android {
 }
 
 dependencies {
+    // Lint checks bundled with the SDK
+    lintPublish(project(":attentive-lint"))
+
     // build errors in unity for appcompat 1.1.0+
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'com.google.android.material:material:1.12.0'

--- a/attentive-lint/build.gradle.kts
+++ b/attentive-lint/build.gradle.kts
@@ -1,0 +1,37 @@
+plugins {
+    id("java-library")
+    id("org.jetbrains.kotlin.jvm")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+kotlin {
+    jvmToolchain(17)
+}
+
+// Ensure kotlin-stdlib doesn't get bundled - it's provided by the lint runtime
+configurations.all {
+    if (name == "runtimeElements" || name == "apiElements") {
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk7")
+    }
+}
+
+dependencies {
+    compileOnly(libs.lint.api)
+    compileOnly(libs.lint.checks)
+
+    testImplementation(libs.lint)
+    testImplementation(libs.lint.tests)
+    testImplementation(libs.junit)
+}
+
+tasks.withType<Jar> {
+    manifest {
+        attributes["Lint-Registry-v2"] = "com.attentive.lint.AttentiveLintRegistry"
+    }
+}

--- a/attentive-lint/src/main/java/com/attentive/lint/AttentiveLintRegistry.kt
+++ b/attentive-lint/src/main/java/com/attentive/lint/AttentiveLintRegistry.kt
@@ -1,0 +1,24 @@
+package com.attentive.lint
+
+import com.android.tools.lint.client.api.IssueRegistry
+import com.android.tools.lint.client.api.Vendor
+import com.android.tools.lint.detector.api.CURRENT_API
+import com.android.tools.lint.detector.api.Issue
+
+class AttentiveLintRegistry : IssueRegistry() {
+    override val issues: List<Issue> =
+        listOf(
+            SdkInitializationDetector.ISSUE,
+        )
+
+    override val api: Int = CURRENT_API
+
+    override val minApi: Int = 12
+
+    override val vendor: Vendor =
+        Vendor(
+            vendorName = "Attentive Mobile",
+            feedbackUrl = "https://github.com/attentive-mobile/attentive-android-sdk/issues",
+            contact = "https://attentive.com",
+        )
+}

--- a/attentive-lint/src/main/java/com/attentive/lint/SdkInitializationDetector.kt
+++ b/attentive-lint/src/main/java/com/attentive/lint/SdkInitializationDetector.kt
@@ -1,0 +1,128 @@
+package com.attentive.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.getParentOfType
+
+class SdkInitializationDetector : Detector(), SourceCodeScanner {
+    override fun getApplicableUastTypes(): List<Class<out UElement>> {
+        return listOf(UCallExpression::class.java)
+    }
+
+    override fun createUastHandler(context: JavaContext): UElementHandler {
+        return object : UElementHandler() {
+            override fun visitCallExpression(node: UCallExpression) {
+                val methodName = node.methodName ?: return
+
+                if (methodName != "initialize") return
+
+                if (!isAttentiveSdkInitializeCall(node)) return
+
+                if (!isInsideApplicationClass(node)) {
+                    context.report(
+                        ISSUE,
+                        node,
+                        context.getLocation(node),
+                        "AttentiveSdk.initialize() should be called in the onCreate() method of " +
+                            "your Application subclass to ensure proper SDK initialization.",
+                    )
+                }
+            }
+        }
+    }
+
+    private fun isAttentiveSdkInitializeCall(node: UCallExpression): Boolean {
+        // Check via receiver (normal call style: AttentiveSdk.initialize())
+        val receiverType = node.receiverType?.canonicalText
+        val receiver = node.receiver?.asSourceString()
+
+        if (receiverType == ATTENTIVE_SDK_CLASS ||
+            receiver == "AttentiveSdk" ||
+            receiver == ATTENTIVE_SDK_CLASS
+        ) {
+            return true
+        }
+
+        // Check via method resolution (handles static imports and imported functions)
+        // e.g., `import static com.attentive.androidsdk.AttentiveSdk.initialize` in Java
+        // or `import com.attentive.androidsdk.AttentiveSdk.initialize` in Kotlin
+        val resolvedMethod = node.resolve() ?: return false
+        val containingClass = resolvedMethod.containingClass ?: return false
+
+        return containingClass.qualifiedName == ATTENTIVE_SDK_CLASS
+    }
+
+    private fun isInsideApplicationClass(node: UCallExpression): Boolean {
+        val containingClass = node.getParentOfType<UClass>() ?: return false
+        return isApplicationSubclass(containingClass)
+    }
+
+    private fun isApplicationSubclass(uClass: UClass): Boolean {
+        val psiClass = uClass.javaPsi
+
+        var superClass = psiClass.superClass
+        while (superClass != null) {
+            val qualifiedName = superClass.qualifiedName
+            if (qualifiedName == "android.app.Application") {
+                return true
+            }
+            superClass = superClass.superClass
+        }
+
+        return false
+    }
+
+    companion object {
+        private const val ATTENTIVE_SDK_CLASS = "com.attentive.androidsdk.AttentiveSdk"
+
+        @JvmField
+        val ISSUE: Issue =
+            Issue.create(
+                id = "AttentiveSdkInitialization",
+                briefDescription = "AttentiveSdk.initialize() called outside Application class",
+                explanation = """
+                The Attentive SDK must be initialized in the `onCreate()` method of your \
+                `Application` subclass. Initializing the SDK elsewhere (such as in an Activity, \
+                Fragment, or other component) can lead to initialization issues, crashes, or \
+                unexpected behavior.
+
+                Move the `AttentiveSdk.initialize()` call to your Application class's `onCreate()` \
+                method to ensure the SDK is properly initialized before any other component \
+                attempts to use it.
+
+                Example:
+                ```kotlin
+                class MyApplication : Application() {
+                    override fun onCreate() {
+                        super.onCreate()
+                        val config = AttentiveConfig.Builder()
+                            .applicationContext(this)
+                            .domain("your-domain")
+                            .mode(AttentiveConfig.Mode.PRODUCTION)
+                            .build()
+                        AttentiveSdk.initialize(config)
+                    }
+                }
+                ```
+            """,
+                category = Category.CORRECTNESS,
+                priority = 8,
+                severity = Severity.WARNING,
+                implementation =
+                    Implementation(
+                        SdkInitializationDetector::class.java,
+                        Scope.JAVA_FILE_SCOPE,
+                    ),
+            )
+    }
+}

--- a/attentive-lint/src/main/resources/META-INF/services/com.android.tools.lint.client.api.IssueRegistry
+++ b/attentive-lint/src/main/resources/META-INF/services/com.android.tools.lint.client.api.IssueRegistry
@@ -1,0 +1,1 @@
+com.attentive.lint.AttentiveLintRegistry

--- a/attentive-lint/src/test/java/com/attentive/lint/SdkInitializationDetectorTest.kt
+++ b/attentive-lint/src/test/java/com/attentive/lint/SdkInitializationDetectorTest.kt
@@ -1,0 +1,359 @@
+package com.attentive.lint
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest
+import com.android.tools.lint.checks.infrastructure.TestFile
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import org.junit.Test
+
+class SdkInitializationDetectorTest : LintDetectorTest() {
+    override fun getDetector(): Detector = SdkInitializationDetector()
+
+    override fun getIssues(): List<Issue> = listOf(SdkInitializationDetector.ISSUE)
+
+    private val attentiveSdkStub: TestFile =
+        kotlin(
+            """
+        package com.attentive.androidsdk
+
+        object AttentiveSdk {
+            @JvmStatic
+            fun initialize(config: Any) {}
+        }
+        """,
+        ).indented()
+
+    private val attentiveSdkJavaStub: TestFile =
+        java(
+            """
+        package com.attentive.androidsdk;
+
+        public class AttentiveSdk {
+            public static void initialize(Object config) {}
+        }
+        """,
+        ).indented()
+
+    private val attentiveConfigStub: TestFile =
+        kotlin(
+            """
+        package com.attentive.androidsdk
+
+        class AttentiveConfig {
+            class Builder {
+                fun applicationContext(context: Any): Builder = this
+                fun domain(domain: String): Builder = this
+                fun mode(mode: Mode): Builder = this
+                fun build(): AttentiveConfig = AttentiveConfig()
+            }
+            enum class Mode { DEBUG, PRODUCTION }
+        }
+        """,
+        ).indented()
+
+    @Test
+    fun `test clean when initialize called in Application onCreate`() {
+        lint()
+            .files(
+                attentiveSdkStub,
+                attentiveConfigStub,
+                kotlin(
+                    """
+                    package com.example.app
+
+                    import android.app.Application
+                    import com.attentive.androidsdk.AttentiveConfig
+                    import com.attentive.androidsdk.AttentiveSdk
+
+                    class MyApplication : Application() {
+                        override fun onCreate() {
+                            super.onCreate()
+                            val config = AttentiveConfig.Builder()
+                                .applicationContext(this)
+                                .domain("test-domain")
+                                .mode(AttentiveConfig.Mode.PRODUCTION)
+                                .build()
+                            AttentiveSdk.initialize(config)
+                        }
+                    }
+                    """,
+                ).indented(),
+            )
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `test clean when initialize called in helper method of Application class`() {
+        lint()
+            .files(
+                attentiveSdkStub,
+                attentiveConfigStub,
+                kotlin(
+                    """
+                    package com.example.app
+
+                    import android.app.Application
+                    import com.attentive.androidsdk.AttentiveConfig
+                    import com.attentive.androidsdk.AttentiveSdk
+
+                    class MyApplication : Application() {
+                        override fun onCreate() {
+                            super.onCreate()
+                            initAttentiveSdk()
+                        }
+
+                        private fun initAttentiveSdk() {
+                            val config = AttentiveConfig.Builder()
+                                .applicationContext(this)
+                                .domain("test-domain")
+                                .mode(AttentiveConfig.Mode.PRODUCTION)
+                                .build()
+                            AttentiveSdk.initialize(config)
+                        }
+                    }
+                    """,
+                ).indented(),
+            )
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `test warning when initialize called in Activity onCreate`() {
+        lint()
+            .files(
+                attentiveSdkStub,
+                attentiveConfigStub,
+                kotlin(
+                    """
+                    package com.example.app
+
+                    import android.app.Activity
+                    import com.attentive.androidsdk.AttentiveConfig
+                    import com.attentive.androidsdk.AttentiveSdk
+
+                    class MainActivity : Activity() {
+                        override fun onCreate(savedInstanceState: android.os.Bundle?) {
+                            super.onCreate(savedInstanceState)
+                            val config = AttentiveConfig.Builder()
+                                .applicationContext(application)
+                                .domain("test-domain")
+                                .mode(AttentiveConfig.Mode.PRODUCTION)
+                                .build()
+                            AttentiveSdk.initialize(config)
+                        }
+                    }
+                    """,
+                ).indented(),
+            )
+            .run()
+            .expect(
+                """
+                src/com/example/app/MainActivity.kt:15: Warning: AttentiveSdk.initialize() should be called in the onCreate() method of your Application subclass to ensure proper SDK initialization. [AttentiveSdkInitialization]
+                        AttentiveSdk.initialize(config)
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                0 errors, 1 warnings
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun `test warning when initialize called in helper class`() {
+        lint()
+            .files(
+                attentiveSdkStub,
+                attentiveConfigStub,
+                kotlin(
+                    """
+                    package com.example.app
+
+                    import android.app.Application
+                    import com.attentive.androidsdk.AttentiveConfig
+                    import com.attentive.androidsdk.AttentiveSdk
+
+                    class SdkHelper {
+                        fun initializeSdk(application: Application) {
+                            val config = AttentiveConfig.Builder()
+                                .applicationContext(application)
+                                .domain("test-domain")
+                                .mode(AttentiveConfig.Mode.PRODUCTION)
+                                .build()
+                            AttentiveSdk.initialize(config)
+                        }
+                    }
+                    """,
+                ).indented(),
+            )
+            .run()
+            .expect(
+                """
+                src/com/example/app/SdkHelper.kt:14: Warning: AttentiveSdk.initialize() should be called in the onCreate() method of your Application subclass to ensure proper SDK initialization. [AttentiveSdkInitialization]
+                        AttentiveSdk.initialize(config)
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                0 errors, 1 warnings
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun `test warning when initialize called in Fragment`() {
+        lint()
+            .files(
+                attentiveSdkStub,
+                attentiveConfigStub,
+                kotlin(
+                    """
+                    package com.example.app
+
+                    import android.app.Fragment
+                    import android.os.Bundle
+                    import android.view.View
+                    import com.attentive.androidsdk.AttentiveConfig
+                    import com.attentive.androidsdk.AttentiveSdk
+
+                    class MyFragment : Fragment() {
+                        override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+                            super.onViewCreated(view, savedInstanceState)
+                            val config = AttentiveConfig.Builder()
+                                .applicationContext(activity?.application!!)
+                                .domain("test-domain")
+                                .mode(AttentiveConfig.Mode.PRODUCTION)
+                                .build()
+                            AttentiveSdk.initialize(config)
+                        }
+                    }
+                    """,
+                ).indented(),
+            )
+            .run()
+            .expect(
+                """
+                src/com/example/app/MyFragment.kt:17: Warning: AttentiveSdk.initialize() should be called in the onCreate() method of your Application subclass to ensure proper SDK initialization. [AttentiveSdkInitialization]
+                        AttentiveSdk.initialize(config)
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                0 errors, 1 warnings
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun `test warning when initialize called via static import in Java Activity`() {
+        lint()
+            .files(
+                attentiveSdkJavaStub,
+                java(
+                    """
+                    package com.example.app;
+
+                    import android.app.Activity;
+                    import android.os.Bundle;
+                    import static com.attentive.androidsdk.AttentiveSdk.initialize;
+
+                    public class MainActivity extends Activity {
+                        @Override
+                        protected void onCreate(Bundle savedInstanceState) {
+                            super.onCreate(savedInstanceState);
+                            initialize(new Object());
+                        }
+                    }
+                    """,
+                ).indented(),
+            )
+            .run()
+            .expect(
+                """
+                src/com/example/app/MainActivity.java:11: Warning: AttentiveSdk.initialize() should be called in the onCreate() method of your Application subclass to ensure proper SDK initialization. [AttentiveSdkInitialization]
+                        initialize(new Object());
+                        ~~~~~~~~~~~~~~~~~~~~~~~~
+                0 errors, 1 warnings
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun `test warning when initialize called via imported function in Kotlin Activity`() {
+        lint()
+            .files(
+                attentiveSdkStub,
+                attentiveConfigStub,
+                kotlin(
+                    """
+                    package com.example.app
+
+                    import android.app.Activity
+                    import android.os.Bundle
+                    import com.attentive.androidsdk.AttentiveSdk.initialize
+
+                    class MainActivity : Activity() {
+                        override fun onCreate(savedInstanceState: Bundle?) {
+                            super.onCreate(savedInstanceState)
+                            initialize(Object())
+                        }
+                    }
+                    """,
+                ).indented(),
+            )
+            .run()
+            .expect(
+                """
+                src/com/example/app/MainActivity.kt:10: Warning: AttentiveSdk.initialize() should be called in the onCreate() method of your Application subclass to ensure proper SDK initialization. [AttentiveSdkInitialization]
+                        initialize(Object())
+                        ~~~~~~~~~~~~~~~~~~~~
+                0 errors, 1 warnings
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun `test clean when initialize called via static import in Java Application`() {
+        lint()
+            .files(
+                attentiveSdkJavaStub,
+                java(
+                    """
+                    package com.example.app;
+
+                    import android.app.Application;
+                    import static com.attentive.androidsdk.AttentiveSdk.initialize;
+
+                    public class MyApplication extends Application {
+                        @Override
+                        public void onCreate() {
+                            super.onCreate();
+                            initialize(new Object());
+                        }
+                    }
+                    """,
+                ).indented(),
+            )
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `test clean when initialize called via imported function in Kotlin Application`() {
+        lint()
+            .files(
+                attentiveSdkStub,
+                attentiveConfigStub,
+                kotlin(
+                    """
+                    package com.example.app
+
+                    import android.app.Application
+                    import com.attentive.androidsdk.AttentiveSdk.initialize
+
+                    class MyApplication : Application() {
+                        override fun onCreate() {
+                            super.onCreate()
+                            initialize(Object())
+                        }
+                    }
+                    """,
+                ).indented(),
+            )
+            .run()
+            .expectClean()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,165 @@
+[versions]
+# SDK versions
+compileSdk = "35"
+minSdk = "21"
+targetSdk = "35"
+
+# Kotlin & Compose
+kotlin = "2.0.0"
+ksp = "2.0.0-1.0.22"
+composeBom = "2025.05.01"
+
+# AndroidX
+appcompat = "1.7.0"
+activityCompose = "1.10.1"
+activityKtx = "1.10.1"
+constraintlayout = "2.2.0"
+coreKtx = "1.16.0"
+lifecycleRuntime = "2.8.7"
+lifecycleProcess = "2.8.7"
+navigationCompose = "2.9.0"
+room = "2.6.1"
+webkit = "1.12.1"
+testRunner = "1.7.0"
+
+# Firebase
+firebaseBom = "33.13.0"
+
+# Networking
+okhttp = "4.12.0"
+retrofit = "3.0.0"
+gson = "2.13.1"
+
+# Image loading
+coil = "3.0.4"
+
+# Coroutines
+coroutines = "1.7.3"
+
+# Serialization
+kotlinxSerialization = "1.8.0"
+
+# Google
+material = "1.12.0"
+accompanistPermissions = "0.37.2"
+engageCore = "1.5.8"
+
+# Logging
+timber = "5.0.1"
+
+# Testing
+junit = "4.13.2"
+junitExt = "1.2.1"
+espresso = "3.6.1"
+mockito = "5.2.0"
+mockitoKotlin = "5.4.0"
+mockitoAndroid = "5.5.0"
+
+# Lint
+lintApi = "31.8.0"
+
+# Build tools
+agp = "8.8.0"
+nexusPublish = "1.3.0"
+googleServices = "4.4.2"
+checkstyle = "8.36"
+ktlint = "12.1.2"
+
+[libraries]
+# AndroidX Core
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activityKtx" }
+androidx-activity-ktx = { group = "androidx.activity", name = "activity-ktx", version.ref = "activityKtx" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "webkit" }
+androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "testRunner" }
+
+# Lifecycle
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntime" }
+androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycleProcess" }
+
+# Navigation
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+
+# Compose
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
+androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
+
+# Room
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+
+# Firebase
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
+firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
+firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
+
+# Networking
+okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+retrofit-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
+gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
+
+# Image loading
+coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
+coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
+
+# Coroutines
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
+
+# Serialization
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+
+# Google
+google-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+accompanist-permissions = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanistPermissions" }
+engage-core = { group = "com.google.android.engage", name = "engage-core", version.ref = "engageCore" }
+
+# Logging
+timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
+
+# Lint
+lint-api = { group = "com.android.tools.lint", name = "lint-api", version.ref = "lintApi" }
+lint-checks = { group = "com.android.tools.lint", name = "lint-checks", version.ref = "lintApi" }
+lint = { group = "com.android.tools.lint", name = "lint", version.ref = "lintApi" }
+lint-tests = { group = "com.android.tools.lint", name = "lint-tests", version.ref = "lintApi" }
+
+# Testing
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitExt" }
+androidx-test-espresso = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }
+mockito-inline = { group = "org.mockito", name = "mockito-inline", version.ref = "mockito" }
+mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockitoKotlin" }
+mockito-android = { group = "org.mockito", name = "mockito-android", version.ref = "mockitoAndroid" }
+
+[bundles]
+compose = ["androidx-compose-ui", "androidx-compose-ui-graphics", "androidx-compose-material3"]
+compose-sdk = ["androidx-compose-ui", "androidx-compose-ui-graphics", "androidx-compose-material3", "androidx-compose-foundation", "androidx-compose-runtime"]
+coil = ["coil-compose", "coil-network-okhttp"]
+coroutines = ["kotlinx-coroutines-core", "kotlinx-coroutines-android"]
+room = ["androidx-room-runtime", "androidx-room-ktx"]
+networking = ["okhttp", "retrofit", "retrofit-gson", "gson"]
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
+nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublish" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,4 +25,5 @@ dependencyResolutionManagement {
 }
 rootProject.name = "Attentive Android SDK"
 include ':attentive-android-sdk'
+include ':attentive-lint'
 include ':bonni'


### PR DESCRIPTION
## Summary
- Cherry-picks the custom lint rule from `develop` that warns when `AttentiveSdk.initialize()` is called outside of an `Application` subclass
- Updates README to clearly document that initialization must happen in `Application.onCreate()` for proper event tracking (app opens, deep links, push launches)
- Mentions the bundled lint check in the README

## Ticket
[MSDK-93](https://attentivemobile.atlassian.net/browse/MSDK-93)

## Test plan
- [ ] Verify lint tests pass (`./gradlew :attentive-lint:test`)
- [ ] Verify SDK tests pass (`./gradlew :attentive-android-sdk:testDebugUnitTest`)
- [ ] Verify lint warning fires when `AttentiveSdk.initialize()` is called in an Activity
- [ ] Verify no lint warning when `AttentiveSdk.initialize()` is called in an Application subclass

Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-93]: https://attentivemobile.atlassian.net/browse/MSDK-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ