### PR TITLE
MSDK-316 Fix GeoAdjustedDomainInterceptor crash for geo-specific domains

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/GeoDomainInterceptor.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/GeoDomainInterceptor.kt
@@ -6,6 +6,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.Response
+import timber.log.Timber
 import java.io.IOException
 import java.util.regex.Pattern
 
@@ -45,16 +46,23 @@ class GeoAdjustedDomainInterceptor(
 
         val url = String.format(ATTENTIVE_DTAG_URL, domain)
         val request = Request.Builder().url(url).build()
-        val response = httpClient.newCall(request).execute()
 
-        if (response.code != 200 || response.body == null) {
-            throw IOException("Failed to get geo-adjusted domain")
+        val geoAdjustedDomain = try {
+            val response = httpClient.newCall(request).execute()
+            if (response.code != 200 || response.body == null) {
+                Timber.w("Failed to get geo-adjusted domain (code: ${response.code}). Using original domain.")
+                domain
+            } else {
+                val fullTag = response.body!!.string()
+                parseAttentiveDomainFromTag(fullTag) ?: run {
+                    Timber.w("Could not parse the domain from the full tag. Using original domain.")
+                    domain
+                }
+            }
+        } catch (e: IOException) {
+            Timber.w("Geo-adjusted domain request failed: ${e.message}. Using original domain.")
+            domain
         }
-
-        val fullTag = response.body!!.string()
-        val geoAdjustedDomain =
-            parseAttentiveDomainFromTag(fullTag)
-                ?: throw IOException("Could not parse the domain from the full tag")
 
         cachedGeoAdjustedDomain = geoAdjustedDomain
         return geoAdjustedDomain

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/GeoDomainInterceptor.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/GeoDomainInterceptor.kt
@@ -48,15 +48,16 @@ class GeoAdjustedDomainInterceptor(
         val request = Request.Builder().url(url).build()
 
         val geoAdjustedDomain = try {
-            val response = httpClient.newCall(request).execute()
-            if (response.code != 200 || response.body == null) {
-                Timber.w("Failed to get geo-adjusted domain (code: ${response.code}). Using original domain.")
-                domain
-            } else {
-                val fullTag = response.body!!.string()
-                parseAttentiveDomainFromTag(fullTag) ?: run {
-                    Timber.w("Could not parse the domain from the full tag. Using original domain.")
+            httpClient.newCall(request).execute().use { response ->
+                if (response.code != 200 || response.body == null) {
+                    Timber.w("Failed to get geo-adjusted domain (code: ${response.code}). Using original domain.")
                     domain
+                } else {
+                    val fullTag = response.body!!.string()
+                    parseAttentiveDomainFromTag(fullTag) ?: run {
+                        Timber.w("Could not parse the domain from the full tag. Using original domain.")
+                        domain
+                    }
                 }
             }
         } catch (e: IOException) {


### PR DESCRIPTION
## Summary
- **Bug**: When a geo-specific domain (e.g. `youngla-pt`) is configured and the user is physically in that country (e.g. Portugal via VPN), the CDN's `dtag.js` endpoint returns HTTP 204 because it attempts to double-suffix the domain (`youngla-pt-pt`). The `GeoAdjustedDomainInterceptor` threw an `IOException` on non-200 responses, causing all Retrofit API calls to fail.
- **Fix**: Fall back to the original domain on dtag.js failure instead of throwing, matching the existing fallback behavior in `getGeoAdjustedDomainAsync`.
- The result is cached, so the failed dtag.js call only happens once per session.

## Jira
[MSDK-316](https://attentivemobile.atlassian.net/browse/MSDK-316)

## Test plan
- [ ] Configure SDK with a geo-specific domain (e.g. `youngla-pt`)
- [ ] Verify normal operation without VPN — dtag.js returns 200, geo-adjusted domain is used
- [ ] Enable VPN to the matching country (Portugal) — dtag.js returns 204, SDK falls back to original domain and all API calls succeed
- [ ] Verify Timber warning logs appear on fallback
- [ ] Verify domain is cached after first resolution (no repeated dtag.js calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-316]: https://attentivemobile.atlassian.net/browse/MSDK-316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ