### PR TITLE
Security updates to the CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ orbs:
   android: circleci/android@2.5.0
   slack: circleci/slack@6.1.3
   attentive: attentive-mobile/circleci-orb@0.0.11
+  github-cli: circleci/github-cli@3.0.0
 
 # ========================
 # Constants
@@ -264,8 +265,11 @@ jobs:
           command: |
             firebase appdistribution:distribute bonni/build/outputs/apk/release/bonni-release.apk \
               --app "$FIREBASE_APP_ID" \
-              --groups "dev, product-+-eng" \
-              --token "$FIREBASE_TOKEN"
+              --groups "dev, product-+-eng"
+      - run:
+          name: Cleanup keystore
+          when: always
+          command: rm -f bonni/bonni-release.keystore
       - store_artifacts:
           path: bonni/build/outputs/apk/release
           destination: bonni-apk
@@ -279,6 +283,7 @@ jobs:
           github_app_client_id: ${GITHUB_APP_CLIENT_ID}
           github_app_private_key_base64: ${GITHUB_APP_PRIVATE_KEY_BASE64}
           github_app_installation_id: ${GITHUB_APP_INSTALLATION_ID}
+      - github-cli/install
       - run:
           name: Switch git remote to HTTPS with App token
           command: |
@@ -325,25 +330,12 @@ jobs:
               git commit -m "Set version to $RELEASE_VERSION"
               git push --force origin "$BRANCH"
 
-              HTTP_STATUS=$(curl -s -o /tmp/pr-response.json -w "%{http_code}" \
-                -X POST \
-                "https://api.github.com/repos/attentive-mobile/attentive-android-sdk/pulls" \
-                -H "Authorization: token $GITHUB_TOKEN" \
-                -H "Content-Type: application/json" \
-                -d "{
-                  \"title\": \"Release v$RELEASE_VERSION\",
-                  \"body\": \"Automated release PR. Maven Central publish and GitHub Release are performed from this branch by CircleCI. Merge into main once verified.\",
-                  \"head\": \"$BRANCH\",
-                  \"base\": \"main\"
-                }")
-
-              echo "GitHub PR API status: $HTTP_STATUS"
-              cat /tmp/pr-response.json
-              echo
-
-              if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
-                exit 1
-              fi
+              gh pr create \
+                --repo attentive-mobile/attentive-android-sdk \
+                --title "Release v$RELEASE_VERSION" \
+                --body "Automated release PR. Maven Central publish and GitHub Release are performed from this branch by CircleCI. Merge into main once verified." \
+                --head "$BRANCH" \
+                --base main
             fi
       - run:
           name: Clean
@@ -360,15 +352,10 @@ jobs:
             fi
             git tag "$RELEASE_VERSION"
             git push origin "$RELEASE_VERSION"
-            curl -sf -X POST \
-              "https://api.github.com/repos/attentive-mobile/attentive-android-sdk/releases" \
-              -H "Authorization: token $GITHUB_TOKEN" \
-              -H "Content-Type: application/json" \
-              -d "{
-                \"tag_name\": \"$RELEASE_VERSION\",
-                \"name\": \"$RELEASE_VERSION\",
-                \"generate_release_notes\": true
-              }"
+            gh release create "$RELEASE_VERSION" \
+              --repo attentive-mobile/attentive-android-sdk \
+              --title "$RELEASE_VERSION" \
+              --generate-notes
       - notify-slack-on-failure
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,8 +266,11 @@ jobs:
           command: |
             firebase appdistribution:distribute bonni/build/outputs/apk/release/bonni-release.apk \
               --app "$FIREBASE_APP_ID" \
-              --groups "dev, product-+-eng" \
-              --token "$FIREBASE_TOKEN"
+              --groups "dev, product-+-eng"
+      - run:
+          name: Cleanup keystore
+          when: always
+          command: rm -f bonni/bonni-release.keystore
       - store_artifacts:
           path: bonni/build/outputs/apk/release
           destination: bonni-apk
@@ -332,6 +335,14 @@ jobs:
           name: Publish to Maven Central
           command: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
       - run:
+          name: Install GitHub CLI
+          command: |
+            if ! command -v gh &> /dev/null; then
+              curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+              echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+              sudo apt-get update && sudo apt-get install -y gh
+            fi
+      - run:
           name: Create GitHub Release
           command: |
             if [ "$IS_BETA" = "true" ]; then
@@ -340,15 +351,10 @@ jobs:
             fi
             git tag "v$RELEASE_VERSION"
             git push origin "v$RELEASE_VERSION"
-            curl -sf -X POST \
-              "https://api.github.com/repos/attentive-mobile/attentive-android-sdk/releases" \
-              -H "Authorization: token $GITHUB_TOKEN" \
-              -H "Content-Type: application/json" \
-              -d "{
-                \"tag_name\": \"v$RELEASE_VERSION\",
-                \"name\": \"v$RELEASE_VERSION\",
-                \"generate_release_notes\": true
-              }"
+            gh release create "v$RELEASE_VERSION" \
+              --repo attentive-mobile/attentive-android-sdk \
+              --title "v$RELEASE_VERSION" \
+              --generate-notes
       - run:
           name: Create version bump PR
           command: |
@@ -366,16 +372,12 @@ jobs:
             git commit -m "Bump version to $NEXT_VERSION"
             git push origin "$BRANCH"
 
-            curl -sf -X POST \
-              "https://api.github.com/repos/attentive-mobile/attentive-android-sdk/pulls" \
-              -H "Authorization: token $GITHUB_TOKEN" \
-              -H "Content-Type: application/json" \
-              -d "{
-                \"title\": \"Bump version to $NEXT_VERSION\",
-                \"body\": \"Automated version bump after releasing v$RELEASE_VERSION to Maven Central.\",
-                \"head\": \"$BRANCH\",
-                \"base\": \"main\"
-              }"
+            gh pr create \
+              --repo attentive-mobile/attentive-android-sdk \
+              --title "Bump version to $NEXT_VERSION" \
+              --body "Automated version bump after releasing v$RELEASE_VERSION to Maven Central." \
+              --head "$BRANCH" \
+              --base main
       - notify-slack-on-failure
 
 workflows:


### PR DESCRIPTION
1. Don't specify the `FIREBASE_TOKEN` variable, as the CLI already knows to read it, so this prevents it from being logged in the history
2. Delete the `bonni-release.keystore` file when done to prevent it from possible persistence
3. Switch to using the Github CLI instead of curl commands to keep the value of `GITHUB_TOKEN` from possibly being printed in logs