### PR TITLE
MSDK-184: Add regex validation for phone and email

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -9,6 +9,7 @@ import com.attentive.androidsdk.inbox.InboxState
 import com.attentive.androidsdk.inbox.Message
 import com.attentive.androidsdk.inbox.Style
 import com.attentive.androidsdk.internal.util.Constants
+import com.attentive.androidsdk.internal.util.isEmail
 import com.attentive.androidsdk.internal.util.isPhoneNumber
 import com.attentive.androidsdk.push.AttentivePush
 import com.attentive.androidsdk.push.TokenFetchResult
@@ -244,6 +245,9 @@ object AttentiveSdk {
         if (phoneNumber.isNotBlank() && phoneNumber.isPhoneNumber().not()) {
             Timber.e("Invalid phone number: $phoneNumber")
         }
+        if (email.isNotBlank() && email.isEmail().not()) {
+            Timber.e("Invalid email: $email")
+        }
 
         AttentiveEventTracker.instance.optIn(email, phoneNumber)
     }
@@ -254,6 +258,9 @@ object AttentiveSdk {
     ) {
         if (phoneNumber.isNotBlank() && phoneNumber.isPhoneNumber().not()) {
             Timber.e("Invalid phone number: $phoneNumber")
+        }
+        if (email.isNotBlank() && email.isEmail().not()) {
+            Timber.e("Invalid email: $email")
         }
         AttentiveEventTracker.instance.optOut(email, phoneNumber)
     }
@@ -337,9 +344,22 @@ object AttentiveSdk {
             }
         }
 
+        var validatedEmail = email
+        email?.let {
+            if (it.isNotEmpty() && it.isEmail().not()) {
+                Timber.e("Invalid email: $email")
+                validatedEmail = null
+            }
+        }
+
+        if (validatedEmail.isNullOrEmpty() && number.isNullOrEmpty()) {
+            Timber.e("No valid email or phone number provided after validation.")
+            return
+        }
+
         val domain = config.domain
         CoroutineScope(Dispatchers.IO).launch {
-            config.attentiveApi.sendUserUpdate(domain, email, number)
+            config.attentiveApi.sendUserUpdate(domain, validatedEmail, number)
         }
     }
 

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/util/AttentiveUtils.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/util/AttentiveUtils.kt
@@ -2,16 +2,35 @@ package com.attentive.androidsdk.internal.util
 
 object AttentiveUtils {
     var phoneValidator: PhoneValidator = DefaultPhoneValidator()
+    var emailValidator: EmailValidator = DefaultEmailValidator()
 }
 
 interface PhoneValidator {
     fun isPhoneNumber(phone: String): Boolean
 }
 
+interface EmailValidator {
+    fun isEmail(email: String): Boolean
+}
+
 class DefaultPhoneValidator : PhoneValidator {
+    private val e164Regex = Regex("""^\+[1-9]\d{1,14}$""")
+
     override fun isPhoneNumber(phone: String): Boolean {
-        return android.telephony.PhoneNumberUtils.isGlobalPhoneNumber(phone)
+        return e164Regex.matches(phone)
+    }
+}
+
+class DefaultEmailValidator : EmailValidator {
+    private val emailRegex = Regex(
+        """^(?!\.)(?!.*\.\.)([a-zA-Z0-9_'+\-.]*)[a-zA-Z0-9_'+\-]@([a-zA-Z0-9][a-zA-Z0-9\-]*\.)+[a-zA-Z]{2,}$""",
+    )
+
+    override fun isEmail(email: String): Boolean {
+        return emailRegex.matches(email)
     }
 }
 
 fun String.isPhoneNumber(): Boolean = AttentiveUtils.phoneValidator.isPhoneNumber(this)
+
+fun String.isEmail(): Boolean = AttentiveUtils.emailValidator.isEmail(this)

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/util/AttentiveUtils.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/util/AttentiveUtils.kt
@@ -23,7 +23,7 @@ class DefaultPhoneValidator : PhoneValidator {
 
 class DefaultEmailValidator : EmailValidator {
     private val emailRegex = Regex(
-        """^(?!\.)(?!.*\.\.)([a-zA-Z0-9_'+\-.]*)[a-zA-Z0-9_'+\-]@([a-zA-Z0-9][a-zA-Z0-9\-]*\.)+[a-zA-Z]{2,}$""",
+        """^(?!\.)(?!.*\.\.)([a-zA-Z0-9_'+\-.]*)[a-zA-Z0-9_'+\-]@([a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$""",
     )
 
     override fun isEmail(email: String): Boolean {

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/internal/util/ValidationRegexTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/internal/util/ValidationRegexTest.kt
@@ -132,6 +132,23 @@ class ValidationRegexTest {
     }
 
     @Test
+    fun email_domainLabelEndingWithHyphen_returnsFalse() {
+        assertFalse(emailValidator.isEmail("user@example-.com"))
+        assertFalse(emailValidator.isEmail("user@e-.co"))
+    }
+
+    @Test
+    fun email_domainLabelWithInternalHyphen_returnsTrue() {
+        assertTrue(emailValidator.isEmail("user@my-domain.com"))
+        assertTrue(emailValidator.isEmail("user@sub-domain.example.com"))
+    }
+
+    @Test
+    fun email_singleCharDomainLabel_returnsTrue() {
+        assertTrue(emailValidator.isEmail("user@a.com"))
+    }
+
+    @Test
     fun email_spacesInEmail_returnsFalse() {
         assertFalse(emailValidator.isEmail("user @example.com"))
         assertFalse(emailValidator.isEmail("user@ example.com"))

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/internal/util/ValidationRegexTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/internal/util/ValidationRegexTest.kt
@@ -1,0 +1,153 @@
+package com.attentive.androidsdk.internal.util
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ValidationRegexTest {
+    private val phoneValidator = DefaultPhoneValidator()
+    private val emailValidator = DefaultEmailValidator()
+
+    // Phone number validation - E.164 format
+
+    @Test
+    fun phone_validE164_returnsTrue() {
+        assertTrue(phoneValidator.isPhoneNumber("+14155552671"))
+        assertTrue(phoneValidator.isPhoneNumber("+442071234567"))
+        assertTrue(phoneValidator.isPhoneNumber("+61291234567"))
+        assertTrue(phoneValidator.isPhoneNumber("+8613800138000"))
+        assertTrue(phoneValidator.isPhoneNumber("+12"))
+        assertTrue(phoneValidator.isPhoneNumber("+123456789012345"))
+    }
+
+    @Test
+    fun phone_missingPlusPrefix_returnsFalse() {
+        assertFalse(phoneValidator.isPhoneNumber("14155552671"))
+        assertFalse(phoneValidator.isPhoneNumber("4155552671"))
+    }
+
+    @Test
+    fun phone_startsWithZero_returnsFalse() {
+        assertFalse(phoneValidator.isPhoneNumber("+0155552671"))
+    }
+
+    @Test
+    fun phone_tooLong_returnsFalse() {
+        assertFalse(phoneValidator.isPhoneNumber("+1234567890123456"))
+    }
+
+    @Test
+    fun phone_empty_returnsFalse() {
+        assertFalse(phoneValidator.isPhoneNumber(""))
+    }
+
+    @Test
+    fun phone_containsLetters_returnsFalse() {
+        assertFalse(phoneValidator.isPhoneNumber("+1415555abc1"))
+    }
+
+    @Test
+    fun phone_containsSpaces_returnsFalse() {
+        assertFalse(phoneValidator.isPhoneNumber("+1 415 555 2671"))
+    }
+
+    @Test
+    fun phone_containsDashes_returnsFalse() {
+        assertFalse(phoneValidator.isPhoneNumber("+1-415-555-2671"))
+    }
+
+    @Test
+    fun phone_containsParentheses_returnsFalse() {
+        assertFalse(phoneValidator.isPhoneNumber("+1(415)5552671"))
+    }
+
+    @Test
+    fun phone_emailInPhoneField_returnsFalse() {
+        assertFalse(phoneValidator.isPhoneNumber("user@example.com"))
+    }
+
+    // Email validation
+
+    @Test
+    fun email_validStandard_returnsTrue() {
+        assertTrue(emailValidator.isEmail("user@example.com"))
+        assertTrue(emailValidator.isEmail("test.user@example.com"))
+        assertTrue(emailValidator.isEmail("test+tag@example.com"))
+        assertTrue(emailValidator.isEmail("user@sub.domain.com"))
+        assertTrue(emailValidator.isEmail("user@example.co.uk"))
+        assertTrue(emailValidator.isEmail("user123@example.com"))
+        assertTrue(emailValidator.isEmail("first-last@example.com"))
+        assertTrue(emailValidator.isEmail("user_name@example.com"))
+        assertTrue(emailValidator.isEmail("user'tag@example.com"))
+    }
+
+    @Test
+    fun email_validMinimal_returnsTrue() {
+        assertTrue(emailValidator.isEmail("a@b.co"))
+    }
+
+    @Test
+    fun email_missingAt_returnsFalse() {
+        assertFalse(emailValidator.isEmail("userexample.com"))
+    }
+
+    @Test
+    fun email_missingDomain_returnsFalse() {
+        assertFalse(emailValidator.isEmail("user@"))
+    }
+
+    @Test
+    fun email_missingLocal_returnsFalse() {
+        assertFalse(emailValidator.isEmail("@example.com"))
+    }
+
+    @Test
+    fun email_missingTld_returnsFalse() {
+        assertFalse(emailValidator.isEmail("user@example"))
+    }
+
+    @Test
+    fun email_singleCharTld_returnsFalse() {
+        assertFalse(emailValidator.isEmail("user@example.c"))
+    }
+
+    @Test
+    fun email_leadingDot_returnsFalse() {
+        assertFalse(emailValidator.isEmail(".user@example.com"))
+    }
+
+    @Test
+    fun email_consecutiveDots_returnsFalse() {
+        assertFalse(emailValidator.isEmail("user..name@example.com"))
+    }
+
+    @Test
+    fun email_empty_returnsFalse() {
+        assertFalse(emailValidator.isEmail(""))
+    }
+
+    @Test
+    fun email_phoneInEmailField_returnsFalse() {
+        assertFalse(emailValidator.isEmail("+14155552671"))
+    }
+
+    @Test
+    fun email_spacesInEmail_returnsFalse() {
+        assertFalse(emailValidator.isEmail("user @example.com"))
+        assertFalse(emailValidator.isEmail("user@ example.com"))
+    }
+
+    // Extension function tests
+
+    @Test
+    fun extensionFunction_isPhoneNumber_works() {
+        assertTrue("+14155552671".isPhoneNumber())
+        assertFalse("not-a-phone".isPhoneNumber())
+    }
+
+    @Test
+    fun extensionFunction_isEmail_works() {
+        assertTrue("user@example.com".isEmail())
+        assertFalse("not-an-email".isEmail())
+    }
+}


### PR DESCRIPTION
## Summary

[MSDK-184](https://attentivemobile.atlassian.net/browse/MSDK-184)
- Replace `PhoneNumberUtils.isGlobalPhoneNumber()` with strict E.164 regex (`^\+[1-9]\d{1,14}$`) for phone number validation
- Add email validation using the [Zod-recommended regex](https://colinhacks.com/essays/reasonable-email-regex) as referenced in the ticket
- Add email validation checks to `optUserIntoMarketingSubscription()`, `optUserOutOfMarketingSubscription()`, and `updateUser()`
- Both validators are pluggable via `PhoneValidator`/`EmailValidator` interfaces for testability
- 24 unit tests covering valid/invalid cases for both phone and email

## Phone regex (E.164)
```
^\+[1-9]\d{1,14}$
```
Requires `+` prefix, country code starting with 1-9, and total of 2-15 digits.

## Email regex
```
^(?!\.)(?!.*\.\.)([a-zA-Z0-9_'+\-.]*)[a-zA-Z0-9_'+\-]@([a-zA-Z0-9][a-zA-Z0-9\-]*\.)+[a-zA-Z]{2,}$
```
Rejects leading dots, consecutive dots, missing TLD, and other common invalid patterns while accepting real-world email formats.

## Test plan
- [x] 24 unit tests pass for phone and email validation
- [x] Full SDK test suite passes
- [x] Bonni app compiles successfully
- [ ] Verify on iOS SDK that same regex patterns are adopted for cross-platform consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-184]: https://attentivemobile.atlassian.net/browse/MSDK-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ