### PR TITLE
Let host apps override Attentive's FirebaseMessagingService

### DIFF
--- a/attentive-android-sdk/src/main/AndroidManifest.xml
+++ b/attentive-android-sdk/src/main/AndroidManifest.xml
@@ -13,10 +13,15 @@
             android:exported="true"
             tools:ignore="ExportedService" />
 
+        <!--
+            Negative priority ensures a host app's own FirebaseMessagingService (default
+            priority 0) wins FCM dispatch when declared. FCM uses PackageManager.resolveService,
+            which honors android:priority. See MSDK ticket for context.
+        -->
         <service
             android:name="com.attentive.androidsdk.push.AttentiveFirebaseMessagingService"
             android:exported="false">
-            <intent-filter>
+            <intent-filter android:priority="-500">
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveConfig.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveConfig.kt
@@ -19,6 +19,7 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
     override var notificationIconBackgroundColorResource: Int =
         builder._notificationIconBackgroundColorResource
     override var logLevel: AttentiveLogLevel? = null
+    val pushEnabled: Boolean = builder._pushEnabled
 
     private val visitorService =
         ClassFactory.buildVisitorService(ClassFactory.buildPersistentStorage(builder._context))
@@ -150,6 +151,7 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
         internal var okHttpClient: OkHttpClient? = null
         internal var skipFatigueOnCreatives: Boolean = false
         internal var logLevel: AttentiveLogLevel = AttentiveLogLevel.STANDARD
+        internal var _pushEnabled: Boolean = true
 
         internal var apiVersion: ApiVersion = ApiVersion.OLD
 
@@ -208,6 +210,23 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
                 this.logLevel = logLevel
             }
 
+        /**
+         * Controls whether the Attentive SDK handles push notifications.
+         * Defaults to `true`. Set to `false` to disable the SDK's push pipeline — no push
+         * token will be fetched or registered, and incoming Attentive push messages will be
+         * ignored. The SDK's FirebaseMessagingService declaration already uses a negative
+         * intent-filter priority so a host app's own service wins FCM dispatch when declared;
+         * this flag is for clients who want to disable push handling entirely regardless.
+         *
+         * TODO: Before merging, decide whether pushEnabled=false should also skip token
+         * fetch/registration entirely, or still register the token without displaying
+         * notifications. See conversation with MSDK team.
+         */
+        fun pushEnabled(enabled: Boolean) =
+            apply {
+                this._pushEnabled = enabled
+            }
+
         fun build(): AttentiveConfig {
             if (this::_context.isInitialized.not()) {
                 throw IllegalStateException("A valid context must be provided.")
@@ -223,7 +242,7 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
 
         override fun toString(): String {
             return "Builder(context=$_context, mode=$_mode, domain=$_domain, okHttpClient=$okHttpClient, " +
-                "skipFatigueOnCreatives=$skipFatigueOnCreatives, logLevel=$logLevel)"
+                "skipFatigueOnCreatives=$skipFatigueOnCreatives, logLevel=$logLevel, pushEnabled=$_pushEnabled)"
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `android:priority="-500"` to Attentive's `FirebaseMessagingService` intent filter so a host app's own service wins FCM dispatch when declared. Same pattern used by OneSignal, Braze, and Airship. Relies on Android's documented `PackageManager.resolveService` behavior (used internally by FCM) rather than a Firebase contract.
- Add `AttentiveConfig.Builder.pushEnabled(Boolean)`, default `true`, for clients who want to disable the SDK's push pipeline entirely.

## Open question (resolve before merging)
**What should `pushEnabled = false` actually skip?** The flag is declared but not yet wired into the runtime. Two options:
1. Skip everything: no push token fetch, no registration, no `POST_NOTIFICATIONS` prompt, no-op `sendNotification` / `isAttentiveFirebaseMessage`.
2. Only suppress notification display — still fetch/register the token so backend analytics continue to work.

Option 1 is the conservative default ("off means off"), but option 2 may be what some clients actually want. Need product input before wiring this up.

## Test plan
- [ ] Build the SDK and verify the manifest-merged host app still gets push delivered when it declares its own `FirebaseMessagingService` at default priority.
- [ ] Without a host service declared, verify Attentive's service still receives the FCM message.
- [ ] Verify `AttentiveConfig.Builder().pushEnabled(false).build().pushEnabled == false` and default is `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)