### PR TITLE
MSDK-327: Clarify that push notification setup is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ val attentiveConfig = AttentiveConfig.Builder()
         .applicationContext(getApplicationContext())
         .domain("YOUR_ATTENTIVE_DOMAIN")
         .mode(AttentiveConfig.Mode.PRODUCTION)
-        // Add a notification icon drawable id if using push
+        // Optional: only needed if using push notifications (see Step 4)
         .notificationIconId(R.drawable.your_notification_icon)
         .build()
 
@@ -365,7 +365,23 @@ val attentiveConfig = AttentiveConfig.Builder()
     .build()
 ```
 
-## Step 4 - Integrate With Push
+## Step 4 (optional) - Integrate With Push
+
+Push notification support is **optional**. The core SDK functionality — event tracking, creatives, and user identification — works without any push setup. Only follow this section if you want to send push notifications to your users via Attentive.
+
+If you are **not** using push notifications, add the following to your `AndroidManifest.xml` to remove the SDK's Firebase messaging service:
+
+```xml
+<service
+    android:name="com.attentive.androidsdk.push.AttentiveFirebaseMessagingService"
+    tools:node="remove" />
+```
+
+Make sure the `tools` namespace is declared in your `<manifest>` tag:
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+```
 
 The conditions for your users to receive push notifications are as follows:
 1. You have initialized the Attentive SDK with a valid domain and a notification icon resource id.


### PR DESCRIPTION
## Summary
- Updated README Step 4 heading to indicate push is optional
- Added note that core SDK functionality (event tracking, creatives, user identification) works without push
- Added manifest snippet for removing `AttentiveFirebaseMessagingService` when not using push
- Clarified that `notificationIconId` in SDK initialization is only needed for push

## Ticket
[MSDK-327](https://attentivemobile.atlassian.net/browse/MSDK-327)

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify manifest snippet is correct XML

Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-327]: https://attentivemobile.atlassian.net/browse/MSDK-327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ