### PR TITLE
MSDK-325: Switch SDK default to new events endpoint

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveConfig.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveConfig.kt
@@ -31,7 +31,7 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
     private val settingsService: SettingsService =
         ClassFactory.buildSettingsService(ClassFactory.buildPersistentStorage(builder._context))
 
-    var apiVersion = ApiVersion.OLD
+    var apiVersion = ApiVersion.NEW
 
     init {
         Timber.d("Initializing AttentiveConfig with configuration: %s", builder)
@@ -142,7 +142,7 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
         internal var skipFatigueOnCreatives: Boolean = false
         internal var logLevel: AttentiveLogLevel = AttentiveLogLevel.STANDARD
 
-        internal var apiVersion: ApiVersion = ApiVersion.OLD
+        internal var apiVersion: ApiVersion = ApiVersion.NEW
 
         fun applicationContext(context: Application) =
             apply {
@@ -175,7 +175,7 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
             _notificationIconBackgroundColorResource = colorResourceId
         }
 
-        private val allowApiVersionOverride = false
+        private val allowApiVersionOverride = true
 
         fun apiVersion(apiVersion: ApiVersion) =
             apply {


### PR DESCRIPTION
## Summary
- Default `ApiVersion` changed from `OLD` to `NEW` — the SDK now uses the `BaseEventRequest` JSON body format via Retrofit instead of the legacy callback-based query parameter format
- `allowApiVersionOverride` flipped from `false` to `true` so `AttentiveConfig.Builder.apiVersion()` is no longer a no-op — callers can configure this during initialization
- Bonni's "Toggle Api Version" setting continues to work for runtime switching

## Changes
Single file: `AttentiveConfig.kt` — 3 lines changed

## Test plan
- [x] `compileDebugKotlin` passes
- [x] `testDebugUnitTest` passes
- [ ] Verify events are sent correctly with the new endpoint format
- [ ] Verify bonni toggle still switches between OLD and NEW at runtime
- [ ] Verify bonni persists the preference across app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)