### PR TITLE
MSDK-304: Break circular dependency between AttentiveApi and AttentiveEventTracker

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
@@ -28,7 +28,6 @@ import com.attentive.androidsdk.internal.network.RetrofitEventsApiService
 import com.attentive.androidsdk.internal.network.UserUpdateRequest
 import com.attentive.androidsdk.internal.util.AppInfo
 import com.attentive.androidsdk.push.AttentivePush
-import com.attentive.androidsdk.push.TokenProvider
 import kotlinx.serialization.PolymorphicSerializer
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
@@ -103,20 +102,13 @@ class AttentiveApi(private var httpClient: OkHttpClient, private val domain: Str
 
     val eventsApi: RetrofitEventsApiService = retrofitEvents.create(RetrofitEventsApiService::class.java)
 
-    internal fun sendUserUpdate(domain: String, email: String?, phoneNumber: String?) {
-        AttentiveEventTracker.instance.config.clearUser()
-
-        val visitorId = AttentiveEventTracker.instance.config.userIdentifiers.visitorId
-        if (visitorId == null) {
-            Timber.e("No visitorId available, cannot send user update")
-            return
-        }
-        val pushToken = TokenProvider.getInstance().token
-        if (pushToken == null) {
-            Timber.e("No push token available, cannot send user update")
-            return
-        }
-
+    internal fun sendUserUpdate(
+        domain: String,
+        email: String?,
+        phoneNumber: String?,
+        visitorId: String,
+        pushToken: String
+    ) {
         val contactInfo = ContactInfo().apply {
             if (email != null) {
                 this.email = email
@@ -125,16 +117,6 @@ class AttentiveApi(private var httpClient: OkHttpClient, private val domain: Str
                 this.phone = phoneNumber
             }
         }
-
-        val builder = UserIdentifiers.Builder()
-        email?.let {
-            builder.withEmail(it)
-        }
-        phoneNumber?.let {
-            builder.withPhone(it)
-        }
-
-        AttentiveEventTracker.instance.config.identify(builder.build())
 
         api.updateUser(
             UserUpdateRequest(
@@ -995,14 +977,14 @@ private fun sendDirectOpenStatusInternal(
 internal fun sendOptInSubscriptionStatus(
     phoneNumber: String? = "",
     email: String? = "",
-    pushToken: String?
+    pushToken: String?,
+    domain: String,
+    userIdentifiers: UserIdentifiers
 ) {
     if (pushToken == null) {
         Timber.e("Invalid push token, cannot send opt-in subscription status")
         return
     }
-    val domain = AttentiveEventTracker.instance.config.domain
-    val userIdentifiers = AttentiveEventTracker.instance.config.userIdentifiers
     if (userIdentifiers.visitorId.isNullOrEmpty()) {
         Timber.e("No visitorId available, cannot send opt-in subscription")
         return
@@ -1035,13 +1017,13 @@ internal fun sendOptOutSubscriptionStatus(
     email: String?,
     phoneNumber: String?,
     domain: String,
-    pushToken: String?
+    pushToken: String?,
+    userIdentifiers: UserIdentifiers
 ) {
     if (pushToken == null) {
         Timber.e("Invalid push token, cannot send opt-out subscription status")
         return
     }
-    val userIdentifiers = AttentiveEventTracker.instance.config.userIdentifiers
     if (userIdentifiers.visitorId.isNullOrEmpty()) {
         Timber.e("No visitorId available, cannot send opt-out subscription")
         return

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveEventTracker.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveEventTracker.kt
@@ -197,6 +197,8 @@ class AttentiveEventTracker private constructor() {
                     phoneNumber,
                     email,
                     it.getOrNull()?.token,
+                    config.domain,
+                    config.userIdentifiers,
                 )
             }
         }
@@ -218,6 +220,7 @@ class AttentiveEventTracker private constructor() {
                     phoneNumber,
                     config.domain,
                     it.getOrNull()?.token,
+                    config.userIdentifiers,
                 )
             }
         }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -12,6 +12,7 @@ import com.attentive.androidsdk.internal.util.Constants
 import com.attentive.androidsdk.internal.util.isPhoneNumber
 import com.attentive.androidsdk.push.AttentivePush
 import com.attentive.androidsdk.push.TokenFetchResult
+import com.attentive.androidsdk.push.TokenProvider
 import com.google.firebase.messaging.RemoteMessage
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -337,9 +338,29 @@ object AttentiveSdk {
             }
         }
 
+        // Clear user and re-identify with updated contact info
+        config.clearUser()
+
+        val visitorId = config.userIdentifiers.visitorId
+        if (visitorId == null) {
+            Timber.e("No visitorId available, cannot send user update")
+            return
+        }
+
+        val pushToken = TokenProvider.getInstance().token
+        if (pushToken == null) {
+            Timber.e("No push token available, cannot send user update")
+            return
+        }
+
+        val identifiersBuilder = UserIdentifiers.Builder()
+        email?.let { identifiersBuilder.withEmail(it) }
+        number?.let { identifiersBuilder.withPhone(it) }
+        config.identify(identifiersBuilder.build())
+
         val domain = config.domain
         CoroutineScope(Dispatchers.IO).launch {
-            config.attentiveApi.sendUserUpdate(domain, email, number)
+            config.attentiveApi.sendUserUpdate(domain, email, number, visitorId, pushToken)
         }
     }
 


### PR DESCRIPTION
## Summary
- `AttentiveApi` no longer accesses `AttentiveEventTracker.instance.config` — all data is now passed via method parameters
- `sendOptOutSubscriptionStatus`: added `userIdentifiers` parameter
- `sendOptInSubscriptionStatus`: added `domain` and `userIdentifiers` parameters
- `sendUserUpdate`: added `visitorId` and `pushToken` parameters; moved `clearUser()`/`identify()` mutation logic to the caller (`AttentiveSdk.updateUser()`)
- All 3 methods are `internal`, so no public API changes

## Test plan
- [x] `compileDebugKotlin` passes
- [x] `testDebugUnitTest` passes
- [ ] Verify opt-in/opt-out flows work end-to-end
- [ ] Verify `updateUser` flow correctly clears and re-identifies

🤖 Generated with [Claude Code](https://claude.com/claude-code)