### PR TITLE
MSDK-338: Wire inbox to mock server via manifest meta-data

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -3,11 +3,13 @@ package com.attentive.androidsdk
 import android.annotation.SuppressLint
 import android.app.Application
 import android.content.Context
+import android.content.pm.PackageManager
 import com.attentive.androidsdk.AttentiveSdk.getPushToken
 import com.attentive.androidsdk.events.Event
 import com.attentive.androidsdk.inbox.InboxState
 import com.attentive.androidsdk.inbox.Message
 import com.attentive.androidsdk.inbox.Style
+import com.attentive.androidsdk.internal.network.RetrofitInboxApiService
 import com.attentive.androidsdk.internal.util.Constants
 import com.attentive.androidsdk.internal.util.isEmail
 import com.attentive.androidsdk.internal.util.isPhoneNumber
@@ -23,7 +25,10 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import okhttp3.OkHttpClient
 import org.jetbrains.annotations.VisibleForTesting
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
 import timber.log.Timber
 
 object AttentiveSdk {
@@ -49,26 +54,68 @@ object AttentiveSdk {
      */
     val inboxState: StateFlow<InboxState> = _inboxState.asStateFlow()
 
+    // Inbox server API (created from manifest meta-data if present)
+    private var inboxApi: RetrofitInboxApiService? = null
+
+    private const val INBOX_BASE_URL_META_KEY = "com.attentive.sdk.INBOX_BASE_URL"
+
     // Pagination management
     private val paginationLock = Mutex()
     private const val INBOX_PAGE_SIZE = 20
 
     /**
-     * Initializes the inbox with mock messages for local testing.
-     * Starts with original 4 messages, then generates 16 more for a total of 20 (first page).
-     * TODO: Remove this function once the backend API is ready.
+     * Initializes the inbox by fetching the first page from the server if configured,
+     * otherwise falls back to mock data.
      */
     @SuppressLint("DefaultLocale")
     @VisibleForTesting
-    internal fun initializeMockInbox() {
-        // Original 4 messages
+    internal fun initializeInbox() {
+        val context = config.applicationContext
+        val appInfo = context.packageManager.getApplicationInfo(
+            context.packageName, PackageManager.GET_META_DATA,
+        )
+        val inboxBaseUrl = appInfo.metaData?.getString(INBOX_BASE_URL_META_KEY)
+        if (inboxBaseUrl != null) {
+            inboxApi = Retrofit.Builder()
+                .baseUrl(inboxBaseUrl)
+                .client(OkHttpClient())
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+                .create(RetrofitInboxApiService::class.java)
+            Timber.d("Inbox API configured with base URL: $inboxBaseUrl")
+        }
+
+        val inboxApi = this.inboxApi
+        if (inboxApi != null) {
+            CoroutineScope(Dispatchers.IO).launch {
+                try {
+                    val response = inboxApi.getMessages(0, INBOX_PAGE_SIZE)
+                    _inboxState.value = InboxState(
+                        messages = response.messages,
+                        unreadCount = response.unreadCount,
+                        currentOffset = response.messages.size,
+                        hasMoreMessages = response.hasMoreMessages,
+                    )
+                    Timber.d("Initialized inbox from server with ${response.messages.size} messages")
+                } catch (e: Exception) {
+                    Timber.e(e, "Failed to fetch inbox from server, falling back to mock data")
+                    initializeMockInbox()
+                }
+            }
+        } else {
+            initializeMockInbox()
+        }
+    }
+
+    @SuppressLint("DefaultLocale")
+    private fun initializeMockInbox() {
         val originalMessages =
             listOf(
                 Message(
                     id = "msg_001",
                     title = "Welcome to Attentive!",
                     body = "Thanks for joining us. Check out our latest offers.",
-                    timestamp = System.currentTimeMillis() - 86400000, // 1 day ago
+                    timestamp = System.currentTimeMillis() - 86400000,
                     isRead = false,
                     actionUrl = "https://example.com/offers",
                     style = Style.Small,
@@ -77,7 +124,7 @@ object AttentiveSdk {
                     id = "msg_002",
                     title = "New Sale Alert",
                     body = "50% off on all items this weekend!",
-                    timestamp = System.currentTimeMillis() - 172800000, // 2 days ago
+                    timestamp = System.currentTimeMillis() - 172800000,
                     isRead = true,
                     imageUrl = "https://as1.ftcdn.net/v2/jpg/03/98/30/92/1000_F_398309275_84cKyqzV2RLTbYmBtt0dzpZkEvqapPZo.jpg",
                     actionUrl = "https://example.com/sale",
@@ -87,7 +134,7 @@ object AttentiveSdk {
                     id = "msg_003",
                     title = "Your Order Has Shipped",
                     body = "Your order #12345 is on its way!",
-                    timestamp = System.currentTimeMillis() - 259200000, // 3 days ago
+                    timestamp = System.currentTimeMillis() - 259200000,
                     isRead = false,
                     actionUrl = "https://shippingeasy.com/wp-content/uploads/2021/04/Easy_Graphics_USPS-Priority-Mail-Blog-01.png",
                     imageUrl = "https://shippingeasy.com/wp-content/uploads/2021/04/Easy_Graphics_USPS-Priority-Mail-Blog-01.png",
@@ -97,17 +144,16 @@ object AttentiveSdk {
                     id = "msg_004",
                     title = "Your cart is waiting",
                     body = "Pickup where you left off!",
-                    timestamp = System.currentTimeMillis() - 259200000, // 3 days ago
+                    timestamp = System.currentTimeMillis() - 259200000,
                     isRead = false,
                     actionUrl = "bonni://cart",
                     style = Style.Small,
                 ),
             )
 
-        // Generate 16 additional messages to complete the first page (total 20)
         val generatedMessages =
             List(16) { index ->
-                val messageNumber = index + 5 // Start from 5 since we have 4 original
+                val messageNumber = index + 5
                 Message(
                     id = "msg_${String.format("%03d", messageNumber)}",
                     title = "Message $messageNumber",
@@ -125,8 +171,8 @@ object AttentiveSdk {
             InboxState(
                 messages = mockMessages,
                 unreadCount = mockMessages.count { !it.isRead },
-                currentOffset = mockMessages.size, // Start offset = 20
-                hasMoreMessages = true, // More messages available to load
+                currentOffset = mockMessages.size,
+                hasMoreMessages = true,
             )
 
         Timber.d("Initialized inbox with ${mockMessages.size} mock messages (4 original + 16 generated)")
@@ -135,13 +181,12 @@ object AttentiveSdk {
     /**
      * Loads more inbox messages (pagination).
      * Call this when the user scrolls near the end of the message list.
-     * This function uses mock data until the backend API is ready.
+     * Uses the server API when configured, otherwise falls back to mock data.
      */
     suspend fun loadMoreInboxMessages() {
         paginationLock.withLock {
             val currentState = _inboxState.value
 
-            // Guard: already loading or no more messages
             if (currentState.isLoadingMore || !currentState.hasMoreMessages) {
                 Timber.d(
                     "Skipping loadMoreInboxMessages - isLoadingMore: ${currentState.isLoadingMore}, hasMoreMessages: ${currentState.hasMoreMessages}",
@@ -153,47 +198,53 @@ object AttentiveSdk {
             _inboxState.value = currentState.copy(isLoadingMore = true)
 
             try {
-                // Capture offset before suspending - this determines which page to fetch
                 val offsetToFetch = currentState.currentOffset
+                val inboxApi = inboxApi
 
-                // Simulate network delay
-                delay(5000)
+                if (inboxApi != null) {
+                    val response = inboxApi.getMessages(offsetToFetch, INBOX_PAGE_SIZE)
+                    val latestState = _inboxState.value
+                    val updatedMessages = latestState.messages + response.messages
 
-                // Generate mock messages based on the offset we requested
-                val mockMessages =
-                    List(INBOX_PAGE_SIZE) { index ->
-                        Message(
-                            id = "msg_${offsetToFetch + index}",
-                            title = "Message ${offsetToFetch + index + 1}",
-                            body = "This is the content of message number ${offsetToFetch + index + 1}",
-                            timestamp = System.currentTimeMillis() - (offsetToFetch + index) * 3600000L,
-                            isRead = (offsetToFetch + index) % 3 == 0,
-                            imageUrl = if ((offsetToFetch + index) % 5 == 0) "https://picsum.photos/200/300?random=${offsetToFetch + index}" else null,
-                            style = if ((offsetToFetch + index) % 5 == 0) Style.Large else Style.Small,
-                        )
-                    }
+                    _inboxState.value = InboxState(
+                        messages = updatedMessages,
+                        unreadCount = response.unreadCount,
+                        isLoadingMore = false,
+                        hasMoreMessages = response.hasMoreMessages,
+                        currentOffset = offsetToFetch + response.messages.size,
+                    )
+                    Timber.d("Loaded ${response.messages.size} more messages from server. Total: ${updatedMessages.size}")
+                } else {
+                    delay(5000)
 
-                // Merge with the CURRENT state to preserve
-                // any changes to the made during the network call
-                // like deletions
-                val latestState = _inboxState.value
-                val updatedMessages = latestState.messages + mockMessages
-                val totalMockMessages = 100 // Mock total
-                // todo hasMore pagination value should come from backend
-                val hasMore = updatedMessages.size < totalMockMessages
+                    val mockMessages =
+                        List(INBOX_PAGE_SIZE) { index ->
+                            Message(
+                                id = "msg_${offsetToFetch + index}",
+                                title = "Message ${offsetToFetch + index + 1}",
+                                body = "This is the content of message number ${offsetToFetch + index + 1}",
+                                timestamp = System.currentTimeMillis() - (offsetToFetch + index) * 3600000L,
+                                isRead = (offsetToFetch + index) % 3 == 0,
+                                imageUrl = if ((offsetToFetch + index) % 5 == 0) "https://picsum.photos/200/300?random=${offsetToFetch + index}" else null,
+                                style = if ((offsetToFetch + index) % 5 == 0) Style.Large else Style.Small,
+                            )
+                        }
 
-                _inboxState.value =
-                    InboxState(
+                    val latestState = _inboxState.value
+                    val updatedMessages = latestState.messages + mockMessages
+                    val totalMockMessages = 100
+                    val hasMore = updatedMessages.size < totalMockMessages
+
+                    _inboxState.value = InboxState(
                         messages = updatedMessages,
                         unreadCount = updatedMessages.count { !it.isRead },
                         isLoadingMore = false,
                         hasMoreMessages = hasMore,
                         currentOffset = offsetToFetch + mockMessages.size,
                     )
-
-                Timber.d("Loaded ${mockMessages.size} more messages. Total: ${updatedMessages.size}, hasMore: $hasMore")
+                    Timber.d("Loaded ${mockMessages.size} more mock messages. Total: ${updatedMessages.size}, hasMore: $hasMore")
+                }
             } finally {
-                // Clear isLoadingMore when loading fails via cancellation or exception
                 if (_inboxState.value.isLoadingMore) {
                     _inboxState.value = _inboxState.value.copy(isLoadingMore = false)
                 }
@@ -212,7 +263,7 @@ object AttentiveSdk {
         synchronized(AttentiveSdk::class.java) {
             this._config = config
             AttentiveEventTracker.instance.initializeInternal(config)
-            initializeMockInbox()
+            initializeInbox()
         }
     }
 
@@ -519,6 +570,12 @@ object AttentiveSdk {
                 unreadCount = updatedMessages.count { !it.isRead },
             )
         Timber.d("Message $messageId marked as read")
+        inboxApi?.also { api ->
+            CoroutineScope(Dispatchers.IO).launch {
+                try { api.updateMessage(messageId, mapOf("isRead" to true)) }
+                catch (e: Exception) { Timber.e(e, "Failed to sync markRead to server") }
+            }
+        }
     }
 
     /**
@@ -543,6 +600,12 @@ object AttentiveSdk {
                 unreadCount = updatedMessages.count { !it.isRead },
             )
         Timber.d("Message $messageId marked as unread")
+        inboxApi?.also { api ->
+            CoroutineScope(Dispatchers.IO).launch {
+                try { api.updateMessage(messageId, mapOf("isRead" to false)) }
+                catch (e: Exception) { Timber.e(e, "Failed to sync markUnread to server") }
+            }
+        }
     }
 
     /**
@@ -563,5 +626,12 @@ object AttentiveSdk {
                 unreadCount = updatedMessages.count { !it.isRead },
             )
         Timber.d("Message $messageId deleted from inbox")
+        val inboxApi = inboxApi
+        if (inboxApi != null) {
+            CoroutineScope(Dispatchers.IO).launch {
+                try { inboxApi.deleteMessage(messageId) }
+                catch (e: Exception) { Timber.e(e, "Failed to sync deleteMessage to server") }
+            }
+        }
     }
 }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/InboxResponse.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/InboxResponse.kt
@@ -1,0 +1,10 @@
+package com.attentive.androidsdk.internal.network
+
+import com.attentive.androidsdk.inbox.Message
+
+internal data class InboxResponse(
+    val messages: List<Message>,
+    val unreadCount: Int,
+    val hasMoreMessages: Boolean,
+    val nextOffset: Int?,
+)

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/RetrofitInboxApiService.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/RetrofitInboxApiService.kt
@@ -1,0 +1,28 @@
+package com.attentive.androidsdk.internal.network
+
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+internal interface RetrofitInboxApiService {
+    @GET("inbox/messages")
+    suspend fun getMessages(
+        @Query("offset") offset: Int,
+        @Query("limit") limit: Int,
+    ): InboxResponse
+
+    @PATCH("inbox/messages/{id}")
+    suspend fun updateMessage(
+        @Path("id") id: String,
+        @Body body: Map<String, Boolean>,
+    ): Response<Unit>
+
+    @DELETE("inbox/messages/{id}")
+    suspend fun deleteMessage(
+        @Path("id") id: String,
+    ): Response<Unit>
+}

--- a/bonni/src/main/AndroidManifest.xml
+++ b/bonni/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <application
         android:name=".BonniApp"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:allowBackup="false"
         android:fullBackupContent="false"
         android:icon="@mipmap/ic_launcher"
@@ -26,5 +27,9 @@
                 <data android:scheme="bonni" android:host="cart" />
             </intent-filter>
         </activity>
+
+        <meta-data
+            android:name="com.attentive.sdk.INBOX_BASE_URL"
+            android:value="http://10.0.2.2:3000/" />
     </application>
 </manifest>

--- a/bonni/src/main/res/xml/network_security_config.xml
+++ b/bonni/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">10.0.2.2</domain>
+        <domain includeSubdomains="false">localhost</domain>
+    </domain-config>
+</network-security-config>

--- a/tools/mock-server/.gitignore
+++ b/tools/mock-server/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tools/mock-server/README.md
+++ b/tools/mock-server/README.md
@@ -1,0 +1,172 @@
+# Attentive Inbox Mock Server
+
+A local Express server that simulates the Attentive inbox API for SDK development and testing. Includes a browser dashboard for managing messages and simulating network conditions.
+
+## Quick Start
+
+```bash
+npm install
+npm start
+```
+
+The server starts on port 3000 (configurable via `PORT` env var).
+
+```bash
+PORT=8080 npm start          # custom port
+DELAY=2000 npm start         # start with 2s response delay
+```
+
+## Accessing the Server
+
+| Context | URL |
+|---------|-----|
+| Browser dashboard | http://localhost:3000 |
+| Android emulator | http://10.0.2.2:3000 |
+| iOS simulator | http://localhost:3000 |
+| Physical device (Android/iOS) | http://<your-local-ip>:3000 |
+
+The startup log prints the correct URLs for your machine.
+
+**Platform notes:**
+- **Android emulator** uses `10.0.2.2` to reach the host machine's localhost.
+- **iOS simulator** shares the host's network stack, so `localhost` works directly.
+- **Physical devices** (both platforms) must be on the same Wi-Fi network as your machine. Use your machine's local IP (printed at startup).
+
+## API Endpoints
+
+### GET /inbox/messages
+
+Fetch paginated messages.
+
+**Query Parameters:**
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| offset | int | 0 | Number of messages to skip |
+| limit | int | 20 | Max messages to return |
+
+**Response:**
+```json
+{
+  "messages": [
+    {
+      "id": "msg_001",
+      "title": "Welcome to Attentive!",
+      "body": "Thanks for joining us. Check out our latest offers.",
+      "timestamp": 1714800000000,
+      "isRead": false,
+      "imageUrl": "https://picsum.photos/seed/inbox1/400/300",
+      "actionUrl": "https://example.com/offer/1",
+      "style": "Small"
+    }
+  ],
+  "unreadCount": 75,
+  "hasMoreMessages": true,
+  "nextOffset": 20
+}
+```
+
+### POST /inbox/messages
+
+Add a new message.
+
+**Request Body:**
+```json
+{
+  "title": "Sale Alert",
+  "body": "50% off everything!",
+  "imageUrl": "https://example.com/image.jpg",
+  "actionUrl": "https://example.com/sale",
+  "style": "Small"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| title | string | no | Message title (default: "New Message") |
+| body | string | no | Message body (default: "") |
+| imageUrl | string | no | Image URL |
+| actionUrl | string | no | Tap action URL |
+| style | string | no | "Small" or "Large" (default: "Small") |
+
+**Response:** `201` with the created message object.
+
+### PATCH /inbox/messages/:id
+
+Update a message's read status.
+
+**Request Body:**
+```json
+{
+  "isRead": true
+}
+```
+
+**Response:** `204` No Content
+
+### DELETE /inbox/messages/:id
+
+Soft-delete a message.
+
+**Response:** `204` No Content
+
+### POST /inbox/messages/reset
+
+Reset inbox to 100 freshly generated messages.
+
+**Response:**
+```json
+{
+  "message": "Inbox reset",
+  "count": 100
+}
+```
+
+### GET /settings
+
+Get current server settings.
+
+**Response:**
+```json
+{
+  "delayMs": 0
+}
+```
+
+### POST /settings
+
+Update server settings (e.g., simulate network delay).
+
+**Request Body:**
+```json
+{
+  "delayMs": 3000
+}
+```
+
+**Response:**
+```json
+{
+  "delayMs": 3000
+}
+```
+
+## Network Delay Simulation
+
+You can simulate slow network conditions to test loading states:
+
+1. **At startup:** `DELAY=3000 npm start`
+2. **At runtime via API:** `curl -X POST localhost:3000/settings -H 'Content-Type: application/json' -d '{"delayMs": 3000}'`
+3. **Via the dashboard:** Use the "Delay" dropdown in the top-right of the actions bar.
+
+The delay applies to all `/inbox` routes.
+
+## Dashboard
+
+Open http://localhost:3000 in a browser to:
+
+- View all messages with read/unread status
+- Add new messages
+- Mark messages as read/unread
+- Delete messages
+- Reset the inbox
+- Adjust network delay

--- a/tools/mock-server/package-lock.json
+++ b/tools/mock-server/package-lock.json
@@ -1,0 +1,842 @@
+{
+  "name": "attentive-inbox-mock-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "attentive-inbox-mock-server",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/tools/mock-server/package.json
+++ b/tools/mock-server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "attentive-inbox-mock-server",
+  "version": "1.0.0",
+  "description": "Mock backend for Attentive SDK inbox feature",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.21.0"
+  }
+}

--- a/tools/mock-server/public/index.html
+++ b/tools/mock-server/public/index.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Attentive Inbox Mock Server</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f5f5; color: #333; }
+    header { background: #1a1a2e; color: white; padding: 20px 24px; display: flex; justify-content: space-between; align-items: center; }
+    header h1 { font-size: 20px; font-weight: 600; }
+    .stats { display: flex; gap: 16px; font-size: 14px; }
+    .stat { background: rgba(255,255,255,0.1); padding: 6px 12px; border-radius: 6px; }
+    .container { max-width: 900px; margin: 0 auto; padding: 20px; }
+    .actions { display: flex; gap: 10px; margin-bottom: 20px; flex-wrap: wrap; }
+    button { padding: 8px 16px; border: none; border-radius: 6px; cursor: pointer; font-size: 14px; font-weight: 500; transition: opacity 0.2s; }
+    button:hover { opacity: 0.85; }
+    .btn-primary { background: #4361ee; color: white; }
+    .btn-danger { background: #e63946; color: white; }
+    .btn-secondary { background: #ddd; color: #333; }
+    .btn-small { padding: 4px 10px; font-size: 12px; }
+    .message-list { display: flex; flex-direction: column; gap: 8px; }
+    .message { background: white; border-radius: 8px; padding: 14px 16px; display: flex; gap: 14px; align-items: flex-start; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+    .message.unread { border-left: 4px solid #4361ee; }
+    .message.read { border-left: 4px solid transparent; opacity: 0.7; }
+    .message.deleted { border-left: 4px solid #e63946; opacity: 0.4; text-decoration: line-through; }
+    .message img { width: 60px; height: 60px; object-fit: cover; border-radius: 6px; flex-shrink: 0; }
+    .message-content { flex: 1; min-width: 0; }
+    .message-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px; }
+    .message-title { font-weight: 600; font-size: 14px; }
+    .message-meta { font-size: 12px; color: #888; display: flex; gap: 8px; align-items: center; }
+    .message-body { font-size: 13px; color: #666; margin-top: 2px; }
+    .message-actions { display: flex; gap: 6px; margin-top: 8px; }
+    .badge { font-size: 10px; padding: 2px 6px; border-radius: 4px; font-weight: 600; text-transform: uppercase; }
+    .badge-style { background: #e8f4f8; color: #1a759f; }
+    .badge-unread { background: #eef0ff; color: #4361ee; }
+    .modal-overlay { display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100; justify-content: center; align-items: center; }
+    .modal-overlay.active { display: flex; }
+    .modal { background: white; border-radius: 12px; padding: 24px; width: 90%; max-width: 500px; }
+    .modal h2 { margin-bottom: 16px; font-size: 18px; }
+    .modal label { display: block; margin-bottom: 4px; font-size: 13px; font-weight: 500; color: #555; }
+    .modal input, .modal textarea, .modal select { width: 100%; padding: 8px 10px; border: 1px solid #ddd; border-radius: 6px; font-size: 14px; margin-bottom: 12px; }
+    .modal textarea { resize: vertical; min-height: 60px; }
+    .modal-actions { display: flex; gap: 10px; justify-content: flex-end; margin-top: 8px; }
+    .empty { text-align: center; padding: 40px; color: #999; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Attentive Inbox Mock Server</h1>
+    <div class="stats">
+      <div class="stat" id="totalStat">Total: —</div>
+      <div class="stat" id="unreadStat">Unread: —</div>
+    </div>
+  </header>
+
+  <div class="container">
+    <div class="actions">
+      <button class="btn-primary" onclick="openAddModal()">+ Add Message</button>
+      <button class="btn-danger" onclick="resetInbox()">Reset Inbox</button>
+      <button class="btn-secondary" onclick="loadMessages()">Refresh</button>
+      <span style="margin-left:auto; display:flex; align-items:center; gap:6px; font-size:13px; color:#555;">
+        Delay:
+        <select id="delaySelect" onchange="setDelay(this.value)" style="padding:4px 8px; border-radius:6px; border:1px solid #ddd; font-size:13px;">
+          <option value="0">None</option>
+          <option value="500">500ms</option>
+          <option value="1000">1s</option>
+          <option value="2000">2s</option>
+          <option value="3000">3s</option>
+          <option value="5000">5s</option>
+          <option value="10000">10s</option>
+        </select>
+      </span>
+    </div>
+    <div class="message-list" id="messageList"></div>
+  </div>
+
+  <div class="modal-overlay" id="addModal">
+    <div class="modal">
+      <h2>Add Message</h2>
+      <label>Title</label>
+      <input type="text" id="msgTitle" placeholder="Message title">
+      <label>Body</label>
+      <textarea id="msgBody" placeholder="Message body"></textarea>
+      <label>Image URL (optional)</label>
+      <input type="text" id="msgImage" placeholder="https://...">
+      <label>Action URL (optional)</label>
+      <input type="text" id="msgAction" placeholder="https://...">
+      <label>Style</label>
+      <select id="msgStyle">
+        <option value="small">Small</option>
+        <option value="large">Large</option>
+      </select>
+      <div class="modal-actions">
+        <button class="btn-secondary" onclick="closeAddModal()">Cancel</button>
+        <button class="btn-primary" onclick="addMessage()">Add</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    let allMessages = [];
+
+    async function loadMessages() {
+      const res = await fetch('/inbox/messages?offset=0&limit=200');
+      const data = await res.json();
+      allMessages = data.messages;
+      document.getElementById('totalStat').textContent = `Total: ${data.messages.length}`;
+      document.getElementById('unreadStat').textContent = `Unread: ${data.unreadCount}`;
+      render();
+    }
+
+    function render() {
+      const list = document.getElementById('messageList');
+      if (allMessages.length === 0) {
+        list.innerHTML = '<div class="empty">No messages. Click "+ Add Message" to create one.</div>';
+        return;
+      }
+      list.innerHTML = allMessages.map(m => `
+        <div class="message ${m.isRead ? 'read' : 'unread'}">
+          ${m.imageUrl ? `<img src="${m.imageUrl}" alt="">` : ''}
+          <div class="message-content">
+            <div class="message-header">
+              <span class="message-title">${esc(m.title)}</span>
+              <div class="message-meta">
+                <span class="badge badge-style">${m.style}</span>
+                ${!m.isRead ? '<span class="badge badge-unread">unread</span>' : ''}
+                <span>${timeAgo(m.timestamp)}</span>
+              </div>
+            </div>
+            <div class="message-body">${esc(m.body)}</div>
+            <div class="message-actions">
+              <button class="btn-small ${m.isRead ? 'btn-primary' : 'btn-secondary'}" onclick="toggleRead('${m.id}', ${!m.isRead})">
+                ${m.isRead ? 'Mark Unread' : 'Mark Read'}
+              </button>
+              <button class="btn-small btn-danger" onclick="deleteMsg('${m.id}')">Delete</button>
+            </div>
+          </div>
+        </div>
+      `).join('');
+    }
+
+    async function toggleRead(id, isRead) {
+      await fetch(`/inbox/messages/${id}`, {
+        method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ isRead }),
+      });
+      loadMessages();
+    }
+
+    async function deleteMsg(id) {
+      await fetch(`/inbox/messages/${id}`, { method: 'DELETE' });
+      loadMessages();
+    }
+
+    async function resetInbox() {
+      if (!confirm('Reset all inbox data?')) return;
+      await fetch('/inbox/messages/reset', { method: 'POST' });
+      loadMessages();
+    }
+
+    async function loadDelay() {
+      const res = await fetch('/settings');
+      const data = await res.json();
+      document.getElementById('delaySelect').value = String(data.delayMs);
+    }
+
+    async function setDelay(ms) {
+      await fetch('/settings', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ delayMs: parseInt(ms) }),
+      });
+    }
+
+    function openAddModal() { document.getElementById('addModal').classList.add('active'); }
+    function closeAddModal() { document.getElementById('addModal').classList.remove('active'); }
+
+    async function addMessage() {
+      const msg = {
+        title: document.getElementById('msgTitle').value,
+        body: document.getElementById('msgBody').value,
+        imageUrl: document.getElementById('msgImage').value || null,
+        actionUrl: document.getElementById('msgAction').value || null,
+        style: document.getElementById('msgStyle').value,
+      };
+      await fetch('/inbox/messages', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(msg),
+      });
+      closeAddModal();
+      document.getElementById('msgTitle').value = '';
+      document.getElementById('msgBody').value = '';
+      document.getElementById('msgImage').value = '';
+      document.getElementById('msgAction').value = '';
+      loadMessages();
+    }
+
+    function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+    function timeAgo(ts) {
+      const s = Math.floor((Date.now() - ts) / 1000);
+      if (s < 60) return 'just now';
+      if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+      if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
+      return `${Math.floor(s / 86400)}d ago`;
+    }
+
+    loadMessages();
+    loadDelay();
+  </script>
+</body>
+</html>

--- a/tools/mock-server/server.js
+++ b/tools/mock-server/server.js
@@ -1,0 +1,177 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+
+let delayMs = parseInt(process.env.DELAY) || 0;
+
+function simulateDelay(req, res, next) {
+  if (delayMs > 0) {
+    console.log(`  ⏳ Delaying ${delayMs}ms...`);
+    setTimeout(next, delayMs);
+  } else {
+    next();
+  }
+}
+
+app.use('/inbox', simulateDelay);
+
+const STYLES = ['small', 'large'];
+
+const SAMPLE_IMAGES = [
+  'https://as1.ftcdn.net/v2/jpg/03/98/30/92/1000_F_398309275_84cKyqzV2RLTbYmBtt0dzpZkEvqapPZo.jpg',
+  'https://picsum.photos/seed/inbox1/400/300',
+  'https://picsum.photos/seed/inbox2/400/300',
+  'https://picsum.photos/seed/inbox3/400/300',
+  'https://picsum.photos/seed/inbox4/400/300',
+];
+
+const SAMPLE_MESSAGES = [
+  { title: 'Welcome to Attentive!', body: 'Thanks for joining us. Check out our latest offers.' },
+  { title: 'New Sale Alert', body: '50% off on all items this weekend!' },
+  { title: 'Your Order Has Shipped', body: 'Your order #12345 is on its way!' },
+  { title: 'Your cart is waiting', body: 'Pick up where you left off!' },
+  { title: 'Flash Sale Ending Soon', body: 'Last chance to save big on summer essentials.' },
+  { title: 'New Arrivals Just Dropped', body: 'Be the first to shop our newest collection.' },
+  { title: 'Exclusive Member Offer', body: 'Unlock 30% off your next purchase — just for you.' },
+  { title: 'We Miss You!', body: "It's been a while. Here's a special deal to welcome you back." },
+  { title: 'Review Your Recent Purchase', body: 'Tell us what you think and earn rewards.' },
+  { title: 'Limited Edition Launch', body: 'Only 100 units available. Get yours before they sell out.' },
+];
+
+let messages = [];
+let nextId = 1;
+
+function generateMessages(count) {
+  const now = Date.now();
+  const result = [];
+  for (let i = 0; i < count; i++) {
+    const sample = SAMPLE_MESSAGES[(nextId - 1) % SAMPLE_MESSAGES.length];
+    const hasImage = nextId % 3 === 0;
+    result.push({
+      id: `msg_${String(nextId).padStart(3, '0')}`,
+      title: nextId <= SAMPLE_MESSAGES.length ? sample.title : `${sample.title} (#${nextId})`,
+      body: sample.body,
+      timestamp: now - (nextId * 3600000),
+      isRead: nextId % 4 === 0,
+      imageUrl: hasImage ? SAMPLE_IMAGES[nextId % SAMPLE_IMAGES.length] : null,
+      actionUrl: `https://example.com/offer/${nextId}`,
+      style: nextId % 5 === 0 ? 'Large' : 'Small',
+    });
+    nextId++;
+  }
+  return result;
+}
+
+messages = generateMessages(100);
+
+// --- API Routes ---
+
+// GET /inbox/messages — paginated message list
+app.get('/inbox/messages', (req, res) => {
+  const offset = parseInt(req.query.offset) || 0;
+  const limit = parseInt(req.query.limit) || 20;
+
+  const page = messages.filter(m => !m._deleted).slice(offset, offset + limit);
+  const remaining = messages.filter(m => !m._deleted).length;
+  const hasMore = offset + limit < remaining;
+
+  console.log(`GET /inbox/messages offset=${offset} limit=${limit} → ${page.length} messages (${remaining} total)`);
+
+  res.json({
+    messages: page.map(({ _deleted, ...m }) => m),
+    unreadCount: messages.filter(m => !m._deleted && !m.isRead).length,
+    hasMoreMessages: hasMore,
+    nextOffset: hasMore ? offset + limit : null,
+  });
+});
+
+// PATCH /inbox/messages/:id — update read status
+app.patch('/inbox/messages/:id', (req, res) => {
+  const msg = messages.find(m => m.id === req.params.id && !m._deleted);
+  if (!msg) return res.status(404).json({ error: 'Message not found' });
+
+  if (req.body.isRead !== undefined) {
+    msg.isRead = req.body.isRead;
+    console.log(`PATCH /inbox/messages/${req.params.id} → isRead=${msg.isRead}`);
+  }
+  res.status(204).end();
+});
+
+// DELETE /inbox/messages/:id — soft delete
+app.delete('/inbox/messages/:id', (req, res) => {
+  const msg = messages.find(m => m.id === req.params.id && !m._deleted);
+  if (!msg) return res.status(404).json({ error: 'Message not found' });
+
+  msg._deleted = true;
+  console.log(`DELETE /inbox/messages/${req.params.id}`);
+  res.status(204).end();
+});
+
+// POST /inbox/messages/reset — reset all data
+app.post('/inbox/messages/reset', (req, res) => {
+  nextId = 1;
+  messages = generateMessages(100);
+  console.log('POST /inbox/messages/reset → regenerated 100 messages');
+  res.json({ message: 'Inbox reset', count: messages.length });
+});
+
+// POST /inbox/messages — add a custom message
+app.post('/inbox/messages', (req, res) => {
+  const msg = {
+    id: `msg_${String(nextId).padStart(3, '0')}`,
+    title: req.body.title || 'New Message',
+    body: req.body.body || '',
+    timestamp: Date.now(),
+    isRead: false,
+    imageUrl: req.body.imageUrl || null,
+    actionUrl: req.body.actionUrl || null,
+    style: req.body.style || 'Small',
+  };
+  nextId++;
+  messages.unshift(msg);
+  console.log(`POST /inbox/messages → created ${msg.id}: "${msg.title}"`);
+  res.status(201).json(msg);
+});
+
+// --- Settings ---
+
+app.get('/settings', (req, res) => {
+  res.json({ delayMs });
+});
+
+app.post('/settings', (req, res) => {
+  if (req.body.delayMs !== undefined) {
+    delayMs = Math.max(0, parseInt(req.body.delayMs) || 0);
+    console.log(`POST /settings → delayMs=${delayMs}`);
+  }
+  res.json({ delayMs });
+});
+
+// --- Dashboard ---
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.listen(PORT, '0.0.0.0', () => {
+  const ifaces = require('os').networkInterfaces();
+  const localIp = Object.values(ifaces).flat()
+    .find(i => i.family === 'IPv4' && !i.internal)?.address || 'localhost';
+
+  console.log('');
+  console.log('=== Attentive Inbox Mock Server ===');
+  console.log('');
+  console.log(`  Dashboard:  http://localhost:${PORT}`);
+  console.log(`  API:        http://localhost:${PORT}/inbox/messages`);
+  console.log('');
+  console.log('  Android emulator: http://10.0.2.2:' + PORT);
+  console.log(`  Physical device:  http://${localIp}:${PORT}`);
+  console.log('');
+  console.log('Endpoints:');
+  console.log('  GET    /inbox/messages?offset=0&limit=20');
+  console.log('  PATCH  /inbox/messages/:id  { "isRead": true }');
+  console.log('  DELETE /inbox/messages/:id');
+  console.log('  POST   /inbox/messages      { "title": "...", "body": "..." }');
+  console.log('  POST   /inbox/messages/reset');
+  console.log('');
+});


### PR DESCRIPTION
## Summary
- SDK reads `com.attentive.sdk.INBOX_BASE_URL` from app manifest `<meta-data>` to create inbox Retrofit service at init time
- Falls back to existing mock data when meta-data is not present
- Includes local Express mock server (`tools/mock-server/`) with browser dashboard and configurable network delay simulation
- Bonni app configured with cleartext network security for local testing

## Ticket
https://attentivemobile.atlassian.net/browse/MSDK-338

## Test plan
- [ ] Run mock server with `cd tools/mock-server && npm install && npm start`
- [ ] Launch Bonni in emulator, verify inbox loads from server (check Logcat for "Initialized inbox from server")
- [ ] Verify pagination, mark read/unread, and delete sync to server (visible in dashboard at localhost:3000)
- [ ] Set delay via dashboard dropdown, verify loading spinner appears during pagination
- [ ] Remove `<meta-data>` tag from Bonni manifest, verify fallback to mock data still works
- [ ] Unit tests pass: `./gradlew :attentive-android-sdk:testDebugUnitTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)