### PR TITLE
MSDK-301: Standardize error handling and async patterns

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
@@ -1,5 +1,6 @@
 package com.attentive.androidsdk
 
+import kotlin.coroutines.cancellation.CancellationException
 import androidx.annotation.VisibleForTesting
 import com.attentive.androidsdk.events.AddToCartEvent
 import com.attentive.androidsdk.events.CustomEvent
@@ -155,6 +156,8 @@ class AttentiveApi(private var httpClient: OkHttpClient, private val domain: Str
                 Timber.e(msg)
                 Result.failure(Exception(msg))
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Timber.e("Failed to send user update: ${e.message}")
             Result.failure(e)
@@ -207,6 +210,8 @@ class AttentiveApi(private var httpClient: OkHttpClient, private val domain: Str
                     Timber.e(msg)
                     return Result.failure(Exception(msg))
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Timber.e("Failed to send ${request.eventType} event: ${e.message}")
                 return Result.failure(e)
@@ -1035,6 +1040,8 @@ internal suspend fun sendOptInSubscriptionStatus(
             Timber.e(msg)
             Result.failure(Exception(msg))
         }
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         Timber.e("Opt-in subscription request failed: ${e.message}")
         Result.failure(e)
@@ -1081,6 +1088,8 @@ internal suspend fun sendOptOutSubscriptionStatus(
             Timber.e(msg)
             Result.failure(Exception(msg))
         }
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         Timber.e("Opt-out subscription request failed: ${e.message}")
         Result.failure(e)

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
@@ -103,18 +103,18 @@ class AttentiveApi(private var httpClient: OkHttpClient, private val domain: Str
 
     val eventsApi: RetrofitEventsApiService = retrofitEvents.create(RetrofitEventsApiService::class.java)
 
-    internal fun sendUserUpdate(domain: String, email: String?, phoneNumber: String?) {
+    internal suspend fun sendUserUpdate(domain: String, email: String?, phoneNumber: String?): Result<Unit> {
         AttentiveEventTracker.instance.config.clearUser()
 
         val visitorId = AttentiveEventTracker.instance.config.userIdentifiers.visitorId
         if (visitorId == null) {
             Timber.e("No visitorId available, cannot send user update")
-            return
+            return Result.failure(IllegalStateException("No visitorId available"))
         }
         val pushToken = TokenProvider.getInstance().token
         if (pushToken == null) {
             Timber.e("No push token available, cannot send user update")
-            return
+            return Result.failure(IllegalStateException("No push token available"))
         }
 
         val contactInfo = ContactInfo().apply {
@@ -136,31 +136,29 @@ class AttentiveApi(private var httpClient: OkHttpClient, private val domain: Str
 
         AttentiveEventTracker.instance.config.identify(builder.build())
 
-        api.updateUser(
-            UserUpdateRequest(
-                company = domain,
-                userId = visitorId,
-                pushToken = pushToken,
-                tokenProvider = "fcm",
-                sdkVersion = "mobile-app-${AppInfo.attentiveSDKVersion}",
-                metadata = contactInfo
+        return try {
+            val response = api.updateUserSuspend(
+                UserUpdateRequest(
+                    company = domain,
+                    userId = visitorId,
+                    pushToken = pushToken,
+                    tokenProvider = "fcm",
+                    sdkVersion = "mobile-app-${AppInfo.attentiveSDKVersion}",
+                    metadata = contactInfo
+                )
             )
-        ).enqueue(object : retrofit2.Callback<Unit> {
-            override fun onResponse(
-                call: retrofit2.Call<Unit>,
-                response: retrofit2.Response<Unit>
-            ) {
-                if(response.isSuccessful) {
-                    Timber.i("Successfully sent user update")
-                } else {
-                    Timber.e("Failed to send user update: ${response.code()}")
-                }
+            if (response.isSuccessful) {
+                Timber.i("Successfully sent user update")
+                Result.success(Unit)
+            } else {
+                val msg = "Failed to send user update: ${response.code()}"
+                Timber.e(msg)
+                Result.failure(Exception(msg))
             }
-
-            override fun onFailure(call: retrofit2.Call<kotlin.Unit?>, t: kotlin.Throwable) {
-               Timber.e("Failed to send user update: ${t.message}")
-            }
-        })
+        } catch (e: Exception) {
+            Timber.e("Failed to send user update: ${e.message}")
+            Result.failure(e)
+        }
     }
 
             /**
@@ -177,39 +175,44 @@ class AttentiveApi(private var httpClient: OkHttpClient, private val domain: Str
         event: Event,
         userIdentifiers: UserIdentifiers,
         domain: String
-    ) {
+    ): Result<Unit> {
         Timber.i("recordEvent called with event: %s", event.javaClass.name)
 
-        // Validate that we have a visitorId
         if (userIdentifiers.visitorId.isNullOrEmpty()) {
-            Timber.e("Cannot send event: visitorId is required but is null or empty")
-            return
+            val msg = "Cannot send event: visitorId is required but is null or empty"
+            Timber.e(msg)
+            return Result.failure(IllegalArgumentException(msg))
         }
 
-        // Map the event to BaseEventRequest(s)
         val baseEventRequests = getBaseEventRequestsFromEvent(event, userIdentifiers, domain)
 
         if (baseEventRequests.isEmpty()) {
-            Timber.w("No event requests generated for event: ${event.javaClass.name}")
-            return
+            val msg = "No event requests generated for event: ${event.javaClass.name}"
+            Timber.w(msg)
+            return Result.failure(IllegalStateException(msg))
         }
 
-        // Send each request
         for (request in baseEventRequests) {
             try {
-                // Serialize the BaseEventRequest to JSON string for the -d parameter
                 val eventDataJson = baseEventRequestJson.encodeToString(
                     BaseEventRequest.serializer(),
                     request
                 )
                 Timber.d("Sending event JSON: $eventDataJson")
-                api.sendEvent(eventDataJson)
-                Timber.i("Successfully sent ${request.eventType} event")
+                val response = api.sendEventSuspend(eventDataJson)
+                if (response.isSuccessful) {
+                    Timber.i("Successfully sent ${request.eventType} event")
+                } else {
+                    val msg = "Failed to send ${request.eventType} event: HTTP ${response.code()}"
+                    Timber.e(msg)
+                    return Result.failure(Exception(msg))
+                }
             } catch (e: Exception) {
                 Timber.e("Failed to send ${request.eventType} event: ${e.message}")
-                e.printStackTrace()
+                return Result.failure(e)
             }
         }
+        return Result.success(Unit)
     }
 
     /**
@@ -993,20 +996,22 @@ private fun sendDirectOpenStatusInternal(
 }
 
 
-internal fun sendOptInSubscriptionStatus(
+internal suspend fun sendOptInSubscriptionStatus(
     phoneNumber: String? = "",
     email: String? = "",
     pushToken: String?
-) {
+): Result<Unit> {
     if (pushToken == null) {
-        Timber.e("Invalid push token, cannot send opt-in subscription status")
-        return
+        val msg = "Invalid push token, cannot send opt-in subscription status"
+        Timber.e(msg)
+        return Result.failure(IllegalStateException(msg))
     }
     val domain = AttentiveEventTracker.instance.config.domain
     val userIdentifiers = AttentiveEventTracker.instance.config.userIdentifiers
     if (userIdentifiers.visitorId.isNullOrEmpty()) {
-        Timber.e("No visitorId available, cannot send opt-in subscription")
-        return
+        val msg = "No visitorId available, cannot send opt-in subscription"
+        Timber.e(msg)
+        return Result.failure(IllegalStateException(msg))
     }
     val externalVendorIdsJson = buildExternalVendorIdsJson(userIdentifiers)
 
@@ -1020,32 +1025,39 @@ internal fun sendOptInSubscriptionStatus(
         phone = phoneNumber,
     )
 
-    api.optInSubscription(request).enqueue(object : retrofit2.Callback<Unit> {
-        override fun onResponse(call: retrofit2.Call<Unit>, response: retrofit2.Response<Unit>) {
-            Timber.i("Opt-in subscription request success: ${response.message()}")
+    return try {
+        val response = api.optInSubscriptionSuspend(request)
+        if (response.isSuccessful) {
+            Timber.i("Opt-in subscription request success")
+            Result.success(Unit)
+        } else {
+            val msg = "Opt-in subscription request failed: HTTP ${response.code()}"
+            Timber.e(msg)
+            Result.failure(Exception(msg))
         }
-
-        override fun onFailure(call: retrofit2.Call<Unit>, t: Throwable) {
-            Timber.e("Opt-in subscription request failed: ${t.message}")
-        }
-    })
+    } catch (e: Exception) {
+        Timber.e("Opt-in subscription request failed: ${e.message}")
+        Result.failure(e)
+    }
 }
 
 
-internal fun sendOptOutSubscriptionStatus(
+internal suspend fun sendOptOutSubscriptionStatus(
     email: String?,
     phoneNumber: String?,
     domain: String,
     pushToken: String?
-) {
+): Result<Unit> {
     if (pushToken == null) {
-        Timber.e("Invalid push token, cannot send opt-out subscription status")
-        return
+        val msg = "Invalid push token, cannot send opt-out subscription status"
+        Timber.e(msg)
+        return Result.failure(IllegalStateException(msg))
     }
     val userIdentifiers = AttentiveEventTracker.instance.config.userIdentifiers
     if (userIdentifiers.visitorId.isNullOrEmpty()) {
-        Timber.e("No visitorId available, cannot send opt-out subscription")
-        return
+        val msg = "No visitorId available, cannot send opt-out subscription"
+        Timber.e(msg)
+        return Result.failure(IllegalStateException(msg))
     }
     val externalVendorIdsJson = buildExternalVendorIdsJson(userIdentifiers)
 
@@ -1059,15 +1071,20 @@ internal fun sendOptOutSubscriptionStatus(
         phone = phoneNumber,
     )
 
-    api.optOutSubscription(request).enqueue(object : retrofit2.Callback<Unit> {
-        override fun onResponse(call: retrofit2.Call<Unit>, response: retrofit2.Response<Unit>) {
-            Timber.i("Opt-out subscription request success: ${response.message()}")
+    return try {
+        val response = api.optOutSubscriptionSuspend(request)
+        if (response.isSuccessful) {
+            Timber.i("Opt-out subscription request success")
+            Result.success(Unit)
+        } else {
+            val msg = "Opt-out subscription request failed: HTTP ${response.code()}"
+            Timber.e(msg)
+            Result.failure(Exception(msg))
         }
-
-        override fun onFailure(call: retrofit2.Call<Unit>, t: Throwable) {
-            Timber.e("Opt-out subscription request failed: ${t.message}")
-        }
-    })
+    } catch (e: Exception) {
+        Timber.e("Opt-out subscription request failed: ${e.message}")
+        Result.failure(e)
+    }
 }
 
 // Test helper functions - marked as @VisibleForTesting internal so tests can access them

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveEventTracker.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveEventTracker.kt
@@ -66,7 +66,10 @@ class AttentiveEventTracker private constructor() {
     )
     fun recordEvent(event: Event) {
         CoroutineScope(Dispatchers.IO).launch {
-            recordEventSuspend(event)
+            val result = recordEventSuspend(event)
+            if (result.isFailure) {
+                Timber.e("recordEvent failed: ${result.exceptionOrNull()?.message}")
+            }
         }
     }
 
@@ -87,11 +90,12 @@ class AttentiveEventTracker private constructor() {
      *
      * @param event The event to record
      */
-    internal suspend fun recordEventSuspend(event: Event) {
-        verifyInitialized()
+    internal suspend fun recordEventSuspend(event: Event): Result<Unit> {
+        if (!::config.isInitialized) {
+            return Result.failure(IllegalStateException("AttentiveEventTracker must be initialized before use"))
+        }
 
-        if (config.apiVersion == ApiVersion.OLD) {
-            // Wrap the callback-based old API in a suspend function
+        return if (config.apiVersion == ApiVersion.OLD) {
             suspendCancellableCoroutine { continuation ->
                 config.attentiveApi.sendEvent(
                     event,
@@ -101,14 +105,14 @@ class AttentiveEventTracker private constructor() {
                         override fun onSuccess() {
                             Timber.i("Event recorded successfully")
                             if (continuation.isActive) {
-                                continuation.resume(Unit)
+                                continuation.resume(Result.success(Unit))
                             }
                         }
 
                         override fun onFailure(message: String?) {
                             Timber.e("Failed to record event: $message")
                             if (continuation.isActive) {
-                                continuation.resume(Unit) // Resume anyway, don't throw
+                                continuation.resume(Result.failure(Exception(message ?: "Unknown error")))
                             }
                         }
                     },
@@ -185,42 +189,52 @@ class AttentiveEventTracker private constructor() {
     internal suspend fun optIn(
         email: String = "",
         phoneNumber: String = "",
-    ) {
-        verifyInitialized()
+    ): Result<Unit> {
+        if (!::config.isInitialized) {
+            return Result.failure(IllegalStateException("AttentiveEventTracker must be initialized before use"))
+        }
         if (phoneNumber.isEmpty() && email.isEmpty()) {
-            Timber.e("At least one of phone number or email must be provided to opt in.")
-            return
+            val msg = "At least one of phone number or email must be provided to opt in."
+            Timber.e(msg)
+            return Result.failure(IllegalArgumentException(msg))
         }
-        TokenProvider.getInstance().getToken(config.applicationContext).let {
-            if (it.isSuccess) {
-                config.attentiveApi.sendOptInSubscriptionStatus(
-                    phoneNumber,
-                    email,
-                    it.getOrNull()?.token,
-                )
-            }
+        val tokenResult = TokenProvider.getInstance().getToken(config.applicationContext)
+        if (tokenResult.isFailure) {
+            val msg = "Failed to fetch push token: ${tokenResult.exceptionOrNull()?.message}"
+            Timber.e(msg)
+            return Result.failure(tokenResult.exceptionOrNull() ?: Exception(msg))
         }
+        return config.attentiveApi.sendOptInSubscriptionStatus(
+            phoneNumber,
+            email,
+            tokenResult.getOrNull()?.token,
+        )
     }
 
     internal suspend fun optOut(
         email: String = "",
         phoneNumber: String = "",
-    ) {
-        verifyInitialized()
+    ): Result<Unit> {
+        if (!::config.isInitialized) {
+            return Result.failure(IllegalStateException("AttentiveEventTracker must be initialized before use"))
+        }
         if (phoneNumber.isEmpty() && email.isEmpty()) {
-            Timber.e("At least one of phone number or email must be provided to opt out.")
-            return
+            val msg = "At least one of phone number or email must be provided to opt out."
+            Timber.e(msg)
+            return Result.failure(IllegalArgumentException(msg))
         }
-        TokenProvider.getInstance().getToken(config.applicationContext).let {
-            if (it.isSuccess) {
-                config.attentiveApi.sendOptOutSubscriptionStatus(
-                    email,
-                    phoneNumber,
-                    config.domain,
-                    it.getOrNull()?.token,
-                )
-            }
+        val tokenResult = TokenProvider.getInstance().getToken(config.applicationContext)
+        if (tokenResult.isFailure) {
+            val msg = "Failed to fetch push token: ${tokenResult.exceptionOrNull()?.message}"
+            Timber.e(msg)
+            return Result.failure(tokenResult.exceptionOrNull() ?: Exception(msg))
         }
+        return config.attentiveApi.sendOptOutSubscriptionStatus(
+            email,
+            phoneNumber,
+            config.domain,
+            tokenResult.getOrNull()?.token,
+        )
     }
 
     private fun verifyInitialized() {

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -375,6 +375,12 @@ object AttentiveSdk {
         email: String? = null,
         phoneNumber: String? = null,
     ): Result<Unit> {
+        if (_config == null) {
+            val msg = "AttentiveSdk must be initialized before calling updateUserSuspend"
+            Timber.e(msg)
+            return Result.failure(IllegalStateException(msg))
+        }
+
         if (email.isNullOrEmpty() && phoneNumber.isNullOrEmpty()) {
             val msg = "Both email and phone number are empty or null. At least one must be provided to update the user."
             Timber.e(msg)

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -245,7 +245,10 @@ object AttentiveSdk {
             Timber.e("Invalid phone number: $phoneNumber")
         }
 
-        AttentiveEventTracker.instance.optIn(email, phoneNumber)
+        val result = AttentiveEventTracker.instance.optIn(email, phoneNumber)
+        if (result.isFailure) {
+            Timber.e("optIn failed: ${result.exceptionOrNull()?.message}")
+        }
     }
 
     suspend fun optUserOutOfMarketingSubscription(
@@ -255,7 +258,10 @@ object AttentiveSdk {
         if (phoneNumber.isNotBlank() && phoneNumber.isPhoneNumber().not()) {
             Timber.e("Invalid phone number: $phoneNumber")
         }
-        AttentiveEventTracker.instance.optOut(email, phoneNumber)
+        val result = AttentiveEventTracker.instance.optOut(email, phoneNumber)
+        if (result.isFailure) {
+            Timber.e("optOut failed: ${result.exceptionOrNull()?.message}")
+        }
     }
 
     /**
@@ -339,7 +345,10 @@ object AttentiveSdk {
 
         val domain = config.domain
         CoroutineScope(Dispatchers.IO).launch {
-            config.attentiveApi.sendUserUpdate(domain, email, number)
+            val result = config.attentiveApi.sendUserUpdate(domain, email, number)
+            if (result.isFailure) {
+                Timber.e("updateUser failed: ${result.exceptionOrNull()?.message}")
+            }
         }
     }
 

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -215,8 +215,13 @@ object AttentiveSdk {
         }
     }
 
+    @Suppress("DEPRECATION")
     fun recordEvent(event: Event) {
         AttentiveEventTracker.instance.recordEvent(event)
+    }
+
+    suspend fun recordEventSuspend(event: Event): Result<Unit> {
+        return AttentiveEventTracker.instance.recordEventSuspend(event)
     }
 
     /**
@@ -240,28 +245,27 @@ object AttentiveSdk {
     suspend fun optUserIntoMarketingSubscription(
         email: String = "",
         phoneNumber: String = "",
-    ) {
+    ): Result<Unit> {
         if (phoneNumber.isNotBlank() && phoneNumber.isPhoneNumber().not()) {
-            Timber.e("Invalid phone number: $phoneNumber")
+            val msg = "Invalid phone number: $phoneNumber"
+            Timber.e(msg)
+            return Result.failure(IllegalArgumentException(msg))
         }
 
-        val result = AttentiveEventTracker.instance.optIn(email, phoneNumber)
-        if (result.isFailure) {
-            Timber.e("optIn failed: ${result.exceptionOrNull()?.message}")
-        }
+        return AttentiveEventTracker.instance.optIn(email, phoneNumber)
     }
 
     suspend fun optUserOutOfMarketingSubscription(
         email: String = "",
         phoneNumber: String = "",
-    ) {
+    ): Result<Unit> {
         if (phoneNumber.isNotBlank() && phoneNumber.isPhoneNumber().not()) {
-            Timber.e("Invalid phone number: $phoneNumber")
+            val msg = "Invalid phone number: $phoneNumber"
+            Timber.e(msg)
+            return Result.failure(IllegalArgumentException(msg))
         }
-        val result = AttentiveEventTracker.instance.optOut(email, phoneNumber)
-        if (result.isFailure) {
-            Timber.e("optOut failed: ${result.exceptionOrNull()?.message}")
-        }
+
+        return AttentiveEventTracker.instance.optOut(email, phoneNumber)
     }
 
     /**
@@ -330,26 +334,35 @@ object AttentiveSdk {
         email: String? = null,
         phoneNumber: String? = null,
     ) {
+        CoroutineScope(Dispatchers.IO).launch {
+            val result = updateUserSuspend(email, phoneNumber)
+            if (result.isFailure) {
+                Timber.e("updateUser failed: ${result.exceptionOrNull()?.message}")
+            }
+        }
+    }
+
+    suspend fun updateUserSuspend(
+        email: String? = null,
+        phoneNumber: String? = null,
+    ): Result<Unit> {
         if (email.isNullOrEmpty() && phoneNumber.isNullOrEmpty()) {
-            Timber.e("Both email and phone number are empty or null. At least one must be provided to update the user.")
-            return
+            val msg = "Both email and phone number are empty or null. At least one must be provided to update the user."
+            Timber.e(msg)
+            return Result.failure(IllegalArgumentException(msg))
         }
 
         var number = phoneNumber
         phoneNumber?.let {
             if (it.isPhoneNumber().not()) {
-                Timber.e("Invalid phone number: $phoneNumber")
-                number = null
+                val msg = "Invalid phone number: $phoneNumber"
+                Timber.e(msg)
+                return Result.failure(IllegalArgumentException(msg))
             }
         }
 
         val domain = config.domain
-        CoroutineScope(Dispatchers.IO).launch {
-            val result = config.attentiveApi.sendUserUpdate(domain, email, number)
-            if (result.isFailure) {
-                Timber.e("updateUser failed: ${result.exceptionOrNull()?.message}")
-            }
-        }
+        return config.attentiveApi.sendUserUpdate(domain, email, number)
     }
 
     interface PushTokenCallback {

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -224,6 +224,13 @@ object AttentiveSdk {
         return AttentiveEventTracker.instance.recordEventSuspend(event)
     }
 
+    @JvmStatic
+    fun recordEventWithCallback(event: Event, callback: AttentiveCallback) {
+        CoroutineScope(Dispatchers.IO).launch {
+            dispatchResult(recordEventSuspend(event), callback)
+        }
+    }
+
     /**
      * Determines whether the given Firebase RemoteMessage is from Attentive.
      */
@@ -255,6 +262,17 @@ object AttentiveSdk {
         return AttentiveEventTracker.instance.optIn(email, phoneNumber)
     }
 
+    @JvmStatic
+    fun optUserIntoMarketingSubscriptionWithCallback(
+        email: String = "",
+        phoneNumber: String = "",
+        callback: AttentiveCallback,
+    ) {
+        CoroutineScope(Dispatchers.IO).launch {
+            dispatchResult(optUserIntoMarketingSubscription(email, phoneNumber), callback)
+        }
+    }
+
     suspend fun optUserOutOfMarketingSubscription(
         email: String = "",
         phoneNumber: String = "",
@@ -266,6 +284,17 @@ object AttentiveSdk {
         }
 
         return AttentiveEventTracker.instance.optOut(email, phoneNumber)
+    }
+
+    @JvmStatic
+    fun optUserOutOfMarketingSubscriptionWithCallback(
+        email: String = "",
+        phoneNumber: String = "",
+        callback: AttentiveCallback,
+    ) {
+        CoroutineScope(Dispatchers.IO).launch {
+            dispatchResult(optUserOutOfMarketingSubscription(email, phoneNumber), callback)
+        }
     }
 
     /**
@@ -365,10 +394,34 @@ object AttentiveSdk {
         return config.attentiveApi.sendUserUpdate(domain, email, number)
     }
 
+    @JvmStatic
+    fun updateUserWithCallback(
+        email: String? = null,
+        phoneNumber: String? = null,
+        callback: AttentiveCallback,
+    ) {
+        CoroutineScope(Dispatchers.IO).launch {
+            dispatchResult(updateUserSuspend(email, phoneNumber), callback)
+        }
+    }
+
     interface PushTokenCallback {
         fun onSuccess(result: TokenFetchResult)
 
         fun onFailure(exception: Exception)
+    }
+
+    interface AttentiveCallback {
+        fun onSuccess()
+
+        fun onFailure(exception: Exception)
+    }
+
+    private fun dispatchResult(result: Result<Unit>, callback: AttentiveCallback) {
+        result.fold(
+            onSuccess = { callback.onSuccess() },
+            onFailure = { callback.onFailure(it as? Exception ?: Exception(it)) },
+        )
     }
 
     fun isPushPermissionGranted(context: Context): Boolean {

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/RetrofitApiService.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/RetrofitApiService.kt
@@ -1,6 +1,7 @@
 package com.attentive.androidsdk.internal.network
 
 import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
@@ -53,4 +54,32 @@ interface RetrofitApiService {
     fun optOutSubscription(
         @Body request: OptOutSubscriptionRequest,
     ): Call<Unit>
+
+    @Headers(
+        "x-datadog-sampling-priority: 1",
+        "Content-Type: application/json",
+    )
+    @POST("user-update")
+    suspend fun updateUserSuspend(
+        @Body request: UserUpdateRequest,
+    ): Response<Unit>
+
+    @Headers("x-datadog-sampling-priority: 1")
+    @FormUrlEncoded
+    @POST("mobile")
+    suspend fun sendEventSuspend(
+        @Field("d") eventData: String,
+    ): Response<Unit>
+
+    @Headers("Content-Type: application/json")
+    @POST("opt-in-subscriptions")
+    suspend fun optInSubscriptionSuspend(
+        @Body request: OptInSubscriptionRequest,
+    ): Response<Unit>
+
+    @Headers("Content-Type: application/json")
+    @POST("opt-out-subscriptions")
+    suspend fun optOutSubscriptionSuspend(
+        @Body request: OptOutSubscriptionRequest,
+    ): Response<Unit>
 }

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/RecordEventCallbackTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/RecordEventCallbackTest.kt
@@ -46,13 +46,10 @@ class RecordEventCallbackTest {
     @Test
     fun oldApi_bothCallbacksInvoked_doesNotCrash() =
         runBlocking {
-            // Arrange - Create a tracker instance with our mock config
             val tracker = createTrackerWithConfig(mockConfig)
 
-            // Mock sendEvent to call BOTH onSuccess AND onFailure (buggy behavior)
             doAnswer { invocation ->
                 val callback = invocation.getArgument<AttentiveApiCallback>(3)
-                // Simulate buggy behavior: call both callbacks
                 callback.onSuccess()
                 callback.onFailure("Some error")
                 null
@@ -65,23 +62,13 @@ class RecordEventCallbackTest {
 
             val event = CustomEvent("test-event", emptyMap())
 
-            // Act - This should not throw "Already resumed" exception thanks to our fix
-            try {
-                tracker.recordEventSuspend(event)
-                // If we get here without exception, the fix worked
-                assertTrue("Expected to complete without crashing", true)
-            } catch (e: IllegalStateException) {
-                if (e.message?.contains("Already resumed") == true) {
-                    throw AssertionError("Got 'Already resumed' crash - fix didn't work!", e)
-                }
-                throw e
-            }
+            val result = tracker.recordEventSuspend(event)
+            assertTrue("First callback (success) should win", result.isSuccess)
         }
 
     @Test
-    fun oldApi_onlyFailureCalled_completesNormally() =
+    fun oldApi_onlyFailureCalled_returnsFailure() =
         runBlocking {
-            // Arrange
             val tracker = createTrackerWithConfig(mockConfig)
 
             doAnswer { invocation ->
@@ -97,17 +84,16 @@ class RecordEventCallbackTest {
 
             val event = CustomEvent("test-event", emptyMap())
 
-            // Act
-            tracker.recordEventSuspend(event)
+            val result = tracker.recordEventSuspend(event)
 
-            // Assert - completed without exception
+            assertTrue("Should return failure when callback reports error", result.isFailure)
+            assertEquals("Network error", result.exceptionOrNull()?.message)
             verify(mockApi, times(1)).sendEvent(any(), any(), any(), any())
         }
 
     @Test
-    fun oldApi_onlySuccessCalled_completesNormally() =
+    fun oldApi_onlySuccessCalled_returnsSuccess() =
         runBlocking {
-            // Arrange
             val tracker = createTrackerWithConfig(mockConfig)
 
             doAnswer { invocation ->
@@ -123,23 +109,20 @@ class RecordEventCallbackTest {
 
             val event = CustomEvent("test-event", emptyMap())
 
-            // Act
-            tracker.recordEventSuspend(event)
+            val result = tracker.recordEventSuspend(event)
 
-            // Assert - completed without exception
+            assertTrue("Should return success when callback reports success", result.isSuccess)
             verify(mockApi, times(1)).sendEvent(any(), any(), any(), any())
         }
 
     @Test
     fun oldApi_callbackInvokedMultipleTimes_onlyResumesOnce() =
         runBlocking {
-            // Arrange
             val tracker = createTrackerWithConfig(mockConfig)
             val callbackInvokeCount = AtomicInteger(0)
 
             doAnswer { invocation ->
                 val callback = invocation.getArgument<AttentiveApiCallback>(3)
-                // Try to invoke callback multiple times
                 callback.onSuccess()
                 callbackInvokeCount.incrementAndGet()
                 callback.onFailure("error 1")
@@ -156,11 +139,28 @@ class RecordEventCallbackTest {
 
             val event = CustomEvent("test-event", emptyMap())
 
-            // Act
-            tracker.recordEventSuspend(event)
+            val result = tracker.recordEventSuspend(event)
 
-            // Assert - all callbacks were called but no crash occurred
             assertEquals(3, callbackInvokeCount.get())
+            assertTrue("First callback (success) should win", result.isSuccess)
+        }
+
+    @Test
+    fun oldApi_notInitialized_returnsFailure() =
+        runBlocking {
+            val tracker =
+                AttentiveEventTracker::class.java.getDeclaredConstructor().apply {
+                    isAccessible = true
+                }.newInstance()
+
+            val event = CustomEvent("test-event", emptyMap())
+
+            val result = tracker.recordEventSuspend(event)
+
+            assertTrue("Should fail when not initialized", result.isFailure)
+            assertTrue(
+                result.exceptionOrNull() is IllegalStateException,
+            )
         }
 
     /**


### PR DESCRIPTION
## Summary

This PR standardizes error handling and async patterns across the `AttentiveSdk` public API. Previously, errors were handled inconsistently — some methods threw, some logged and returned silently, and some swallowed errors entirely. Now all async operations return `Result<T>` (the Kotlin-idiomatic choice), validation errors consistently return `Result.failure`, and every suspend function has a callback variant for Java consumers.

### Approach

**Phase 1 — Internal plumbing:** Convert `AttentiveApi` methods from fire-and-forget `Call.enqueue()` to suspend functions returning `Result<Unit>`. Propagate errors through `AttentiveEventTracker` instead of swallowing them. Also fixes a bug where `recordEvent()` on the NEW API path called `api.sendEvent()` but never executed the returned `Call` — events were silently dropped.

**Phase 2 — Public API:** Expose `Result<Unit>` on `AttentiveSdk` methods. Keep fire-and-forget overloads (`recordEvent`, `updateUser`) for backward compatibility. Standardize validation so invalid inputs always return `Result.failure(IllegalArgumentException)` instead of the previous mix of throwing, logging, or silently proceeding.

**Phase 3 — Java interop:** Add callback variants for all suspend functions using a new `AttentiveCallback` interface, following the existing `getPushTokenWithCallback` pattern.

---

## Before / After Usage Patterns

### recordEvent

**Before** — Fire-and-forget, no way to know if it succeeded:
```kotlin
// Kotlin
AttentiveSdk.recordEvent(event) // returns Unit, errors swallowed silently
```
```java
// Java
AttentiveSdk.recordEvent(event); // no error feedback
```

**After** — Choose your style:
```kotlin
// Kotlin (fire-and-forget, backward compat)
AttentiveSdk.recordEvent(event)

// Kotlin (suspend, with error handling)
val result = AttentiveSdk.recordEventSuspend(event)
result.onSuccess { Log.d("TAG", "Event sent") }
      .onFailure { Log.e("TAG", "Event failed: ${it.message}") }
```
```java
// Java (callback)
AttentiveSdk.recordEventWithCallback(event, new AttentiveSdk.AttentiveCallback() {
    @Override public void onSuccess() { /* sent */ }
    @Override public void onFailure(Exception e) { /* handle error */ }
});
```

---

### optUserIntoMarketingSubscription / optUserOutOfMarketingSubscription

**Before** — Suspend returning Unit, invalid phone logged but request still sent:
```kotlin
// Kotlin
AttentiveSdk.optUserIntoMarketingSubscription(phoneNumber = "not-a-phone")
// Timber.e logged, but request proceeds anyway. No error returned.
```
```java
// Java — not callable without coroutine boilerplate
```

**After** — Returns Result, validation fails early:
```kotlin
// Kotlin
val result = AttentiveSdk.optUserIntoMarketingSubscription(phoneNumber = "+14155551234")
if (result.isFailure) {
    // handle: invalid phone, missing token, network error, etc.
}
```
```java
// Java (callback)
AttentiveSdk.optUserIntoMarketingSubscriptionWithCallback("", "+14155551234",
    new AttentiveSdk.AttentiveCallback() {
        @Override public void onSuccess() { /* opted in */ }
        @Override public void onFailure(Exception e) { /* handle error */ }
    });
```

---

### updateUser

**Before** — Sync fire-and-forget, invalid phone silently nullified:
```kotlin
// Kotlin
AttentiveSdk.updateUser(phoneNumber = "bad-number")
// Timber.e logged, phone set to null, request sent anyway with null phone
```
```java
// Java
AttentiveSdk.updateUser(null, "bad-number");
// same silent behavior
```

**After** — Choose your style:
```kotlin
// Kotlin (fire-and-forget, backward compat)
AttentiveSdk.updateUser(email = "user@example.com")

// Kotlin (suspend, with error handling)
val result = AttentiveSdk.updateUserSuspend(phoneNumber = "bad-number")
// result.isFailure == true, IllegalArgumentException("Invalid phone number: bad-number")
```
```java
// Java (callback)
AttentiveSdk.updateUserWithCallback("user@example.com", null,
    new AttentiveSdk.AttentiveCallback() {
        @Override public void onSuccess() { /* updated */ }
        @Override public void onFailure(Exception e) { /* handle error */ }
    });
```

---

### Error handling summary

| Scenario | Before | After |
|---|---|---|
| Invalid phone number | Logged, request proceeds or phone silently nullified | `Result.failure(IllegalArgumentException)` |
| Network failure | Swallowed in callback/catch | `Result.failure(e)` propagated to caller |
| SDK not initialized | Throws `IllegalStateException` (some paths) or logs (others) | `Result.failure(IllegalStateException)` consistently |
| Missing visitorId/token | Logged and returned silently | `Result.failure(IllegalStateException)` |
| Coroutine cancellation | Caught and wrapped as failure | Re-thrown to preserve structured concurrency |

---

## Test plan
- [x] All existing unit tests pass
- [x] Updated `RecordEventCallbackTest` to assert `Result.isSuccess`/`Result.isFailure` instead of just "didn't crash"
- [x] Added test for uninitialized tracker returning `Result.failure`
- [x] SDK and Bonni app compile cleanly
- [ ] Manual verification: trigger events, opt-in/out, and update user in Bonni app — confirm operations succeed and errors surface in Logcat

🤖 Generated with [Claude Code](https://claude.com/claude-code)