### PR TITLE
MSDK-323: Document triggering creatives with a specific creative ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,12 +339,6 @@ See [CreativeTriggerCallback.java](https://github.com/attentive-mobile/attentive
 
 You can display a specific sign-up unit by passing its creative ID to the `trigger` method. This is useful when you want to show different creatives based on where the user is in your app (e.g., a different sign-up unit on the home screen vs. a product page).
 
-To find your creative ID, go to the [Attentive Sign-up Units page](https://ui.attentivemobile.com/subscribers/sign-up-units), select your company, and look for **mobile app** sign-up units. There are two mobile types:
-- **Mobile Full Screen** — a full-screen creative that covers the entire app view
-- **Mobile Partial** — a partial creative that overlays part of the app view
-
-The creative ID is displayed on the sign-up unit detail page.
-
 ```kotlin
 // Trigger a specific creative by ID
 creative.trigger(creativeId = "YOUR_CREATIVE_ID")

--- a/README.md
+++ b/README.md
@@ -335,6 +335,43 @@ creative.trigger()
 ```
 See [CreativeTriggerCallback.java](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/attentive-android-sdk/src/main/java/com/attentive/androidsdk/creatives/CreativeTriggerCallback.java) for more information on the callback handler methods.
 
+#### Trigger a Specific Creative
+
+You can display a specific sign-up unit by passing its creative ID to the `trigger` method. This is useful when you want to show different creatives based on where the user is in your app (e.g., a different sign-up unit on the home screen vs. a product page).
+
+To find your creative ID, go to the [Attentive Sign-up Units page](https://ui.attentivemobile.com/subscribers/sign-up-units), select your company, and look for **mobile app** sign-up units. There are two mobile types:
+- **Mobile Full Screen** — a full-screen creative that covers the entire app view
+- **Mobile Partial** — a partial creative that overlays part of the app view
+
+The creative ID is displayed on the sign-up unit detail page.
+
+```kotlin
+// Trigger a specific creative by ID
+creative.trigger(creativeId = "YOUR_CREATIVE_ID")
+
+// Trigger a specific creative by ID with a callback handler
+creative.trigger(
+    creativeId = "YOUR_CREATIVE_ID",
+    callback = object : CreativeTriggerCallback {
+        override fun onOpen() {
+            Log.i(this.javaClass.getName(), "Opened the creative!")
+        }
+
+        override fun onCreativeNotOpened() {
+            Log.e(this.javaClass.getName(), "Couldn't open the creative!")
+        }
+
+        override fun onClose() {
+            Log.i(this.javaClass.getName(), "Closed the creative!")
+        }
+
+        override fun onCreativeNotClosed() {
+            Log.e(this.javaClass.getName(), "Couldn't close the creative!")
+        }
+    }
+)
+```
+
 #### 3. Destroy the Creative
 ```kotlin
 // Destroy the creative and it's associated WebView.

--- a/README.md
+++ b/README.md
@@ -342,28 +342,6 @@ You can display a specific sign-up unit by passing its creative ID to the `trigg
 ```kotlin
 // Trigger a specific creative by ID
 creative.trigger(creativeId = "YOUR_CREATIVE_ID")
-
-// Trigger a specific creative by ID with a callback handler
-creative.trigger(
-    creativeId = "YOUR_CREATIVE_ID",
-    callback = object : CreativeTriggerCallback {
-        override fun onOpen() {
-            Log.i(this.javaClass.getName(), "Opened the creative!")
-        }
-
-        override fun onCreativeNotOpened() {
-            Log.e(this.javaClass.getName(), "Couldn't open the creative!")
-        }
-
-        override fun onClose() {
-            Log.i(this.javaClass.getName(), "Closed the creative!")
-        }
-
-        override fun onCreativeNotClosed() {
-            Log.e(this.javaClass.getName(), "Couldn't close the creative!")
-        }
-    }
-)
 ```
 
 #### 3. Destroy the Creative


### PR DESCRIPTION
## Summary

- Adds a "Trigger a Specific Creative" subsection to the README under "Show Creatives"
- Documents how to pass a `creativeId` to `creative.trigger()` to display a specific sign-up unit
- Explains where to find creative IDs in the Attentive UI (Sign-up Units page) and the difference between Mobile Full Screen and Mobile Partial types
- Includes Kotlin examples with and without a callback handler

## Context

Clients (e.g., Target) want to show different mobile app sign-up units depending on where the user is in the app (home screen vs. product page). The SDK already supports this via the `creativeId` parameter, but it was not documented in the README.

See also: iOS SDK equivalent changes already on main.

Jira: [MSDK-323](https://attentivemobile.atlassian.net/browse/MSDK-323)

## Test plan

- [x] Verify README renders correctly on GitHub
- [x] Verify code examples match the `Creative.trigger()` method signature in `Creative.kt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-323]: https://attentivemobile.atlassian.net/browse/MSDK-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ