### PR TITLE
MSDK-346: Document SDK identity calls and backend effects

### DIFF
--- a/docs/identity-ios.md
+++ b/docs/identity-ios.md
@@ -1,0 +1,238 @@
+# Attentive iOS SDK — Identity calls
+
+This document describes the identity-related SDK methods in the iOS SDK (`~/attentive-ios-sdk`), when they fire, what the backend does with them, and when an integrator needs to call them manually. It is a companion to [`identity.md`](./identity.md) (Android) and uses the same structure so the two can be compared directly.
+
+## Overview
+
+Every identity call reads from or writes to `ATTNUserIdentity`, an in-memory object holding:
+
+- `visitorId` — auto-generated UUID (without hyphens), persisted in UserDefaults, regenerated on user switch or logout
+- `clientUserId`, `email`, `phone`, `shopifyId`, `klaviyoId`, `customIdentifiers`
+
+**Minimum integration** (events + auto push registration work):
+
+1. `ATTNSDK(domain:mode:)` — required
+2. APNs registered and `application(_:didRegisterForRemoteNotificationsWithDeviceToken:)` forwarding the token to `ATTNSDK.registerDeviceToken(...)` — required *only if* you want push notifications
+
+Everything else (`identify`, `updateUser`, `optIn/Out`, `clearUser`) is optional and driven by the host app's user-account lifecycle.
+
+## What fires automatically
+
+| Trigger | Endpoint | What it does |
+| --- | --- | --- |
+| `ATTNSDK` init | `POST events.attentivemobile.com/e?t=i` | Ping ("info event") — not identity |
+| App foreground (`UIApplication.didBecomeActiveNotification`) | `POST mobile.attentivemobile.com/token` + `POST /mtctrl` | Checks push authorization, re-registers token if authorized, fires an app-open event. Debounced to 2 seconds. |
+| APNs token registration (`didRegisterForRemoteNotificationsWithDeviceToken`) | `POST /token` (+ `/mtctrl`) | Registers device token, permission status, and fires an app-open event |
+| Push notification tapped | `POST /mtctrl` | Direct-open tracking |
+| Permission state change (denied → authorized, detected on foreground) | `POST /token` | Clears cached token, re-registers with APNs, re-sends to `/token` |
+
+Like Android, the foreground hook fires `/token` every time the app comes to the foreground — not just on process start. If APNs has not delivered a token yet, it is a no-op.
+
+## Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant App as Host App
+    participant SDK as ATTNSDK
+    participant APNs
+    participant BE as Attentive Backend
+
+    Note over App,BE: One-time initialization
+    App->>SDK: ATTNSDK(domain:mode:)
+    SDK->>BE: POST /e?t=i (info event)
+
+    Note over App,BE: APNs token delivery (automatic)
+    APNs->>App: didRegisterForRemoteNotificationsWithDeviceToken
+    App->>SDK: registerDeviceToken(...)
+    SDK->>BE: POST /token
+    SDK->>BE: POST /mtctrl
+
+    Note over App,BE: Every app foreground (automatic)
+    App-->>SDK: didBecomeActiveNotification
+    SDK->>APNs: re-register if authorized
+    SDK->>BE: POST /token
+    SDK->>BE: POST /mtctrl
+
+    Note over App,BE: Push tapped (automatic)
+    App->>SDK: didReceive UNNotificationResponse
+    SDK->>BE: POST /mtctrl (direct open)
+
+    Note over App,BE: User identifies themselves (manual)
+    App->>SDK: identify([email: ..., phone: ...])
+    SDK->>BE: POST /e?t=idn (merge into current visitor)
+
+    Note over App,BE: User logs in as different user (manual)
+    App->>SDK: updateUser(email:phone:)
+    SDK->>SDK: clear identifiers + new visitor ID
+    SDK->>BE: POST /user-update
+
+    Note over App,BE: User logs out (manual)
+    App->>SDK: clearUser()
+    SDK->>SDK: new visitor ID
+    SDK->>BE: POST /user-update (empty metadata)
+
+    Note over App,BE: Subscription actions (manual)
+    App->>SDK: optInMarketingSubscription(email:phone:)
+    SDK->>BE: POST /opt-in-subscriptions
+```
+
+## Methods
+
+### `ATTNSDK.identify(_ userIdentifiers:)`
+
+**Source:** `Sources/ATTNSDK/ATTNSDK.swift:143–149`
+
+**Purpose:** Attach an email, phone, or other identifier to the current visitor.
+
+**Fires immediately:** `POST events.attentivemobile.com/e?t=idn`
+
+**Backend effect:** `UserIdentifierService.generateUserIdentity()` merges the submitted identifiers into the existing visitor profile. Merge, not replace — identifiers accumulate across calls.
+
+**Changes visitor ID?** No.
+
+**When to call:** whenever you learn the user's email, phone, or vendor IDs.
+
+**Required?** No.
+
+---
+
+### `ATTNSDK.updateUser(email:phone:callback:)`
+
+**Source:** `Sources/ATTNSDK/ATTNSDK.swift:559–587`
+
+**Purpose:** Declare that the current device is now a different user.
+
+**Fires:**
+
+1. **Synchronously, locally:** clears all identifiers and generates a new visitor ID, then merges in the new email/phone.
+2. **Async:** `POST /user-update` with the new visitor ID, current push token, and email/phone.
+
+**Backend effect:** `UserUpdateController.handleUserUpdateRequest()` re-associates the push token with the new visitor.
+
+**Changes visitor ID?** **Yes.**
+
+**When to call:** user logs in as a different account on the same device.
+
+**Required?** Only for multi-user apps.
+
+> ⚠️ **Known limitation:** `/user-update` is silently dropped by the backend (204) if the push token is blank. Under review — see [MSDK-345](https://attentivemobile.atlassian.net/browse/MSDK-345).
+
+---
+
+### `ATTNSDK.clearUser()`
+
+**Source:** `Sources/ATTNSDK/ATTNSDK.swift:190–209`
+
+**Purpose:** Log the current user out. Resets local visitor identity and tells the backend to detach the push token from the prior user.
+
+**Fires:**
+
+1. **Synchronously, locally:** generates a new visitor ID.
+2. **Async:** `POST /user-update` with empty metadata (only if a push token is present).
+
+**Backend effect:** Detaches the push token from the previous user's identity and re-associates it with the new anonymous visitor.
+
+**Changes visitor ID?** **Yes.**
+
+**Required?** Strongly recommended on logout.
+
+> ⚠️ **Known limitation:** Same as `updateUser` — silent no-op on backend if push token is blank. See [MSDK-345](https://attentivemobile.atlassian.net/browse/MSDK-345).
+
+---
+
+### `ATTNSDK.optInMarketingSubscription(email:phone:callback:)`
+
+**Source:** `Sources/ATTNSDK/ATTNSDK.swift:439–475`
+
+**Purpose:** Subscribe the user to Attentive marketing on email and/or SMS.
+
+**Fires:** `POST mobile.attentivemobile.com/opt-in-subscriptions`
+
+**Backend effect:** `NonPushSubscriptionController` creates a subscription record (`ACTION_TYPE_SUBSCRIBE`). Idempotent.
+
+**Changes visitor ID?** No.
+
+**iOS-specific behavior:** if no push token is available when called, the request is **queued for up to 60 seconds** and sent as soon as the token arrives (`ATTNSDK.swift:730–757`). This is different from Android, which fires the request immediately regardless of token state.
+
+**Required?** Only if your app drives marketing opt-in UI.
+
+---
+
+### `ATTNSDK.optOutMarketingSubscription(email:phone:callback:)`
+
+**Source:** `Sources/ATTNSDK/ATTNSDK.swift:493–529`
+
+**Purpose:** Unsubscribe.
+
+**Fires:** `POST /opt-out-subscriptions` — same queue-until-token behavior as opt-in.
+
+---
+
+### `ATTNSDK.registerDeviceToken(_:authorizationStatus:callback:)`
+
+**Source:** `Sources/ATTNSDK/ATTNSDK.swift:267–298`
+
+**Purpose:** Register the APNs device token and permission state with Attentive.
+
+**Fires:** `POST /token`, then flushes any queued opt-in/out requests, then `POST /mtctrl`.
+
+**When to call:** from `application(_:didRegisterForRemoteNotificationsWithDeviceToken:)` in your AppDelegate.
+
+**Required?** Yes, if you want push notifications.
+
+---
+
+### (No direct `updatePushPermissionStatus` method)
+
+Unlike Android, iOS does not expose a manual `updatePushPermissionStatus()` method. Permission re-registration happens automatically on app foreground (`handleAppDidBecomeActive` at `ATTNSDK.swift:639`), including the case where the user returns from Settings after changing permission (detected via authorization status flipping from denied → authorized, `ATTNSDK.swift:655–662`).
+
+## Comparison: `identify()` vs `updateUser()`
+
+|  | `identify()` | `updateUser()` |
+| --- | --- | --- |
+| Changes visitor ID | No — merges into current | Yes — generates new |
+| Calls `/user-update` | No | Yes |
+| Emits `/e?t=idn` | Yes | No (on iOS — Android also emits idn as a side effect, iOS does not) |
+| Meaning | "Here is additional info about this visitor" | "This is a different person now" |
+
+## Bonni iOS settings screen
+
+Source: `Bonni/.../SettingsViewController.swift`
+
+| UI Button | SDK method |
+| --- | --- |
+| "Add email" | `identify([email: ...])` |
+| "Add phone" | `identify([phone: ...])` |
+| "Switch User" | `updateUser(email:phone:)` |
+| "Log Out" | `clearUser()` |
+| "Clear User" | `clearUser()` (duplicate of "Log Out") |
+| "Opt in email" | `optInMarketingSubscription(email:)` |
+| "Opt out email" | `optOutMarketingSubscription(email:)` |
+| "Opt in phone" | `optInMarketingSubscription(phone:)` |
+| "Opt out phone" | `optOutMarketingSubscription(phone:)` |
+| "Show Push Permission" | `registerForPushNotifications()` |
+
+## iOS-specific behaviors (not on Android)
+
+1. **Opt-in/out requests queue until a push token is available** (up to 60s). Android fires them immediately and relies on the backend accepting tokenless subscription requests. This is a precedent relevant to [MSDK-345](https://attentivemobile.atlassian.net/browse/MSDK-345) — iOS has already solved the tokenless-call problem by queueing rather than by backend change.
+2. **Push-token sends debounced to 2 seconds** (`ATTNAPI.swift:62`). App-open events debounced to 2 seconds (`ATTNSDK.swift:354–360`). Android's `/mtctrl` is debounced to 3 seconds.
+3. **Provisional push permission** — iOS automatically requests provisional notification permission on first foreground when permission is undetermined (`ATTNSDK.swift:717–728`). No equivalent on Android (no "provisional" concept in the OS).
+4. **No manual `updatePushPermissionStatus()`** — permission re-registration is entirely automatic.
+5. **No separate `AppLaunchTracker`** — app-launch tracking is handled inline by `handleRegularOpen()` which sends `/mtctrl` events with the app-launch type (`"ist": "al"`).
+
+## Naming differences vs Android
+
+| Android | iOS | Notes |
+| --- | --- | --- |
+| `AttentiveConfig.identify(userIdentifiers)` | `ATTNSDK.identify(_ userIdentifiers:)` | Same semantic, different parameter type (Map vs Dictionary). |
+| `AttentiveSdk.updateUser(email, phoneNumber)` | `ATTNSDK.updateUser(email:phone:callback:)` | Same. iOS takes a callback; Android is fire-and-forget. |
+| `AttentiveSdk.clearUser()` | `ATTNSDK.clearUser()` | Same name. iOS method is also imperfect without a token (same limitation). |
+| `AttentiveSdk.optUserIntoMarketingSubscription(email, phone)` | `ATTNSDK.optInMarketingSubscription(email:phone:callback:)` | iOS name is ~30% shorter. The Android name reads as "opt *user* into marketing *subscription*" — iOS drops "user" and "subscription" cleanly. |
+| `AttentiveSdk.optUserOutOfMarketingSubscription(...)` | `ATTNSDK.optOutMarketingSubscription(...)` | Same. |
+| `AttentiveSdk.updatePushPermissionStatus(context)` | (none) | iOS handles it automatically. |
+
+The iOS naming is generally tighter. The proposed Android renames in [`identity.md`](./identity.md#naming-proposal) would align Android closer to iOS in most cases, but would also introduce divergence in places (e.g. Android's proposed `subscribe`/`unsubscribe` vs iOS's `optInMarketingSubscription`/`optOutMarketingSubscription`). Any cross-platform rename should be coordinated.
+
+## Known limitations / follow-ups
+
+- **[MSDK-345](https://attentivemobile.atlassian.net/browse/MSDK-345)** — `/user-update` requires a non-blank push token or is silently discarded. Affects `updateUser()` and `clearUser()` on iOS the same way as Android. Note that iOS has already adopted a client-side workaround (queueing) for opt-in/out — the same pattern could be applied to `/user-update` on both platforms if the backend can't be changed.

--- a/docs/identity-ios.md
+++ b/docs/identity-ios.md
@@ -115,8 +115,6 @@ sequenceDiagram
 
 **Required?** Only for multi-user apps.
 
-> ⚠️ **Known limitation:** `/user-update` is silently dropped by the backend (204) if the push token is blank. Under review — see [MSDK-345](https://attentivemobile.atlassian.net/browse/MSDK-345).
-
 ---
 
 ### `ATTNSDK.clearUser()`
@@ -135,8 +133,6 @@ sequenceDiagram
 **Changes visitor ID?** **Yes.**
 
 **Required?** Strongly recommended on logout.
-
-> ⚠️ **Known limitation:** Same as `updateUser` — silent no-op on backend if push token is blank. See [MSDK-345](https://attentivemobile.atlassian.net/browse/MSDK-345).
 
 ---
 
@@ -235,4 +231,4 @@ The iOS naming is generally tighter. The proposed Android renames in [`identity.
 
 ## Known limitations / follow-ups
 
-- **[MSDK-345](https://attentivemobile.atlassian.net/browse/MSDK-345)** — `/user-update` requires a non-blank push token or is silently discarded. Affects `updateUser()` and `clearUser()` on iOS the same way as Android. Note that iOS has already adopted a client-side workaround (queueing) for opt-in/out — the same pattern could be applied to `/user-update` on both platforms if the backend can't be changed.
+None currently tracked for iOS. The tokenless `/user-update` behavior flagged on Android as [MSDK-345](https://attentivemobile.atlassian.net/browse/MSDK-345) has the same underlying backend behavior on iOS, but iOS mitigates it through the opt-in/out queueing pattern (the queue holds requests until a token arrives, then flushes). If MSDK-345 results in a client-side fix, the same queueing approach could be extended to `/user-update` on iOS.

--- a/docs/identity-lifecycle.md
+++ b/docs/identity-lifecycle.md
@@ -1,0 +1,202 @@
+# Android SDK Identifiers Lifecycle Guide
+
+## The Four Identifiers
+
+The Android SDK manages four categories of user-related identifiers. Each has a different lifecycle and purpose.
+
+| Identifier | What it is | Where it lives | Created when | Destroyed when |
+| --- | --- | --- | --- | --- |
+| **Visitor ID** | 32-char hex string (e.g. `E79AFB5C69904529A309957F1AFCC3DA`) that represents "a person on this device right now" | On device (persists across app launches in SharedPreferences) | SDK initialized for the first time (or after `clearUser`/`updateUser`) | Replaced with a new ID on `clearUser()` or `updateUser()` |
+| **Push Token** | FCM registration token — identifies this Firebase app installation for push delivery | In-memory + sent to backend | Firebase delivers it after app registers for FCM | Detached from the current user on `clearUser()`; re-associated on next foreground or `updateUser()` |
+| **Email / Phone / Other IDs (`identify`)** | User-provided contact info attached to a visitor for analytics and identity resolution | In-memory on `AttentiveConfig.userIdentifiers` | App calls `identify()` with email/phone | Cleared on `clearUser()` or `updateUser()` |
+| **Email / Phone (opt-in subscriptions)** | Contact info used to create a marketing subscription (SMS/email) | Sent directly to backend — not stored locally | App calls `optUserIntoMarketingSubscription()` | Backend removes on `optUserOutOfMarketingSubscription()` |
+
+> **Key distinction:** The email/phone passed to `identify()` says "this visitor is reachable at this address" (identity resolution). The email/phone passed to `optUserIntoMarketingSubscription()` says "this person consents to receive marketing at this address" (subscription management). They can be the same values, but serve different purposes and go to different backend systems.
+
+## Identifier Lifecycle Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         APP LIFECYCLE                                   │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  ┌──────────────┐                                                       │
+│  │ SDK Init     │──▶ Visitor ID created (or loaded from SharedPrefs)    │
+│  └──────────────┘                                                       │
+│         │                                                               │
+│         ▼                                                               │
+│  ┌──────────────┐                                                       │
+│  │ FCM Token    │──▶ Push Token registered with backend on every        │
+│  │ Available +  │    app foreground (POST /token with visitorId +       │
+│  │ App Foreground│   token + permission)                                │
+│  └──────────────┘                                                       │
+│         │                                                               │
+│         ▼                                                               │
+│  ┌──────────────┐                                                       │
+│  │ identify()   │──▶ Email/phone merged into current Visitor ID         │
+│  │              │    (POST /e?t=idn — identity event)                   │
+│  └──────────────┘                                                       │
+│         │                                                               │
+│         ▼                                                               │
+│  ┌──────────────┐                                                       │
+│  │ optIn()      │──▶ Subscription created for email/phone               │
+│  │              │    (POST /opt-in-subscriptions)                       │
+│  └──────────────┘                                                       │
+│         │                                                               │
+│         ▼                                                               │
+│  ┌──────────────┐    ┌─────────────────────────────────────────┐        │
+│  │ clearUser()  │──▶ │ 1. New Visitor ID generated              │        │
+│  │  (logout)    │    │ 2. All local identifiers wiped           │        │
+│  └──────────────┘    │ 3. Push token detached from old visitor  │        │
+│                      │    (POST /user-update with empty data)   │        │
+│                      │ 4. Push token re-associated with new     │        │
+│                      │    anonymous visitor                     │        │
+│                      └─────────────────────────────────────────┘        │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## What Each Operation Does
+
+### `identify(userIdentifiers)`
+
+> **Think of it as:** "Here's more info about whoever is using this device right now."
+
+| Effect | Detail |
+| --- | --- |
+| Visitor ID | **Unchanged** — merges into existing visitor |
+| Push Token | **Unchanged** |
+| Email/Phone (local) | **Added/merged** — identifiers accumulate, never overwrite |
+| Backend call | `POST /e?t=idn` — identity event merges identifiers into visitor profile |
+
+**When to call:** Anytime you learn the user's email, phone, or other identifier (e.g., after login, after form submission). Safe to call multiple times — identifiers accumulate.
+
+---
+
+### `clearUser()`
+
+> **Think of it as:** "The current user logged out. Forget everything about them on this device."
+
+| Effect | Detail |
+| --- | --- |
+| Visitor ID | **Replaced** — new ID generated immediately |
+| Push Token | **Detached** from old visitor, re-associated with new anonymous visitor |
+| Email/Phone (local) | **Cleared** — all local identity data wiped |
+| Backend call | `POST /user-update` with empty metadata (only if push token exists) |
+
+**When to call:** On user logout. Prevents the next user on this device from receiving the previous user's push notifications or being associated with their identity.
+
+> **⚠️ Use `AttentiveSdk.clearUser()`, not the deprecated `AttentiveConfig.clearUser()`.** The deprecated version only clears local state and does NOT call `/user-update`, so the backend still thinks the logged-out user owns the push token.
+
+---
+
+### `updateUser(email, phoneNumber)`
+
+> **Think of it as:** "A different person just logged into this device. Switch everything over to them."
+
+| Effect | Detail |
+| --- | --- |
+| Visitor ID | **Replaced** — new ID generated |
+| Push Token | **Re-associated** with the new visitor + new email/phone |
+| Email/Phone (local) | **Cleared then set** — old wiped, new email/phone merged in |
+| Backend calls | `POST /user-update` with new visitorId + push token + email/phone, **plus** `POST /e?t=idn` (side effect of local `identify()` invocation during the switch) |
+
+**When to call:** User switches accounts without the app restarting (e.g., "Log in as different user" flow). Only needed for multi-user apps.
+
+> **Android/iOS divergence:** Android fires both `/user-update` and `/e?t=idn`; iOS fires only `/user-update`. Identity graphs end up correctly populated on both platforms (because `/user-update` is consumed by `mobile-subscription-consumer` and calls identity-api directly), but iOS does not emit a `UserIdentifierCollected` analytics event on user switch.
+
+---
+
+### `optUserIntoMarketingSubscription(email, phoneNumber)`
+
+> **Think of it as:** "This person consents to receive marketing messages at this address."
+
+| Effect | Detail |
+| --- | --- |
+| Visitor ID | **Unchanged** |
+| Push Token | **Unchanged** (but included in the request) |
+| Email/Phone (local) | **Unchanged** — not stored locally, sent directly to backend |
+| Backend call | `POST /opt-in-subscriptions` — creates subscription record |
+
+> **Android/iOS divergence:** Unlike iOS, Android does **not** queue the request if the push token is unavailable — it fires immediately. If a token isn't present, the backend may reject or silently drop the request.
+
+---
+
+### `optUserOutOfMarketingSubscription(email, phoneNumber)`
+
+> **Think of it as:** "This person revokes consent for marketing at this address."
+
+| Effect | Detail |
+| --- | --- |
+| Visitor ID | **Unchanged** |
+| Push Token | **Unchanged** |
+| Email/Phone (local) | **Unchanged** |
+| Backend call | `POST /opt-out-subscriptions` — removes subscription record |
+
+Same no-queueing behavior as opt-in.
+
+## State Transition Summary
+
+| Operation | Visitor ID | Push Token | Local Email/Phone | Backend Subscriptions |
+| --- | --- | --- | --- | --- |
+| `identify()` | — | — | Adds to existing | — |
+| `clearUser()` | New ID | Detach → re-attach to new anonymous | Wiped | — |
+| `updateUser()` | New ID | Re-attach to new user | Replaced | — |
+| `optIn()` | — | — | — | Created |
+| `optOut()` | — | — | — | Removed |
+
+"—" means no change.
+
+## Push Token Lifecycle (Deep Dive)
+
+The push token is managed partly by Firebase and partly by the SDK:
+
+1. **Creation:** Firebase generates and delivers the FCM token asynchronously after app init. Available via `FirebaseMessaging.getInstance().getToken()` at any time once Firebase is initialized.
+2. **Registration (automatic):** On every app foreground (`ProcessLifecycleOwner.onStart`), `AppLaunchTracker` fetches the token and calls `POST /token` with visitorId + token + permission status. No manual integration step required.
+3. **Token rotation (automatic):** `AttentiveFirebaseMessagingService.onNewToken` fires when Firebase rotates the token, calling `POST /token` immediately. This only fires if the SDK's `FirebaseMessagingService` wins dispatch — host apps that declare their own service (default intent-filter priority 0) will win over the SDK's service (priority -500).
+4. **Permission change (manual):** Android exposes `AttentiveSdk.updatePushPermissionStatus(context)` to re-register with updated permission state immediately. Otherwise, the next app foreground will pick up the new permission automatically.
+5. **Detachment (on `clearUser`):** Token is detached from the old visitor and re-associated with the new anonymous visitor.
+6. **Transfer (on `updateUser`):** Token is re-associated with the new identified visitor.
+
+> **Push disabled entirely:** If the host app uses `AttentiveConfig.Builder.pushEnabled(false)` or does not integrate Firebase at all, no push token will be available. In that case `updateUser()` and `clearUser()` currently silently no-op on the backend side (see [MSDK-345](https://attentivemobile.atlassian.net/browse/MSDK-345)).
+
+## Visitor ID Lifecycle (Deep Dive)
+
+1. **Created once** on first SDK init — stored in SharedPreferences, survives app restarts and updates.
+2. **Persists** across all `identify()` calls — identity merges into the same visitor.
+3. **Replaced** (not cleared) on `clearUser()` or `updateUser()` — old ID is gone, new ID takes over.
+4. **Never shared** across devices — each device has its own Visitor ID.
+
+> **Common misconception:** Visitor ID ≠ user account. A single human can have multiple Visitor IDs (one per device, or a new one after each logout). The backend identity graph resolves these into a unified profile using email/phone from `identify()` calls.
+
+## FAQ
+
+**Q: Does calling `identify()` multiple times create duplicate visitors?**
+No. Identifiers accumulate on the same Visitor ID. Calling `identify(email)` then `identify(phone)` results in one visitor with both.
+
+**Q: What happens if I call `optIn()` before the push token is available?**
+Unlike iOS (which queues for up to 60 seconds), Android fires the request immediately. If no token is present, the backend may reject or silently drop the request. Best practice is to wait for the first app foreground (which triggers `/token` registration) before calling `optIn()`.
+
+**Q: If I call `clearUser()`, does that unsubscribe them from marketing?**
+No. `clearUser()` only affects the device-level identity (Visitor ID, push token association, local identifiers). Marketing subscriptions created via `optIn()` persist on the backend until explicitly removed via `optOut()`.
+
+**Q: Can the same email appear in both `identify()` and `optIn()`?**
+Yes, and this is common. `identify()` tells the identity system "this visitor is this person." `optIn()` tells the subscription system "this person consents to marketing." They serve different purposes even with the same value.
+
+**Q: What backend endpoints should I monitor for identity issues?**
+
+* `POST /e?t=idn` — identity events from `identify()` and (on Android only) as a side-effect of `updateUser()`
+* `POST /token` — push token registration (fires on every app foreground)
+* `POST /user-update` — `clearUser()` and `updateUser()`
+* `POST /opt-in-subscriptions` and `POST /opt-out-subscriptions` — marketing consent
+* `POST /mtctrl` — app launch tracking (not identity, but often correlated)
+
+**Q: Is there a risk of push notifications going to the wrong person?**
+Only if the app fails to call `AttentiveSdk.clearUser()` on logout. Without it, the push token remains associated with the previous user's Visitor ID, so they could receive pushes intended for someone else on a shared device. Using the deprecated `AttentiveConfig.clearUser()` has the same problem — it only clears local state.
+
+**Q: Can a host app use its own `FirebaseMessagingService`?**
+Yes. The SDK's `AttentiveFirebaseMessagingService` declares its intent-filter at `android:priority="-500"` so a host-declared service (default priority 0) wins FCM dispatch. The host app is then responsible for calling `AttentiveSdk.isAttentiveFirebaseMessage(remoteMessage)` and `AttentiveSdk.sendNotification(remoteMessage)` to forward Attentive pushes. A host app can also opt out of the SDK's push pipeline entirely with `AttentiveConfig.Builder.pushEnabled(false)`.
+
+---
+
+*See also:* [Attentive Android SDK — Identity Calls](./identity.md) (detailed technical reference with source code locations and backend implementation details), and [iOS SDK Identifiers Lifecycle Guide](https://attentivemobile.atlassian.net/wiki/spaces/ENG/pages/6712098863) for the iOS counterpart.

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -2,6 +2,8 @@
 
 This document describes the identity-related SDK methods, when they fire, what the backend does with them, and when an integrator needs to call them manually.
 
+See [`identity-ios.md`](./identity-ios.md) for the iOS companion.
+
 ## Overview
 
 Every identity call reads from or writes to `AttentiveConfig.userIdentifiers`, an in-memory object holding:

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -1,0 +1,196 @@
+# Attentive Android SDK — Identity calls
+
+This document describes the identity-related SDK methods, when they fire, what the backend does with them, and when an integrator needs to call them manually.
+
+## Overview
+
+Every identity call reads from or writes to `AttentiveConfig.userIdentifiers`, an in-memory object holding:
+
+- `visitorId` — auto-generated UUID, persisted in SharedPreferences, regenerated on user switch or logout
+- `clientUserId`, `email`, `phone`, `shopifyId`, `klaviyoId`, `customIdentifiers`
+
+**Minimum integration** (events + auto push registration work):
+
+1. `AttentiveConfig.Builder()…build()` — required
+2. `AttentiveSdk.initialize(config)` — required
+3. FCM set up in the host app — required *only if* you want push notifications
+
+Everything else (`identify`, `updateUser`, `optIn/Out`, `clearUser`) is optional and driven by the host app's user-account lifecycle.
+
+## What fires automatically
+
+| Trigger | Endpoint | What it does |
+| --- | --- | --- |
+| `AttentiveConfig.Builder.build()` | `POST events.attentivemobile.com/e?t=i` | Ping ("info event") — not identity |
+| App foreground (`ProcessLifecycleOwner.onStart`) | `POST mobile.attentivemobile.com/token` | Registers current FCM push token + permission state on the current visitor |
+| Activity resume after foreground | `POST mobile.attentivemobile.com/mtctrl` | App-launch tracking (`APP_LAUNCHED` or `DIRECT_OPEN` if launched from push). Debounced to 3 seconds |
+| FCM token rotation (`onNewToken`) | `POST /token` | Same as foreground-triggered `/token` call |
+
+The foreground `/token` call happens every time the app comes to the foreground from background, not just on process start. If FCM has not yet delivered a token, this is a no-op.
+
+## Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant App as Host App
+    participant SDK as AttentiveSdk
+    participant Tracker as AppLaunchTracker
+    participant FCM as Firebase FCM
+    participant BE as Attentive Backend
+
+    Note over App,BE: One-time initialization
+    App->>SDK: AttentiveConfig.Builder…build()
+    SDK->>BE: POST /e?t=i (info event)
+    App->>SDK: AttentiveSdk.initialize(config)
+    SDK->>Tracker: observe ProcessLifecycleOwner
+
+    Note over App,BE: Every app foreground (automatic)
+    App-->>Tracker: onStart
+    Tracker->>FCM: getToken()
+    FCM-->>Tracker: token
+    Tracker->>BE: POST /token
+
+    Note over App,BE: Every Activity resume after foreground (automatic)
+    App-->>Tracker: onActivityResumed
+    Tracker->>BE: POST /mtctrl
+
+    Note over App,BE: FCM token rotation (automatic, only if our service wins dispatch)
+    FCM->>SDK: onNewToken
+    SDK->>BE: POST /token
+
+    Note over App,BE: User identifies themselves (manual)
+    App->>SDK: config.identify(email/phone)
+    SDK->>BE: POST /e?t=idn (merge into current visitor)
+
+    Note over App,BE: User logs in as different user (manual)
+    App->>SDK: AttentiveSdk.updateUser(email, phone)
+    SDK->>SDK: resetIdentifiers() — new visitor ID
+    SDK->>BE: POST /e?t=idn
+    SDK->>BE: POST /user-update
+
+    Note over App,BE: User logs out (manual)
+    App->>SDK: AttentiveSdk.clearUser()
+    SDK->>SDK: resetIdentifiers() — new visitor ID
+    SDK->>BE: POST /user-update (empty metadata)
+
+    Note over App,BE: Subscription actions (manual)
+    App->>SDK: optUserIntoMarketingSubscription
+    SDK->>BE: POST /opt-in-subscriptions
+```
+
+## Methods
+
+### `AttentiveConfig.identify(userIdentifiers)`
+
+**Purpose:** Attach an email, phone, or other identifier to the current visitor.
+
+**Fires immediately:** `POST events.attentivemobile.com/e?t=idn`
+
+**Backend effect:** `UserIdentifierService.generateUserIdentity()` merges the submitted identifiers into the existing visitor profile. This is a merge, not a replace — identifiers accumulate across calls.
+
+**Changes visitor ID?** No.
+
+**When to call:** whenever you learn the user's email, phone, or vendor IDs (sign-in, form submit, etc.). Safe to call multiple times.
+
+**Required?** No. The SDK works without it — visitor-level events still land.
+
+---
+
+### `AttentiveSdk.updateUser(email, phoneNumber)`
+
+**Purpose:** Declare that the current device is now a different user (multi-user apps).
+
+**Fires:**
+
+1. **Synchronously, locally:** `resetIdentifiers()` generates a new visitor ID and clears prior identifiers.
+2. **Async:** `POST /user-update` with the new visitor ID, current push token, and email/phone.
+3. **Async (triggered by step 2):** `POST /e?t=idn` with the new identifiers.
+
+**Backend effect:** `UserUpdateController.handleUserUpdateRequest()` re-associates the push token with the new visitor. The `/e?t=idn` emission merges email/phone into the new visitor's profile.
+
+**Changes visitor ID?** **Yes.**
+
+**When to call:** user logs in as a different account on the same device.
+
+**Required?** Only for apps that support multiple user accounts on one device.
+
+> ⚠️ **Known limitation:** `/user-update` is silently dropped by the backend (204) if `pushToken` is blank. This affects apps without Firebase Cloud Messaging, and apps using `pushEnabled = false`. Under review — see [MSDK-345](https://attentivemobile.atlassian.net/browse/MSDK-345).
+
+---
+
+### `AttentiveSdk.clearUser()`
+
+**Purpose:** Log the current user out. Resets local visitor identity and tells the backend to detach the push token from the prior user.
+
+**Fires:**
+
+1. **Synchronously, locally:** `resetIdentifiers()` generates a new visitor ID.
+2. **Async:** `POST /user-update` with empty metadata and the new visitor ID.
+
+**Backend effect:** Detaches the push token from the previous user's identity and re-associates it with the new anonymous visitor.
+
+**Changes visitor ID?** **Yes.**
+
+**When to call:** on logout.
+
+**Required?** Strongly recommended on logout. Without it, the push token stays mapped to the logged-out user on the backend and will keep receiving targeted messages.
+
+> ⚠️ **Known limitation:** Same as `updateUser()` — silent no-op on backend if `pushToken` is blank. See [MSDK-345](https://attentivemobile.atlassian.net/browse/MSDK-345).
+
+> ⚠️ **Deprecated:** `AttentiveConfig.clearUser()` only clears local state and does NOT call `/user-update`. Always use `AttentiveSdk.clearUser()`. The deprecated method will be removed in a future release.
+
+---
+
+### `AttentiveSdk.optUserIntoMarketingSubscription(email, phoneNumber)`
+
+**Purpose:** Subscribe the user to Attentive marketing on email and/or SMS.
+
+**Fires:** `POST mobile.attentivemobile.com/opt-in-subscriptions`
+
+**Backend effect:** `NonPushSubscriptionController` creates a subscription record (`ACTION_TYPE_SUBSCRIBE`). Idempotent.
+
+**Changes visitor ID?** No.
+
+**When to call:** user explicitly consents to marketing.
+
+**Required?** Only if your app drives marketing opt-in UI. If subscriptions are managed entirely through Attentive's web/SMS flows, you never need to call this.
+
+---
+
+### `AttentiveSdk.optUserOutOfMarketingSubscription(email, phoneNumber)`
+
+**Purpose:** Unsubscribe the user from Attentive marketing on email and/or SMS.
+
+**Fires:** `POST /opt-out-subscriptions`
+
+**Backend effect:** `ACTION_TYPE_UNSUBSCRIBE`. Idempotent.
+
+**Changes visitor ID?** No.
+
+**Required?** Only if your app drives subscription UI.
+
+---
+
+### `AttentiveSdk.updatePushPermissionStatus(context)`
+
+**Purpose:** Re-register the push token with the latest `permissionGranted` state.
+
+**Fires:** `POST /token` with current token and permission.
+
+**When to call:** after the user returns from system settings and may have changed notification permission. Optional — the next app foreground will register permission state automatically.
+
+**Required?** No.
+
+## Comparison: `identify()` vs `updateUser()`
+
+|  | `identify()` | `updateUser()` |
+| --- | --- | --- |
+| Changes visitor ID | No — merges into current | Yes — generates new |
+| Calls `/user-update` | No | Yes |
+| Emits `/e?t=idn` | Yes | Yes (via `/user-update` side-effect) |
+| Meaning | "Here is additional info about this visitor" | "This is a different person now" |
+
+## Known limitations / follow-ups
+
+- **[MSDK-345](https://attentivemobile.atlassian.net/browse/MSDK-345)** — `/user-update` requires a non-blank FCM push token or it is silently discarded. Affects `updateUser()` and `clearUser()` for apps without Firebase or with `pushEnabled = false`. Under review.
+- **Deprecated `AttentiveConfig.clearUser()`** — will be removed in a future release. Use `AttentiveSdk.clearUser()`.

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -196,3 +196,47 @@ sequenceDiagram
 
 - **[MSDK-345](https://attentivemobile.atlassian.net/browse/MSDK-345)** — `/user-update` requires a non-blank FCM push token or it is silently discarded. Affects `updateUser()` and `clearUser()` for apps without Firebase or with `pushEnabled = false`. Under review.
 - **Deprecated `AttentiveConfig.clearUser()`** — will be removed in a future release. Use `AttentiveSdk.clearUser()`.
+
+## Naming proposal
+
+The current method names bury the semantics under implementation language. The following is a proposed renaming to be discussed and tracked — not yet agreed.
+
+### SDK public API
+
+| Current | Proposed | Why |
+| --- | --- | --- |
+| `AttentiveConfig.identify(userIdentifiers)` | `setUserIdentifiers(...)` or `addUserIdentifiers(...)` | "Identify" is overloaded jargon from other analytics SDKs (Segment, Amplitude, Mixpanel) and doesn't signal what it does. "Add" emphasizes the merge semantic. |
+| `AttentiveSdk.updateUser(email, phone)` | `loginUser(email, phone)` or `setCurrentUser(...)` | "Update" suggests modifying the existing user. This call *replaces* the user — new visitor ID, detaches token from prior user. "Login" captures the intent. |
+| `AttentiveSdk.clearUser()` | `logoutUser()` | "Clear" is vague. This is specifically a logout — it's the symmetric pair to `loginUser`. |
+| `AttentiveSdk.optUserIntoMarketingSubscription(...)` | `subscribe(email, phone)` or `subscribeToMarketing(...)` | Current name is five words for one concept. "Opt in to marketing subscription" reads as bureaucratic compliance language; "subscribe" is the verb the backend actually uses (`ACTION_TYPE_SUBSCRIBE`). |
+| `AttentiveSdk.optUserOutOfMarketingSubscription(...)` | `unsubscribe(email, phone)` | Same. |
+| `AttentiveSdk.updatePushPermissionStatus(context)` | `refreshPushPermission(context)` | "Update" makes it sound like you're *setting* the permission. You're not — you're re-registering so the backend learns what the OS now says. |
+| `AttentiveConfig.clearUser()` (deprecated) | delete | Already deprecated. Don't rename, just remove. |
+
+### Bonni settings labels
+
+The bonni debug screen currently mixes "action you're performing" with "field you're editing" in a confusing way. Proposed grouping:
+
+**Current user (edit-in-place fields):**
+
+- "Change current domain" → keep
+- "Change current email" → **"Email"** (it's just a field)
+- "Change current phone number" → **"Phone"**
+
+**User lifecycle actions:**
+
+- "Switch User with email" / "Switch User with phone" → **"Log in as different user"** (single button, uses whichever fields are populated)
+- "Identify User" → **"Attach identifiers to current user"** (or remove entirely — it does the same thing as editing the email/phone field above)
+- "Clear Users" → **"Log out"**
+
+**Marketing subscription:**
+
+- "Opt-In User email" / "Opt-In User Phone Number" → **"Subscribe email" / "Subscribe SMS"**
+- "Opt-Out User email" / "Opt-Out User Phone Number" → **"Unsubscribe email" / "Unsubscribe SMS"**
+
+### Things to flag before renaming
+
+1. **`identify()` is the oldest public API.** Renaming it is a breaking change. Would need a deprecation cycle: add `setUserIdentifiers()` that delegates to `identify()`, mark `identify()` deprecated, remove in a major version.
+2. **"Login/logout" vs. "update/clear" is opinionated.** `updateUser()` technically doesn't require a "login" concept — an app could call it to correct a typo'd email too. But the fact that it *resets the visitor ID* means it's semantically a login, even if you call it for other reasons. Worth discussing with the team.
+3. **Bonni's "Identify User" button currently does the same thing as saving the email field.** That's a UX bug, not a naming issue. Worth deleting that button entirely.
+4. **iOS SDK parity.** If the iOS SDK has matching names, renames should happen in both to keep the cross-platform surface consistent.

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -197,6 +197,7 @@ sequenceDiagram
 ## Known limitations / follow-ups
 
 - **[MSDK-345](https://attentivemobile.atlassian.net/browse/MSDK-345)** — `/user-update` requires a non-blank FCM push token or it is silently discarded. Affects `updateUser()` and `clearUser()` for apps without Firebase or with `pushEnabled = false`. Under review.
+  - For reference, the iOS SDK already handles the analogous tokenless case for `/opt-in-subscriptions` and `/opt-out-subscriptions` by **queueing the request in memory for up to 60 seconds** and flushing it as soon as a push token arrives (`ATTNSDK.swift:730–757`). If MSDK-345 lands as a client-side fix, the same queueing pattern is a natural template for Android and could also be extended to `/user-update` on both platforms.
 - **Deprecated `AttentiveConfig.clearUser()`** — will be removed in a future release. Use `AttentiveSdk.clearUser()`.
 
 ## Naming proposal

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -98,6 +98,8 @@ sequenceDiagram
 
 ### `AttentiveSdk.updateUser(email, phoneNumber)`
 
+**Also known as "switch user".** There is no separate `switchUser` SDK method — `updateUser()` is the call that performs a user switch. The bonni demo app exposes it as "Switch User with email" / "Switch User with phone".
+
 **Purpose:** Declare that the current device is now a different user (multi-user apps).
 
 **Fires:**


### PR DESCRIPTION
## Ticket
[MSDK-346](https://attentivemobile.atlassian.net/browse/MSDK-346)

## Summary
Add `docs/identity.md` (Android), `docs/identity-ios.md` (iOS companion), and `docs/identity-lifecycle.md` (Android lifecycle guide) describing the identity-related SDK methods: what each does locally, what HTTP request it fires, how the backend mutates identity state, and when integrators need to call each method manually vs. when the SDK fires it automatically.

Includes:
- Per-method breakdown: `identify`, `updateUser`, `clearUser`, `optIn/Out`, `updatePushPermissionStatus`
- Automatic lifecycle: foreground `/token` registration, `/mtctrl` launch tracking, FCM `onNewToken` rotation
- Mermaid sequence diagram for automatic vs. manual flows
- `identify()` vs. `updateUser()` comparison table
- Cross-platform divergence on `updateUser()` (Android fires both `/user-update` and `/e?t=idn`, iOS fires only `/user-update`)
- Naming proposal for the Android SDK public API and bonni debug labels
- Known limitations linking to MSDK-345 (tokenless `/user-update`)

## Related
- [MSDK-345](https://attentivemobile.atlassian.net/browse/MSDK-345) — Investigate backend support for tokenless `updateUser()`/`clearUser()` (referenced in the doc as a known limitation)
- [MSDK-343](https://attentivemobile.atlassian.net/browse/MSDK-343) — `pushEnabled` config flag (referenced in the doc)

## Test plan
- [ ] Verify all three docs render correctly on GitHub (including the Mermaid sequence diagram)
- [ ] Spot-check that the per-method "Fires" and "Backend effect" descriptions match the current code in `AttentiveSdk.kt`, `AttentiveConfig.kt`, and `AttentiveApi.kt`

Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-346]: https://attentivemobile.atlassian.net/browse/MSDK-346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MSDK-345]: https://attentivemobile.atlassian.net/browse/MSDK-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ