### PR TITLE
MSDK-239: Add Slack failure notifications to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,13 @@ version: 2.1
 
 orbs:
   android: circleci/android@2.5.0
+  slack: circleci/slack@6.1.3
+
+# ========================
+# Constants
+# ========================
+slack_channel_ci_alerts: &slack_channel_ci_alerts "eng-mobile-sdk-ci-alerts-android"
+default_context: &default_context org-global
 
 parameters:
   run_release:
@@ -31,6 +38,23 @@ executors:
     environment:
       <<: *default_environment
 
+# ========================
+# Commands (Reusable)
+# ========================
+commands:
+  notify-slack-on-failure:
+    description: "Send Slack notification on job failure"
+    steps:
+      - run:
+          name: Build Slack failure payload
+          when: on_fail
+          command: .circleci/slack-notify-failure.sh
+      - slack/notify:
+          channel: *slack_channel_ci_alerts
+          event: fail
+          custom: |
+            ${SLACK_FAILURE_PAYLOAD}
+
 jobs:
   lint:
     executor: android-executor
@@ -54,6 +78,7 @@ jobs:
       - store_artifacts:
           path: attentive-android-sdk/build/reports/lint-results-debug.html
           destination: lint-report.html
+      - notify-slack-on-failure
 
   unit-test:
     executor: android-executor
@@ -87,6 +112,7 @@ jobs:
           root: attentive-android-sdk/build/reports
           paths:
             - jacoco/jacocoTestReport/jacocoTestReport.xml
+      - notify-slack-on-failure
 
   instrumented-test:
     machine:
@@ -129,6 +155,7 @@ jobs:
       - store_artifacts:
           path: attentive-android-sdk/build/reports/coverage/androidTest/debug
           destination: instrumented-coverage-report
+      - notify-slack-on-failure
 
   build:
     executor: android-executor
@@ -149,6 +176,7 @@ jobs:
       - store_artifacts:
           path: attentive-android-sdk/build/outputs/aar
           destination: aar
+      - notify-slack-on-failure
 
   snapshot-test:
     executor: android-executor
@@ -169,6 +197,7 @@ jobs:
       - store_artifacts:
           path: bonni/build/outputs/roborazzi
           destination: snapshot-diffs
+      - notify-slack-on-failure
 
   distribute-bonni:
     executor: android-executor
@@ -242,6 +271,7 @@ jobs:
       - store_artifacts:
           path: bonni/build/outputs/apk/release
           destination: bonni-apk
+      - notify-slack-on-failure
 
   release:
     executor: android-executor
@@ -346,21 +376,28 @@ jobs:
                 \"head\": \"$BRANCH\",
                 \"base\": \"main\"
               }"
+      - notify-slack-on-failure
 
 workflows:
   build-and-test:
     unless: << pipeline.parameters.run_release >>
     jobs:
-      - lint
-      - unit-test
-      - instrumented-test
-      - snapshot-test
+      - lint:
+          context: *default_context
+      - unit-test:
+          context: *default_context
+      - instrumented-test:
+          context: *default_context
+      - snapshot-test:
+          context: *default_context
       - build:
+          context: *default_context
           requires:
             - lint
             - unit-test
             - snapshot-test
       - distribute-bonni:
+          context: *default_context
           requires:
             - build
           filters:
@@ -372,4 +409,5 @@ workflows:
   release:
     when: << pipeline.parameters.run_release >>
     jobs:
-      - release
+      - release:
+          context: *default_context

--- a/.circleci/slack-notify-failure.sh
+++ b/.circleci/slack-notify-failure.sh
@@ -43,7 +43,7 @@ PAYLOAD=$(jq -n \
   --arg project "$CIRCLE_PROJECT_REPONAME" \
   '{
     "blocks": [
-      {"type":"header","text":{"type":"plain_text","text":"Job Failed","emoji":true}},
+      {"type":"header","text":{"type":"plain_text","text":"🚨 Job Failed","emoji":true}},
       {"type":"section","fields":(
         [{"type":"mrkdwn","text":("*Job/Build:*\n<" + $job_url + "|" + $job + ">")}]
         + (if $workflow != "" then [{"type":"mrkdwn","text":("*Workflow:*\n<" + $workflow_url + "|" + $workflow + ">")}] else [] end)

--- a/.circleci/slack-notify-failure.sh
+++ b/.circleci/slack-notify-failure.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Builds a Slack Block Kit payload for job failure notifications.
+# Exports SLACK_FAILURE_PAYLOAD to BASH_ENV for use by the slack orb.
+#
+# Required env vars: CIRCLE_JOB, CIRCLE_BUILD_NUM, CIRCLE_BUILD_URL,
+#   CIRCLE_WORKFLOW_ID, CIRCLE_BRANCH, CIRCLE_PROJECT_REPONAME
+# Optional env vars: CIRCLE_PULL_REQUEST, CIRCLE_USERNAME,
+#   CIRCLE_PROJECT_USERNAME, GITHUB_TOKEN
+
+# Fetch workflow name from CircleCI API (no auth required)
+WORKFLOW_NAME=$(curl -sf \
+  "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}" \
+  | jq -r '.name // empty' || true)
+WORKFLOW_URL="https://app.circleci.com/pipelines/workflows/${CIRCLE_WORKFLOW_ID}"
+
+# Fetch PR title if available
+PR_TEXT=""
+if [ -n "${CIRCLE_PULL_REQUEST:-}" ] && [ -n "${GITHUB_TOKEN:-}" ]; then
+  PR_NUMBER="${CIRCLE_PULL_REQUEST##*/}"
+  PR_TITLE=$(curl -sf \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME:-}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUMBER}" \
+    | jq -r '.title // empty' || true)
+  if [ -n "$PR_TITLE" ]; then
+    PR_TEXT="<${CIRCLE_PULL_REQUEST}|#${PR_NUMBER}: ${PR_TITLE}>"
+  else
+    PR_TEXT="<${CIRCLE_PULL_REQUEST}|#${PR_NUMBER}>"
+  fi
+fi
+
+# Build payload safely with jq --arg for all dynamic values
+PAYLOAD=$(jq -n \
+  --arg job "${CIRCLE_JOB}/${CIRCLE_BUILD_NUM}" \
+  --arg job_url "$CIRCLE_BUILD_URL" \
+  --arg workflow "${WORKFLOW_NAME}" \
+  --arg workflow_url "$WORKFLOW_URL" \
+  --arg pr "$PR_TEXT" \
+  --arg author "${CIRCLE_USERNAME:-}" \
+  --arg branch "$CIRCLE_BRANCH" \
+  --arg project "$CIRCLE_PROJECT_REPONAME" \
+  '{
+    "blocks": [
+      {"type":"header","text":{"type":"plain_text","text":"Job Failed","emoji":true}},
+      {"type":"section","fields":(
+        [{"type":"mrkdwn","text":("*Job/Build:*\n<" + $job_url + "|" + $job + ">")}]
+        + (if $workflow != "" then [{"type":"mrkdwn","text":("*Workflow:*\n<" + $workflow_url + "|" + $workflow + ">")}] else [] end)
+        + (if $pr != "" then [{"type":"mrkdwn","text":("*PR:*\n" + $pr)}] else [] end)
+        + (if $author != "" then [{"type":"mrkdwn","text":("*Author:*\n" + $author)}] else [] end)
+        + [{"type":"mrkdwn","text":("*Branch:*\n" + $branch)}]
+        + [{"type":"mrkdwn","text":("*Project:*\n" + $project)}]
+      )}
+    ]
+  }')
+
+echo "export SLACK_FAILURE_PAYLOAD='$(echo "$PAYLOAD" | sed "s/'/'\\\\''/g")'" >> "$BASH_ENV"


### PR DESCRIPTION
## Summary
- Adds `circleci/slack@6.1.3` orb and a reusable `notify-slack-on-failure` command to the CircleCI config
- Adds `.circleci/slack-notify-failure.sh` which builds a rich Slack Block Kit payload with job/build link, workflow link, PR title, author, and branch info
- Wires failure notifications into all jobs (lint, unit-test, instrumented-test, build, snapshot-test, distribute-bonni, release) posting to `#eng-mobile-sdk-ci-alerts-android`
- Adds `org-global` context to all workflow jobs for Slack token access

Mirrors the existing setup in the iOS SDK repo.

**Jira:** https://attentivemobile.atlassian.net/browse/MSDK-239

## Test plan
- [x] CircleCI config validates locally (`circleci config validate`)
- [x] Trigger a CI run and verify failure notification appears in `#eng-mobile-sdk-ci-alerts-android`
- [ ] Verify successful jobs do not send notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)