### PR TITLE
MSDK-126: Migrate all OkHttp calls to Retrofit

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
@@ -11,14 +11,21 @@ import com.attentive.androidsdk.internal.events.InfoEvent
 import com.attentive.androidsdk.internal.network.AddToCartMetadataDto
 import com.attentive.androidsdk.internal.network.ContactInfo
 import com.attentive.androidsdk.internal.network.CustomEventMetadataDto
-import com.attentive.androidsdk.internal.network.GeoAdjustedDomainInterceptor
+import com.attentive.androidsdk.internal.network.DeviceInfo
+import com.attentive.androidsdk.internal.network.DirectOpenRequest
+import com.attentive.androidsdk.internal.network.LaunchEvent
 import com.attentive.androidsdk.internal.network.Metadata
+import com.attentive.androidsdk.internal.network.OptInSubscriptionRequest
+import com.attentive.androidsdk.internal.network.OptOutSubscriptionRequest
+import com.attentive.androidsdk.internal.network.PushTokenRequest
 import com.attentive.androidsdk.internal.network.OrderConfirmedMetadataDto
 import com.attentive.androidsdk.internal.network.ProductDto
 import com.attentive.androidsdk.internal.network.ProductMetadata
 import com.attentive.androidsdk.internal.network.ProductViewMetadataDto
 import com.attentive.androidsdk.internal.network.PurchaseMetadataDto
 import com.attentive.androidsdk.internal.network.RetrofitApiService
+import com.attentive.androidsdk.internal.network.RetrofitCdnApiService
+import com.attentive.androidsdk.internal.network.RetrofitEventsApiService
 import com.attentive.androidsdk.internal.network.UserUpdateRequest
 import com.attentive.androidsdk.internal.util.AppInfo
 import com.attentive.androidsdk.push.AttentivePush
@@ -29,18 +36,12 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
-import okhttp3.Call
-import okhttp3.Callback
 import okhttp3.HttpUrl
-import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody
-import okhttp3.Response
+import com.google.gson.JsonParser
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import timber.log.Timber
-import java.io.IOException
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.util.Locale
@@ -77,12 +78,6 @@ class AttentiveApi(private var httpClient: OkHttpClient, private val domain: Str
         encodeDefaults = true  // Must encode defaults to include eventType field
     }
 
-    private val httpUrlEventsEndpointBuilder: HttpUrl.Builder
-        get() = HttpUrl.Builder()
-            .scheme("https")
-            .host(ATTENTIVE_EVENTS_ENDPOINT_HOST)
-            .addPathSegment("e")
-
     private val retrofitEventsEndpoint: HttpUrl.Builder
         get() = HttpUrl.Builder()
             .scheme("https")
@@ -96,36 +91,6 @@ class AttentiveApi(private var httpClient: OkHttpClient, private val domain: Str
 
 
 
-    private val httpUrlPushTokenStatusEndpointBuilder: HttpUrl.Builder
-        get() = HttpUrl.Builder()
-            .scheme("https")
-            .host(ATTENTIVE_MOBILE_ENDPOINT_HOST)
-            .addPathSegment("token")
-
-    private val httpUrlDirectOpenStatusEndpointBuilder: HttpUrl.Builder
-        get() = HttpUrl.Builder()
-            .scheme("https")
-            .host(ATTENTIVE_MOBILE_ENDPOINT_HOST)
-            .addPathSegment("mtctrl")
-
-    private val httpUrlOptInSubscriptionStatusEndpointBuilder: HttpUrl.Builder
-        get() = HttpUrl.Builder()
-            .scheme("https")
-            .host(ATTENTIVE_MOBILE_ENDPOINT_HOST)
-            .addPathSegment("opt-in-subscriptions")
-
-    private val httpUrlOptOutSubscriptionStatusEndpointBuilder: HttpUrl.Builder
-        get() = HttpUrl.Builder()
-            .scheme("https")
-            .host(ATTENTIVE_MOBILE_ENDPOINT_HOST)
-            .addPathSegment("opt-out-subscriptions")
-
-    private val httpMobileEndpointBuilder: HttpUrl.Builder
-        get() = HttpUrl.Builder()
-            .scheme("https")
-            .host(ATTENTIVE_MOBILE_ENDPOINT_HOST)
-
-
     val retrofit: Retrofit = Retrofit.Builder()
         .baseUrl(retrofitMobileEndpoint.build())
         .client(httpClient)
@@ -136,6 +101,21 @@ class AttentiveApi(private var httpClient: OkHttpClient, private val domain: Str
         .build()
 
     val api: RetrofitApiService = retrofit.create(RetrofitApiService::class.java)
+
+    val retrofitEvents: Retrofit = Retrofit.Builder()
+        .baseUrl(retrofitEventsEndpoint.build())
+        .client(httpClient)
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+
+    val eventsApi: RetrofitEventsApiService = retrofitEvents.create(RetrofitEventsApiService::class.java)
+
+    private val retrofitCdn: Retrofit = Retrofit.Builder()
+        .baseUrl("https://cdn.attn.tv/")
+        .client(httpClient)
+        .build()
+
+    private val cdnApi: RetrofitCdnApiService = retrofitCdn.create(RetrofitCdnApiService::class.java)
 
     internal fun sendUserUpdate(domain: String, email: String?, phoneNumber: String?) {
         AttentiveEventTracker.instance.config.clearUser()
@@ -406,40 +386,32 @@ internal fun getGeoAdjustedDomainAsync(domain: String, callback: GetGeoAdjustedD
         return
     }
 
-    val url = String.format(ATTENTIVE_DTAG_URL, domain)
-    val request: Request = Request.Builder().url(url).build()
-    httpClient.newCall(request).enqueue(object : Callback {
-        override fun onFailure(call: Call, e: IOException) {
-            callback.onFailure("Getting geo-adjusted domain failed: " + e.message)
-        }
-
-        @Throws(IOException::class)
-        override fun onResponse(call: Call, response: Response) {
-            // Check explicitly for 200 (instead of response.isSuccessful()) because the response only has the tag in the body when its code is 200
-            if (response.code != 200) {
+    cdnApi.getDtag(domain).enqueue(object : retrofit2.Callback<okhttp3.ResponseBody> {
+        override fun onResponse(
+            call: retrofit2.Call<okhttp3.ResponseBody>,
+            response: retrofit2.Response<okhttp3.ResponseBody>
+        ) {
+            // Check explicitly for 200 because the response only has the tag in the body when its code is 200
+            if (response.code() != 200) {
                 callback.onFailure(
                     String.format(
                         Locale.getDefault(),
                         "Getting geo-adjusted domain returned invalid code: '%d', message: '%s'",
-                        response.code,
-                        response.message
+                        response.code(),
+                        response.message()
                     )
                 )
                 return
             }
 
-            val body = response.body
-
+            val body = response.body()
             if (body == null) {
                 callback.onFailure("Getting geo-adjusted domain returned no body")
                 return
             }
 
-            var fullTag: String? = null
-            if (response.body != null) {
-                fullTag = response.body!!.string()
-            }
-            val geoAdjustedDomain = parseAttentiveDomainFromTag(fullTag!!)
+            val fullTag = body.string()
+            val geoAdjustedDomain = parseAttentiveDomainFromTag(fullTag)
 
             if (geoAdjustedDomain == null) {
                 callback.onFailure("Could not parse the domain from the full tag")
@@ -448,6 +420,10 @@ internal fun getGeoAdjustedDomainAsync(domain: String, callback: GetGeoAdjustedD
 
             cachedGeoAdjustedDomain = geoAdjustedDomain
             callback.onSuccess(geoAdjustedDomain)
+        }
+
+        override fun onFailure(call: retrofit2.Call<okhttp3.ResponseBody>, t: Throwable) {
+            callback.onFailure("Getting geo-adjusted domain failed: ${t.message}")
         }
     })
 }
@@ -487,46 +463,33 @@ private fun internalSendUserIdentifiersCollectedEventAsync(
         return
     }
 
-    val urlBuilder = httpUrlEventsEndpointBuilder
-        .addQueryParameter("tag", "modern")
-        .addQueryParameter("v", "mobile-app")
-        .addQueryParameter("c", geoAdjustedDomain)
-        .addQueryParameter("t", "idn")
-        .addQueryParameter("evs", externalVendorIdsJson)
-        .addQueryParameter("m", metadataJson)
-        .addQueryParameter("lt", "0")
-
-    if (userIdentifiers.visitorId != null) {
-        urlBuilder.addQueryParameter("u", userIdentifiers.visitorId)
-    }
-
-    val url: HttpUrl = urlBuilder.build()
-
-    val request: Request = Request.Builder().url(url).post(buildEmptyRequest()).build()
-    httpClient.newCall(request).enqueue(object : Callback {
-        override fun onFailure(call: Call, e: IOException) {
-            callback.onFailure(
-                String.format(
-                    "Error when calling the event endpoint: '%s'",
-                    e.message
-                )
-            )
-        }
-
-        override fun onResponse(call: Call, response: Response) {
-            if (!response.isSuccessful) {
+    eventsApi.sendEvent(
+        version = "mobile-app",
+        externalVendorIds = externalVendorIdsJson,
+        domain = geoAdjustedDomain,
+        eventType = "idn",
+        visitorId = userIdentifiers.visitorId,
+        metadata = metadataJson,
+    ).enqueue(object : retrofit2.Callback<Unit> {
+        override fun onResponse(call: retrofit2.Call<Unit>, response: retrofit2.Response<Unit>) {
+            if (response.isSuccessful) {
+                callback.onSuccess()
+            } else {
                 callback.onFailure(
                     String.format(
                         Locale.getDefault(),
                         "Invalid response code when calling the event endpoint: '%d', message: '%s'",
-                        response.code,
-                        response.message
+                        response.code(),
+                        response.message()
                     )
                 )
-                return
             }
+        }
 
-            callback.onSuccess()
+        override fun onFailure(call: retrofit2.Call<Unit>, t: Throwable) {
+            callback.onFailure(
+                String.format("Error when calling the event endpoint: '%s'", t.message)
+            )
         }
     })
 }
@@ -948,48 +911,35 @@ private fun sendEventInternalAsync(
         externalVendorIdsJson = "[]"
     }
 
-    val urlBuilder = httpUrlEventsEndpointBuilder
-        .addQueryParameter("v", "mobile-app")
-        .addQueryParameter("lt", "0")
-        .addQueryParameter("tag", "modern")
-        .addQueryParameter("evs", externalVendorIdsJson)
-        .addQueryParameter("c", domain)
-        .addQueryParameter("t", eventRequest.type.abbreviation)
-        .addQueryParameter("u", userIdentifiers.visitorId)
-        .addQueryParameter(
-            "m",
-            json.encodeToString(PolymorphicSerializer(Metadata::class), metadata)
-        )
+    val metadataJson = json.encodeToString(PolymorphicSerializer(Metadata::class), metadata)
+    val extraParameters = eventRequest.extraParameters ?: emptyMap()
 
-    if (eventRequest.extraParameters != null) {
-        for ((key, value) in eventRequest.extraParameters.entries) {
-            urlBuilder.addQueryParameter(key, value)
-        }
-    }
+    Timber.i("Send event type: %s, domain: %s", eventRequest.type.abbreviation, domain)
 
-    val url: HttpUrl = urlBuilder.build()
-    Timber.i("Send event url: %s", url.toString())
-
-    val request: Request = Request.Builder().url(url).post(buildEmptyRequest()).build()
-    httpClient.newCall(request).enqueue(object : Callback {
-        override fun onFailure(call: Call, e: IOException) {
-            val error = "Could not send the request. Error: " + e.message
-            Timber.e(error)
-            callback?.onFailure(error)
-        }
-
-        override fun onResponse(call: Call, response: Response) {
-            if (!response.isSuccessful) {
-                val error =
-                    ("Could not send the request. Invalid response code: " + response.code + ", message: "
-                            + response.message)
+    eventsApi.sendEvent(
+        version = "mobile-app",
+        externalVendorIds = externalVendorIdsJson,
+        domain = domain,
+        eventType = eventRequest.type.abbreviation,
+        visitorId = userIdentifiers.visitorId,
+        metadata = metadataJson,
+        extraParameters = extraParameters,
+    ).enqueue(object : retrofit2.Callback<Unit> {
+        override fun onResponse(call: retrofit2.Call<Unit>, response: retrofit2.Response<Unit>) {
+            if (response.isSuccessful) {
+                Timber.i("Sent the '${eventRequest.type}' request successfully.")
+                callback?.onSuccess()
+            } else {
+                val error = "Could not send the request. Invalid response code: ${response.code()}, message: ${response.message()}"
                 Timber.e(error)
                 callback?.onFailure(error)
-                return
             }
+        }
 
-            Timber.i("Sent the '${eventRequest.type}' request successfully.")
-            callback?.onSuccess()
+        override fun onFailure(call: retrofit2.Call<Unit>, t: Throwable) {
+            val error = "Could not send the request. Error: ${t.message}"
+            Timber.e(error)
+            callback?.onFailure(error)
         }
     })
 }
@@ -1030,54 +980,34 @@ internal fun registerPushToken(
     userIdentifiers: UserIdentifiers
 ) {
     val externalVendorIdsJson = buildExternalVendorIdsJson(userIdentifiers)
-    val metadataJson: String
     val metadata: Metadata
     try {
         metadata = buildMetadata(userIdentifiers)
-        metadataJson = json.encodeToString(metadata)
     } catch (e: SerializationException) {
-        Timber.e(
-            "Could not serialize metadata. Message: '%s'",
-            e.message
-        )
+        Timber.e("Could not serialize metadata. Message: '%s'", e.message)
         return
     }
 
-    //        "pd": "${buildExtraParametersWithDeeplink()}",
+    val request = PushTokenRequest(
+        company = geoAdjustedDomain,
+        version = "mobile-app-${AppInfo.attentiveSDKVersion}",
+        visitorId = userIdentifiers.visitorId ?: "",
+        externalVendorIds = JsonParser.parseString(externalVendorIdsJson),
+        metadata = ContactInfo(
+            phone = metadata.phone ?: "",
+            email = metadata.email ?: "",
+        ),
+        pushToken = token,
+        permissionGranted = permissionGranted.toString(),
+    )
 
-
-    val jsonBody = """
-    {
-        "c": "$geoAdjustedDomain",
-        "v": "mobile-app-${AppInfo.attentiveSDKVersion}",
-        "u": "${userIdentifiers.visitorId}",
-        "evs": ${externalVendorIdsJson},
-        "m": $metadataJson,
-        "pt": "$token",
-        "st": "$permissionGranted",
-        "tp": "fcm"
-    }
-""".trimIndent()
-
-    val pushUrl = httpUrlPushTokenStatusEndpointBuilder.build()
-
-    val requestBody = RequestBody.create("application/json".toMediaType(), jsonBody)
-
-    val request = Request.Builder()
-        .url(pushUrl)
-        .addHeader("x-datadog-sampling-priority", "1")
-        .addHeader("Content-Type", "application/json")
-        .post(requestBody)
-        .build()
-
-
-    httpClient.newCall(request).enqueue(object : Callback {
-        override fun onFailure(call: Call, e: IOException) {
-            Timber.e("Push request failed with exception ${e.message}")
+    api.registerPushToken(request).enqueue(object : retrofit2.Callback<Unit> {
+        override fun onResponse(call: retrofit2.Call<Unit>, response: retrofit2.Response<Unit>) {
+            Timber.i("Push request success with response ${response.message()}")
         }
 
-        override fun onResponse(call: Call, response: Response) {
-            Timber.i("Push request success with response ${response.message}")
+        override fun onFailure(call: retrofit2.Call<Unit>, t: Throwable) {
+            Timber.e("Push request failed with exception ${t.message}")
         }
     })
 }
@@ -1128,7 +1058,7 @@ private fun sendDirectOpenStatusInternal(
     geoAdjustedDomain: String,
 ) {
 
-    Timber.d("sendDirectOpenStatusInternal called with alaunchType: %s", launchType.value)
+    Timber.d("sendDirectOpenStatusInternal called with launchType: %s", launchType.value)
 
     //TODO root cause triage this
     if (lastLaunchEventTimeStamp == 0L) {
@@ -1143,86 +1073,47 @@ private fun sendDirectOpenStatusInternal(
     }
 
     val externalVendorIdsJson = buildExternalVendorIdsJson(userIdentifiers)
-    val metadataJson: String
     val metadata: Metadata
     try {
         metadata = buildMetadata(userIdentifiers)
-        metadataJson = json.encodeToString(metadata)
     } catch (e: SerializationException) {
-        Timber.e(
-            "Could not serialize metadata. Message: '%s'",
-            e.message
-        )
+        Timber.e("Could not serialize metadata. Message: '%s'", e.message)
         return
     }
 
-    //TODO
     val deepLink = callbackMap[AttentivePush.ATTENTIVE_DEEP_LINK_KEY]
-//        val pd = "${buildExtraParametersWithDeeplink(deepLink)}"
 
-    // Build the data array from callbackMap
-    val dataArray = callbackMap.entries.joinToString(separator = ",") { entry ->
-        """"${entry.key}" : "${entry.value}""""
+    val events = mutableListOf(
+        LaunchEvent(type = launchType.value, data = callbackMap)
+    )
+    if (launchType != LaunchType.APP_LAUNCHED) {
+        events.add(LaunchEvent(type = LaunchType.APP_LAUNCHED.value, data = callbackMap))
     }
 
-    val eventsArray = if (launchType == LaunchType.APP_LAUNCHED) {
-        """{
-          "events":[
-            {
-                "ist": "${launchType.value}",
-                "data": {$dataArray}
-            }
-          ],"""
-    } else {
-        """{
-          "events":[
-            {
-                "ist": "${launchType.value}",
-                "data": {$dataArray}
-            },
-            {
-                "ist": "${LaunchType.APP_LAUNCHED.value}",
-                "data": {$dataArray}
-            }
-          ],"""
-    }
+    val request = DirectOpenRequest(
+        events = events,
+        device = DeviceInfo(
+            company = geoAdjustedDomain,
+            version = "mobile-app-${AppInfo.attentiveSDKVersion}",
+            visitorId = userIdentifiers.visitorId ?: "",
+            externalVendorIds = JsonParser.parseString(externalVendorIdsJson),
+            metadata = ContactInfo(
+                phone = metadata.phone ?: "",
+                email = metadata.email ?: "",
+            ),
+            pushToken = pushToken,
+            permissionGranted = permissionGranted.toString(),
+            deepLink = deepLink,
+        ),
+    )
 
-
-    val jsonBody = """
-    $eventsArray
-    "device":{
-        "c": "$geoAdjustedDomain",
-        "v": "mobile-app-${AppInfo.attentiveSDKVersion}",
-        "u": "${userIdentifiers.visitorId}",
-        "evs": ${externalVendorIdsJson},
-        "m": $metadataJson,
-        "pt": "$pushToken",
-        "st": "$permissionGranted",
-        "pd": "$deepLink",
-        "tp": "fcm"
-        }
-    }
-""".trimIndent()
-
-    val openStatusUrl = httpUrlDirectOpenStatusEndpointBuilder.build()
-
-    val requestBody = RequestBody.create("application/json".toMediaType(), jsonBody)
-
-    val request = Request.Builder()
-        .url(openStatusUrl)
-        .addHeader("x-datadog-sampling-priority", "1")
-        .addHeader("Content-Type", "application/json")
-        .post(requestBody)
-        .build()
-
-
-    httpClient.newCall(request).enqueue(object : Callback {
-        override fun onFailure(call: Call, e: IOException) {
-            Timber.e("Push request failed with exception ${e.message}")
+    api.sendDirectOpenStatus(request).enqueue(object : retrofit2.Callback<Unit> {
+        override fun onResponse(call: retrofit2.Call<Unit>, response: retrofit2.Response<Unit>) {
+            Timber.i("Direct open status request success with response ${response.message()}")
         }
 
-        override fun onResponse(call: Call, response: Response) {
-            Timber.i("Push request success with response ${response.message}")
+        override fun onFailure(call: retrofit2.Call<Unit>, t: Throwable) {
+            Timber.e("Direct open status request failed with exception ${t.message}")
         }
     })
 }
@@ -1265,40 +1156,27 @@ internal fun sendOptInSubscriptionStatus(
                 email: String? = "",
                 domain: String,
                 pushToken: String,
-                type: String = "MARKETING"
             ) {
                 val userIdentifiers = AttentiveEventTracker.instance.config.userIdentifiers
                 val externalVendorIdsJson = buildExternalVendorIdsJson(userIdentifiers)
-                val visitorId = userIdentifiers.visitorId ?: ""
-                val jsonBody = """
-        {
-            "c": "$domain",
-            "v": "mobile-app",
-            "u": "$visitorId",
-            "evs": $externalVendorIdsJson,
-            "tp": "fcm",
-            "pt": "$pushToken",
-            "email": "$email",
-            "phone": "$phoneNumber",
-            "type": "$type"
-        }
-    """.trimIndent()
 
-                val url = httpUrlOptInSubscriptionStatusEndpointBuilder.build()
-                val requestBody = RequestBody.create("application/json".toMediaType(), jsonBody)
-                val request = Request.Builder()
-                    .url(url)
-                    .addHeader("Content-Type", "application/json")
-                    .post(requestBody)
-                    .build()
+                val request = OptInSubscriptionRequest(
+                    company = domain,
+                    version = "mobile-app",
+                    visitorId = userIdentifiers.visitorId ?: "",
+                    externalVendorIds = JsonParser.parseString(externalVendorIdsJson),
+                    pushToken = pushToken,
+                    email = email,
+                    phone = phoneNumber,
+                )
 
-                httpClient.newCall(request).enqueue(object : Callback {
-                    override fun onFailure(call: Call, e: IOException) {
-                        Timber.e("Opt-in subscription request failed: ${e.message}")
+                api.optInSubscription(request).enqueue(object : retrofit2.Callback<Unit> {
+                    override fun onResponse(call: retrofit2.Call<Unit>, response: retrofit2.Response<Unit>) {
+                        Timber.i("Opt-in subscription request success: ${response.message()}")
                     }
 
-                    override fun onResponse(call: Call, response: Response) {
-                        Timber.i("Opt-in subscription request success: ${response.message}")
+                    override fun onFailure(call: retrofit2.Call<Unit>, t: Throwable) {
+                        Timber.e("Opt-in subscription request failed: ${t.message}")
                     }
                 })
             }
@@ -1347,47 +1225,30 @@ internal fun sendOptOutSubscriptionStatus(
         ) {
             val userIdentifiers = AttentiveEventTracker.instance.config.userIdentifiers
             val externalVendorIdsJson = buildExternalVendorIdsJson(userIdentifiers)
-            val email = email
-            val phone = phoneNumber
-            val visitorId = userIdentifiers.visitorId ?: ""
-            val jsonBody = """
-        {
-            "c": "$domain",
-            "v": "mobile-app",
-            "u": "$visitorId",
-            "evs": $externalVendorIdsJson,
-            "tp": "fcm",
-            "pt": "$pushToken",
-            "email": "$email",
-            "phone": "$phone"
-        }
-    """.trimIndent()
 
-            val url = httpUrlOptOutSubscriptionStatusEndpointBuilder.build()
-            val requestBody = RequestBody.create("application/json".toMediaType(), jsonBody)
-            val request = Request.Builder()
-                .url(url)
-                .addHeader("Content-Type", "application/json")
-                .post(requestBody)
-                .build()
+            val request = OptOutSubscriptionRequest(
+                company = domain,
+                version = "mobile-app",
+                visitorId = userIdentifiers.visitorId ?: "",
+                externalVendorIds = JsonParser.parseString(externalVendorIdsJson),
+                pushToken = pushToken,
+                email = email,
+                phone = phoneNumber,
+            )
 
-            httpClient.newCall(request).enqueue(object : Callback {
-                override fun onFailure(call: Call, e: IOException) {
-                    Timber.e("Opt-out subscription request failed: ${e.message}")
+            api.optOutSubscription(request).enqueue(object : retrofit2.Callback<Unit> {
+                override fun onResponse(call: retrofit2.Call<Unit>, response: retrofit2.Response<Unit>) {
+                    Timber.i("Opt-out subscription request success: ${response.message()}")
                 }
 
-                override fun onResponse(call: Call, response: Response) {
-                    Timber.i("Opt-out subscription request success: ${response.message}")
+                override fun onFailure(call: retrofit2.Call<Unit>, t: Throwable) {
+                    Timber.e("Opt-out subscription request failed: ${t.message}")
                 }
             })
         }
 
 
     })
-}
-
-private fun buildEmptyRequest(): RequestBody {
-    return RequestBody.create(null, ByteArray(0))
 }
 
 // Test helper functions - marked as @VisibleForTesting internal so tests can access them

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
@@ -410,7 +410,12 @@ internal fun getGeoAdjustedDomainAsync(domain: String, callback: GetGeoAdjustedD
                 return
             }
 
-            val fullTag = body.string()
+            val fullTag = try {
+                body.use { it.string() }
+            } catch (e: java.io.IOException) {
+                callback.onFailure("Failed to read geo-adjusted domain response body: ${e.message}")
+                return
+            }
             val geoAdjustedDomain = parseAttentiveDomainFromTag(fullTag)
 
             if (geoAdjustedDomain == null) {
@@ -979,6 +984,11 @@ internal fun registerPushToken(
     permissionGranted: Boolean,
     userIdentifiers: UserIdentifiers
 ) {
+    if (userIdentifiers.visitorId.isNullOrEmpty()) {
+        Timber.e("No visitorId available, cannot register push token")
+        return
+    }
+
     val externalVendorIdsJson = buildExternalVendorIdsJson(userIdentifiers)
     val metadata: Metadata
     try {
@@ -991,7 +1001,7 @@ internal fun registerPushToken(
     val request = PushTokenRequest(
         company = geoAdjustedDomain,
         version = "mobile-app-${AppInfo.attentiveSDKVersion}",
-        visitorId = userIdentifiers.visitorId ?: "",
+        visitorId = userIdentifiers.visitorId,
         externalVendorIds = JsonParser.parseString(externalVendorIdsJson),
         metadata = ContactInfo(
             phone = metadata.phone ?: "",
@@ -1060,6 +1070,11 @@ private fun sendDirectOpenStatusInternal(
 
     Timber.d("sendDirectOpenStatusInternal called with launchType: %s", launchType.value)
 
+    if (userIdentifiers.visitorId.isNullOrEmpty()) {
+        Timber.e("No visitorId available, cannot send direct open status")
+        return
+    }
+
     //TODO root cause triage this
     if (lastLaunchEventTimeStamp == 0L) {
         lastLaunchEventTimeStamp = System.currentTimeMillis()
@@ -1095,7 +1110,7 @@ private fun sendDirectOpenStatusInternal(
         device = DeviceInfo(
             company = geoAdjustedDomain,
             version = "mobile-app-${AppInfo.attentiveSDKVersion}",
-            visitorId = userIdentifiers.visitorId ?: "",
+            visitorId = userIdentifiers.visitorId,
             externalVendorIds = JsonParser.parseString(externalVendorIdsJson),
             metadata = ContactInfo(
                 phone = metadata.phone ?: "",
@@ -1158,12 +1173,16 @@ internal fun sendOptInSubscriptionStatus(
                 pushToken: String,
             ) {
                 val userIdentifiers = AttentiveEventTracker.instance.config.userIdentifiers
+                if (userIdentifiers.visitorId.isNullOrEmpty()) {
+                    Timber.e("No visitorId available, cannot send opt-in subscription")
+                    return
+                }
                 val externalVendorIdsJson = buildExternalVendorIdsJson(userIdentifiers)
 
                 val request = OptInSubscriptionRequest(
                     company = domain,
                     version = "mobile-app",
-                    visitorId = userIdentifiers.visitorId ?: "",
+                    visitorId = userIdentifiers.visitorId,
                     externalVendorIds = JsonParser.parseString(externalVendorIdsJson),
                     pushToken = pushToken,
                     email = email,
@@ -1224,12 +1243,16 @@ internal fun sendOptOutSubscriptionStatus(
             pushToken: String
         ) {
             val userIdentifiers = AttentiveEventTracker.instance.config.userIdentifiers
+            if (userIdentifiers.visitorId.isNullOrEmpty()) {
+                Timber.e("No visitorId available, cannot send opt-out subscription")
+                return
+            }
             val externalVendorIdsJson = buildExternalVendorIdsJson(userIdentifiers)
 
             val request = OptOutSubscriptionRequest(
                 company = domain,
                 version = "mobile-app",
-                visitorId = userIdentifiers.visitorId ?: "",
+                visitorId = userIdentifiers.visitorId,
                 externalVendorIds = JsonParser.parseString(externalVendorIdsJson),
                 pushToken = pushToken,
                 email = email,

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/DirectOpenRequest.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/DirectOpenRequest.kt
@@ -1,0 +1,39 @@
+package com.attentive.androidsdk.internal.network
+
+import com.google.gson.JsonElement
+import com.google.gson.annotations.SerializedName
+
+data class DirectOpenRequest(
+    @SerializedName("events")
+    val events: List<LaunchEvent>,
+    @SerializedName("device")
+    val device: DeviceInfo,
+)
+
+data class LaunchEvent(
+    @SerializedName("ist")
+    val type: String,
+    @SerializedName("data")
+    val data: Map<String, String>,
+)
+
+data class DeviceInfo(
+    @SerializedName("c")
+    val company: String,
+    @SerializedName("v")
+    val version: String,
+    @SerializedName("u")
+    val visitorId: String,
+    @SerializedName("evs")
+    val externalVendorIds: JsonElement,
+    @SerializedName("m")
+    val metadata: ContactInfo,
+    @SerializedName("pt")
+    val pushToken: String,
+    @SerializedName("st")
+    val permissionGranted: String,
+    @SerializedName("pd")
+    val deepLink: String?,
+    @SerializedName("tp")
+    val tokenProvider: String = "fcm",
+)

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/PushTokenRequest.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/PushTokenRequest.kt
@@ -1,0 +1,23 @@
+package com.attentive.androidsdk.internal.network
+
+import com.google.gson.JsonElement
+import com.google.gson.annotations.SerializedName
+
+data class PushTokenRequest(
+    @SerializedName("c")
+    val company: String,
+    @SerializedName("v")
+    val version: String,
+    @SerializedName("u")
+    val visitorId: String,
+    @SerializedName("evs")
+    val externalVendorIds: JsonElement,
+    @SerializedName("m")
+    val metadata: ContactInfo,
+    @SerializedName("pt")
+    val pushToken: String,
+    @SerializedName("st")
+    val permissionGranted: String,
+    @SerializedName("tp")
+    val tokenProvider: String = "fcm",
+)

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/RetrofitApiService.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/RetrofitApiService.kt
@@ -23,4 +23,34 @@ interface RetrofitApiService {
     fun sendEvent(
         @Field("d") eventData: String,
     ): Call<Unit>
+
+    @Headers(
+        "x-datadog-sampling-priority: 1",
+        "Content-Type: application/json",
+    )
+    @POST("token")
+    fun registerPushToken(
+        @Body request: PushTokenRequest,
+    ): Call<Unit>
+
+    @Headers(
+        "x-datadog-sampling-priority: 1",
+        "Content-Type: application/json",
+    )
+    @POST("mtctrl")
+    fun sendDirectOpenStatus(
+        @Body request: DirectOpenRequest,
+    ): Call<Unit>
+
+    @Headers("Content-Type: application/json")
+    @POST("opt-in-subscriptions")
+    fun optInSubscription(
+        @Body request: OptInSubscriptionRequest,
+    ): Call<Unit>
+
+    @Headers("Content-Type: application/json")
+    @POST("opt-out-subscriptions")
+    fun optOutSubscription(
+        @Body request: OptOutSubscriptionRequest,
+    ): Call<Unit>
 }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/RetrofitCdnApiService.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/RetrofitCdnApiService.kt
@@ -1,0 +1,13 @@
+package com.attentive.androidsdk.internal.network
+
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface RetrofitCdnApiService {
+    @GET("{domain}/dtag.js")
+    fun getDtag(
+        @Path("domain") domain: String,
+    ): Call<ResponseBody>
+}

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/RetrofitEventsApiService.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/RetrofitEventsApiService.kt
@@ -1,0 +1,21 @@
+package com.attentive.androidsdk.internal.network
+
+import retrofit2.Call
+import retrofit2.http.POST
+import retrofit2.http.Query
+import retrofit2.http.QueryMap
+
+interface RetrofitEventsApiService {
+    @POST("e")
+    fun sendEvent(
+        @Query("v") version: String,
+        @Query("lt") lt: String = "0",
+        @Query("tag") tag: String = "modern",
+        @Query("evs") externalVendorIds: String,
+        @Query("c") domain: String,
+        @Query("t") eventType: String,
+        @Query("u") visitorId: String?,
+        @Query("m") metadata: String,
+        @QueryMap extraParameters: Map<String, String> = emptyMap(),
+    ): Call<Unit>
+}

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/SubscriptionRequest.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/SubscriptionRequest.kt
@@ -1,0 +1,44 @@
+package com.attentive.androidsdk.internal.network
+
+import com.google.gson.JsonElement
+import com.google.gson.annotations.SerializedName
+
+data class OptInSubscriptionRequest(
+    @SerializedName("c")
+    val company: String,
+    @SerializedName("v")
+    val version: String,
+    @SerializedName("u")
+    val visitorId: String,
+    @SerializedName("evs")
+    val externalVendorIds: JsonElement,
+    @SerializedName("tp")
+    val tokenProvider: String = "fcm",
+    @SerializedName("pt")
+    val pushToken: String,
+    @SerializedName("email")
+    val email: String?,
+    @SerializedName("phone")
+    val phone: String?,
+    @SerializedName("type")
+    val type: String = "MARKETING",
+)
+
+data class OptOutSubscriptionRequest(
+    @SerializedName("c")
+    val company: String,
+    @SerializedName("v")
+    val version: String,
+    @SerializedName("u")
+    val visitorId: String,
+    @SerializedName("evs")
+    val externalVendorIds: JsonElement,
+    @SerializedName("tp")
+    val tokenProvider: String = "fcm",
+    @SerializedName("pt")
+    val pushToken: String,
+    @SerializedName("email")
+    val email: String?,
+    @SerializedName("phone")
+    val phone: String?,
+)

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveApiTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveApiTest.kt
@@ -16,6 +16,7 @@ import com.attentive.androidsdk.internal.network.ProductDto
 import com.attentive.androidsdk.internal.network.ProductViewMetadataDto
 import com.attentive.androidsdk.internal.network.PurchaseMetadataDto
 import com.attentive.androidsdk.internal.util.AppInfo
+import com.google.gson.JsonParser
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import okhttp3.Call
@@ -43,6 +44,8 @@ import org.mockito.kotlin.whenever
 import java.math.BigDecimal
 import java.util.Currency
 import java.util.Locale
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class AttentiveApiTest {
     private lateinit var attentiveApi: AttentiveApi
@@ -551,6 +554,192 @@ class AttentiveApiTest {
 //            callback.onSuccess(GEO_ADJUSTED_DOMAIN)
 //        }
 //    }
+
+    // -- Retrofit endpoint tests (registerPushToken, sendDirectOpenStatus) --
+
+    @Test
+    fun registerPushToken_callsTokenEndpoint_withCorrectRequestFields() {
+        // Arrange
+        val capturedRequests = mutableListOf<CapturedApiRequest>()
+        val requestLatch = CountDownLatch(1)
+        val interceptorClient = buildInterceptorClient(capturedRequests, requestLatch)
+        val testApi = AttentiveApi(interceptorClient, "games")
+
+        // Act
+        testApi.registerPushToken(
+            GEO_ADJUSTED_DOMAIN,
+            "test-push-token",
+            true,
+            ALL_USER_IDENTIFIERS,
+        )
+        requestLatch.await(5, TimeUnit.SECONDS)
+
+        // Assert
+        Assert.assertEquals(1, capturedRequests.size)
+        val captured = capturedRequests[0]
+
+        // Verify endpoint and method
+        Assert.assertTrue(captured.request.url.encodedPath.endsWith("/token"))
+        Assert.assertEquals("POST", captured.request.method)
+
+        // Verify headers
+        Assert.assertEquals("1", captured.request.header("x-datadog-sampling-priority"))
+
+        // Verify JSON body fields match @SerializedName annotations
+        val body = JsonParser.parseString(captured.bodyJson).asJsonObject
+        Assert.assertEquals(GEO_ADJUSTED_DOMAIN, body.get("c").asString)
+        Assert.assertTrue(body.get("v").asString.startsWith("mobile-app-"))
+        Assert.assertEquals(ALL_USER_IDENTIFIERS.visitorId, body.get("u").asString)
+        Assert.assertEquals("test-push-token", body.get("pt").asString)
+        Assert.assertEquals("true", body.get("st").asString)
+        Assert.assertEquals("fcm", body.get("tp").asString)
+
+        // Verify metadata (m) contains phone and email
+        val metadata = body.getAsJsonObject("m")
+        Assert.assertEquals(ALL_USER_IDENTIFIERS.phone, metadata.get("phone").asString)
+        Assert.assertEquals(ALL_USER_IDENTIFIERS.email, metadata.get("email").asString)
+
+        // Verify external vendor IDs (evs) are serialized
+        val evs = body.getAsJsonArray("evs")
+        Assert.assertEquals(3, evs.size())
+    }
+
+    @Test
+    fun sendDirectOpenStatus_callsMtctrlEndpoint_withCorrectRequestFields() {
+        // Arrange
+        val capturedRequests = mutableListOf<CapturedApiRequest>()
+        val requestLatch = CountDownLatch(1)
+        val interceptorClient = buildInterceptorClient(capturedRequests, requestLatch)
+        val testApi = Mockito.spy(AttentiveApi(interceptorClient, "games"))
+
+        Mockito.doAnswer { invocation: InvocationOnMock ->
+            val callback = invocation.getArgument(1, GetGeoAdjustedDomainCallback::class.java)
+            callback.onSuccess(GEO_ADJUSTED_DOMAIN)
+        }.whenever(testApi).getGeoAdjustedDomainAsync(eq(DOMAIN), any())
+
+        val callbackMap = mapOf(
+            "attentive_open_action_url" to "https://example.com/deep-link",
+            "someKey" to "someValue",
+        )
+
+        // Act - use DIRECT_OPEN launch type ("o")
+        testApi.sendDirectOpenStatus(
+            AttentiveApi.LaunchType.DIRECT_OPEN,
+            "test-push-token",
+            callbackMap,
+            true,
+            ALL_USER_IDENTIFIERS,
+            DOMAIN,
+        )
+        requestLatch.await(5, TimeUnit.SECONDS)
+
+        // Assert
+        Assert.assertEquals(1, capturedRequests.size)
+        val captured = capturedRequests[0]
+
+        // Verify endpoint and method
+        Assert.assertTrue(captured.request.url.encodedPath.endsWith("/mtctrl"))
+        Assert.assertEquals("POST", captured.request.method)
+
+        // Verify headers
+        Assert.assertEquals("1", captured.request.header("x-datadog-sampling-priority"))
+
+        // Verify JSON body structure
+        val body = JsonParser.parseString(captured.bodyJson).asJsonObject
+
+        // Verify events array
+        val events = body.getAsJsonArray("events")
+        Assert.assertTrue(events.size() >= 1)
+        val firstEvent = events[0].asJsonObject
+        Assert.assertEquals("o", firstEvent.get("ist").asString)  // DIRECT_OPEN value
+        val eventData = firstEvent.getAsJsonObject("data")
+        Assert.assertEquals("https://example.com/deep-link", eventData.get("attentive_open_action_url").asString)
+
+        // Verify device info
+        val device = body.getAsJsonObject("device")
+        Assert.assertEquals(GEO_ADJUSTED_DOMAIN, device.get("c").asString)
+        Assert.assertTrue(device.get("v").asString.startsWith("mobile-app-"))
+        Assert.assertEquals(ALL_USER_IDENTIFIERS.visitorId, device.get("u").asString)
+        Assert.assertEquals("test-push-token", device.get("pt").asString)
+        Assert.assertEquals("true", device.get("st").asString)
+        Assert.assertEquals("fcm", device.get("tp").asString)
+        Assert.assertEquals("https://example.com/deep-link", device.get("pd").asString)
+
+        // Verify metadata in device
+        val metadata = device.getAsJsonObject("m")
+        Assert.assertEquals(ALL_USER_IDENTIFIERS.phone, metadata.get("phone").asString)
+        Assert.assertEquals(ALL_USER_IDENTIFIERS.email, metadata.get("email").asString)
+
+        // Verify external vendor IDs in device
+        val evs = device.getAsJsonArray("evs")
+        Assert.assertEquals(3, evs.size())
+    }
+
+    @Test
+    fun sendDirectOpenStatus_directOpen_alsoIncludesAppLaunchedEvent() {
+        // Arrange
+        val capturedRequests = mutableListOf<CapturedApiRequest>()
+        val requestLatch = CountDownLatch(1)
+        val interceptorClient = buildInterceptorClient(capturedRequests, requestLatch)
+        val testApi = Mockito.spy(AttentiveApi(interceptorClient, "games"))
+
+        Mockito.doAnswer { invocation: InvocationOnMock ->
+            val callback = invocation.getArgument(1, GetGeoAdjustedDomainCallback::class.java)
+            callback.onSuccess(GEO_ADJUSTED_DOMAIN)
+        }.whenever(testApi).getGeoAdjustedDomainAsync(eq(DOMAIN), any())
+
+        // Act
+        testApi.sendDirectOpenStatus(
+            AttentiveApi.LaunchType.DIRECT_OPEN,
+            "test-push-token",
+            mapOf("key" to "value"),
+            true,
+            ALL_USER_IDENTIFIERS,
+            DOMAIN,
+        )
+        requestLatch.await(5, TimeUnit.SECONDS)
+
+        // Assert - DIRECT_OPEN should include both the direct open event and an APP_LAUNCHED event
+        val body = JsonParser.parseString(capturedRequests[0].bodyJson).asJsonObject
+        val events = body.getAsJsonArray("events")
+        Assert.assertEquals(2, events.size())
+        Assert.assertEquals("o", events[0].asJsonObject.get("ist").asString)   // DIRECT_OPEN
+        Assert.assertEquals("al", events[1].asJsonObject.get("ist").asString)  // APP_LAUNCHED
+    }
+
+    private data class CapturedApiRequest(
+        val request: Request,
+        val bodyJson: String,
+    )
+
+    private fun buildInterceptorClient(
+        capturedRequests: MutableList<CapturedApiRequest>,
+        latch: CountDownLatch,
+    ): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val request = chain.request()
+                if (request.url.host == "mobile.attentivemobile.com") {
+                    val buffer = okio.Buffer()
+                    request.body?.writeTo(buffer)
+                    capturedRequests.add(
+                        CapturedApiRequest(
+                            request = request,
+                            bodyJson = buffer.readUtf8(),
+                        ),
+                    )
+                    latch.countDown()
+                }
+                Response.Builder()
+                    .request(request)
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(204)
+                    .message("No Content")
+                    .body("".toResponseBody())
+                    .build()
+            }
+            .build()
+    }
 
     private fun assertRequestMethodIsPost(request: Request) {
         Assert.assertEquals("POST", request.method.uppercase(Locale.getDefault()))

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveApiTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveApiTest.kt
@@ -495,7 +495,6 @@ class AttentiveApiTest {
                     }
                 }
                 "cdn.attn.tv" -> {
-                    val dtagResponse = mock<Response>()
                     val content =
                         String.format(
                             "window.__attentive_domain='%s.attn.tv'",
@@ -503,12 +502,13 @@ class AttentiveApiTest {
                         )
                     val responseBody = content.toResponseBody("text/html".toMediaTypeOrNull())
 
-                    whenever(dtagResponse.body).thenReturn(responseBody)
-                    whenever(dtagResponse.request).thenReturn(request)
-                    whenever(dtagResponse.protocol).thenReturn(Protocol.HTTP_1_1)
-                    whenever(dtagResponse.code).thenReturn(200)
-                    whenever(dtagResponse.message).thenReturn("OK")
-                    whenever(dtagResponse.isSuccessful).thenReturn(true)
+                    val dtagResponse = Response.Builder()
+                        .request(request)
+                        .protocol(Protocol.HTTP_1_1)
+                        .code(200)
+                        .message("OK")
+                        .body(responseBody)
+                        .build()
 
                     whenever(call.enqueue(any())).doAnswer { enqueueInvocation: InvocationOnMock ->
                         val callback = enqueueInvocation.getArgument<Callback>(0)


### PR DESCRIPTION
## Summary
- Migrate all 7 remaining raw OkHttp network calls in `AttentiveApi` to Retrofit declarative service interfaces
- Add new Retrofit services: `RetrofitEventsApiService` (events.attentivemobile.com) and `RetrofitCdnApiService` (cdn.attn.tv)
- Add request DTOs: `PushTokenRequest`, `DirectOpenRequest`, `OptInSubscriptionRequest`, `OptOutSubscriptionRequest` using Gson serialization with `JsonElement` for external vendor IDs
- Remove unused OkHttp imports, URL builders (`httpUrlEventsEndpointBuilder`, `httpMobileEndpointBuilder`), and `buildEmptyRequest()`
- Update test mock to use real OkHttp `Response` instead of mock for Retrofit compatibility


I manually tested this extensively in the bonni app. I see all calls succeeding or failing gracefully when there is no network.


## Ticket
[MSDK-126](https://attentivemobile.atlassian.net/browse/MSDK-126)

## Test plan
- [x] All 99 SDK unit tests pass
- [x] Verify push token registration works on device
- [x] Verify DIRECT_OPEN / APP_LAUNCHED events fire correctly
- [x] Verify opt-in/opt-out subscription calls succeed
- [x] Verify geo-adjusted domain resolution and caching works
- [x] Verify legacy event sending (purchase, product view, add to cart, custom) works end-to-end

Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-126]: https://attentivemobile.atlassian.net/browse/MSDK-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ