### PR TITLE
MSDK-340: Add KDoc to public SDK API

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApiCallback.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApiCallback.kt
@@ -5,15 +5,7 @@ package com.attentive.androidsdk
  * callback-based network code.
  */
 interface AttentiveApiCallback {
-    /**
-     * Invoked when the request failed.
-     *
-     * @param message A diagnostic message describing the failure, or `null`.
-     */
     fun onFailure(message: String?)
 
-    /**
-     * Invoked when the request succeeded.
-     */
     fun onSuccess()
 }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApiCallback.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApiCallback.kt
@@ -1,7 +1,19 @@
 package com.attentive.androidsdk
 
+/**
+ * Generic success/failure callback for internal Attentive API requests. Used by internal
+ * callback-based network code.
+ */
 interface AttentiveApiCallback {
+    /**
+     * Invoked when the request failed.
+     *
+     * @param message A diagnostic message describing the failure, or `null`.
+     */
     fun onFailure(message: String?)
 
+    /**
+     * Invoked when the request succeeded.
+     */
     fun onSuccess()
 }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveConfig.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveConfig.kt
@@ -219,64 +219,34 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
 
         internal var apiVersion: ApiVersion = ApiVersion.OLD
 
-        /**
-         * Sets the host application context used by the SDK for lifecycle observation,
-         * permission checks, and persistent storage. Required.
-         *
-         * @param context The host [Application] instance.
-         */
         fun applicationContext(context: Application) =
             apply {
                 ParameterValidation.verifyNotNull(context, "context")
                 _context = context
             }
 
-        /**
-         * Deprecated alias for [applicationContext]. Will be removed in a future release.
-         *
-         * @param context The host [Application] instance.
-         */
         @Deprecated("Use applicationContext() instead. This function will be removed in a future release.")
         fun context(context: Application) = apply {
             _context = context
         }
 
-        /**
-         * Sets the SDK runtime mode. Required.
-         *
-         * @param mode [Mode.PRODUCTION] for release builds, [Mode.DEBUG] for development.
-         */
         fun mode(mode: Mode) = apply {
             _mode = mode
         }
 
         /**
-         * Sets the Attentive domain. Required.
-         *
-         * @param domain Your Attentive domain (e.g. `"mybrand"`). Must not contain `attn.tv`,
-         *   `:`, or `/` — pass only the domain identifier, not a URL.
-         * @throws IllegalArgumentException if [domain] is empty or malformed.
+         * @throws IllegalArgumentException if [domain] is empty or contains `attn.tv`, `:`, or `/`.
          */
         fun domain(domain: String) = apply {
             domain.verifyValidAttentiveDomain()
             _domain = domain
         }
 
-        /**
-         * Sets the drawable resource used as the small icon for Attentive push notifications.
-         *
-         * @param notificationIconId A drawable resource ID. Default is `0` (no custom icon).
-         */
         fun notificationIconId(notificationIconId: Int) =
             apply {
                 _notificationIconId = notificationIconId
             }
 
-        /**
-         * Sets the background color used behind the notification small icon.
-         *
-         * @param colorResourceId A color resource ID. Default is `0` (no custom color).
-         */
         fun notificationIconBackgroundColor(
             @ColorRes colorResourceId: Int,
         ) = apply {
@@ -286,10 +256,7 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
         private val allowApiVersionOverride = false
 
         /**
-         * Overrides the event-API version. Internal/testing use only — the override is
-         * currently gated behind a private flag and is a no-op for integrators.
-         *
-         * @param apiVersion The [ApiVersion] to use.
+         * Currently a no-op for integrators — the override is gated behind a private flag.
          */
         fun apiVersion(apiVersion: ApiVersion) =
             apply {
@@ -299,41 +266,21 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
             }
 
 
-        /**
-         * Supplies a custom [OkHttpClient] for the SDK's HTTP traffic. Optional — the SDK
-         * constructs a default client if none is provided.
-         *
-         * @param okHttpClient A pre-configured [OkHttpClient].
-         */
         fun okHttpClient(okHttpClient: OkHttpClient) = apply {
             this.okHttpClient = okHttpClient
         }
 
-        /**
-         * Controls whether creatives bypass frequency-capping / fatigue rules. Useful for
-         * internal testing apps that want to display creatives on demand.
-         *
-         * @param skipFatigueOnCreatives `true` to skip fatigue checks, `false` (default) to respect them.
-         */
         fun skipFatigueOnCreatives(skipFatigueOnCreatives: Boolean) =
             apply {
                 this.skipFatigueOnCreatives = skipFatigueOnCreatives
             }
 
-        /**
-         * Sets the SDK log level. Default is [AttentiveLogLevel.STANDARD].
-         *
-         * @param logLevel The [AttentiveLogLevel] to use.
-         */
         fun logLevel(logLevel: AttentiveLogLevel) =
             apply {
                 this.logLevel = logLevel
             }
 
         /**
-         * Builds the configured [AttentiveConfig].
-         *
-         * @return A new [AttentiveConfig] instance.
          * @throws IllegalStateException if [applicationContext], [mode], or [domain] was not set.
          */
         fun build(): AttentiveConfig {

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveConfig.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveConfig.kt
@@ -11,6 +11,15 @@ import com.attentive.androidsdk.internal.util.VerboseTree
 import okhttp3.OkHttpClient
 import timber.log.Timber
 
+/**
+ * SDK-wide configuration created via [Builder] and passed to [AttentiveSdk.initialize].
+ *
+ * Holds the Attentive domain, runtime mode, notification styling, log level, and the
+ * current [UserIdentifiers]. Exactly one instance should exist per process. Construct
+ * with [Builder] and hand it to [AttentiveSdk.initialize] during `Application.onCreate()`.
+ *
+ * On construction the SDK fires an `InfoEvent` to the Attentive backend as a ping.
+ */
 class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInterface {
     override val mode = builder._mode
     override var domain: String = builder._domain
@@ -48,16 +57,41 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
         sendInfoEvent()
     }
 
+    /**
+     * Whether creatives should bypass frequency-capping / fatigue rules.
+     *
+     * @return `true` if fatigue is skipped for creatives, `false` otherwise.
+     */
     override fun skipFatigueOnCreatives(): Boolean {
         return skipFatigueOnCreatives
     }
 
+    /**
+     * Associates a client-provided user ID with the current visitor.
+     *
+     * Merges a new [UserIdentifiers] containing the given [clientUserId] into the existing
+     * identifiers. Use this when you know the user's account ID in your own system.
+     *
+     * @param clientUserId The user's ID in your system. Must not be empty.
+     * @throws IllegalArgumentException if [clientUserId] is empty.
+     */
     override fun identify(clientUserId: String) {
         Timber.i("identify called with clientUserId: %s", clientUserId)
         ParameterValidation.verifyNotEmpty(clientUserId, "clientUserId")
         identify(UserIdentifiers.Builder().withClientUserId(clientUserId).build())
     }
 
+    /**
+     * Merges the given identifiers into the current visitor and notifies the backend.
+     *
+     * Does not change the visitor ID. Identifiers accumulate across calls — the second
+     * overwrites the first only for fields it explicitly sets. Fires `POST /e?t=idn` to
+     * the Attentive backend.
+     *
+     * Call this whenever you learn more about the user (email, phone, vendor IDs).
+     *
+     * @param userIdentifiers The identifiers to merge into the current visitor.
+     */
     override fun identify(userIdentifiers: UserIdentifiers) {
         this.userIdentifiers = UserIdentifiers.merge(this.userIdentifiers, userIdentifiers)
         Timber.i("identify called with userIdentifiers: %s", this.userIdentifiers)
@@ -70,6 +104,13 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
         userIdentifiers = UserIdentifiers.Builder().withVisitorId(newVisitorId).build()
     }
 
+    /**
+     * Clears local user identifiers and generates a new visitor ID.
+     *
+     * Does **not** notify the backend — the push token remains associated with the prior
+     * user server-side. For a full logout that detaches the push token on the backend, use
+     * [AttentiveSdk.clearUser] instead.
+     */
     @Deprecated(
         message = "Use AttentiveSdk.clearUser() instead. It properly detaches the push token from the logged-out user.",
         replaceWith = ReplaceWith("AttentiveSdk.clearUser()")
@@ -79,6 +120,12 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
         resetIdentifiers()
     }
 
+    /**
+     * Changes the Attentive domain at runtime. Fires a fresh `InfoEvent` if the domain changed.
+     *
+     * @param domain The new Attentive domain. Must pass the standard domain validation
+     *   (no `attn.tv`, no colons, no slashes).
+     */
     override fun changeDomain(domain: String) {
         domain.verifyValidAttentiveDomain()
         if (domain != this.domain) {
@@ -87,6 +134,11 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
         }
     }
 
+    /**
+     * Changes the event-API version at runtime. Debug/testing use.
+     *
+     * @param apiVersion The new [ApiVersion] to use for subsequent event requests.
+     */
     fun changeApiVersion(apiVersion: ApiVersion) {
         Timber.d("Changing API version from ${this@AttentiveConfig.apiVersion} to $apiVersion")
         this@AttentiveConfig.apiVersion = apiVersion
@@ -140,6 +192,20 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
         }
     }
 
+    /**
+     * Builder for [AttentiveConfig]. Required fields: [applicationContext], [mode], [domain].
+     * All other fields are optional.
+     *
+     * Example:
+     * ```
+     * val config = AttentiveConfig.Builder()
+     *     .applicationContext(application)
+     *     .mode(AttentiveConfig.Mode.PRODUCTION)
+     *     .domain("mybrand")
+     *     .build()
+     * AttentiveSdk.initialize(config)
+     * ```
+     */
     class Builder {
         internal lateinit var _context: Application
         internal lateinit var _mode: Mode
@@ -153,31 +219,64 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
 
         internal var apiVersion: ApiVersion = ApiVersion.OLD
 
+        /**
+         * Sets the host application context used by the SDK for lifecycle observation,
+         * permission checks, and persistent storage. Required.
+         *
+         * @param context The host [Application] instance.
+         */
         fun applicationContext(context: Application) =
             apply {
                 ParameterValidation.verifyNotNull(context, "context")
                 _context = context
             }
 
+        /**
+         * Deprecated alias for [applicationContext]. Will be removed in a future release.
+         *
+         * @param context The host [Application] instance.
+         */
         @Deprecated("Use applicationContext() instead. This function will be removed in a future release.")
         fun context(context: Application) = apply {
             _context = context
         }
 
+        /**
+         * Sets the SDK runtime mode. Required.
+         *
+         * @param mode [Mode.PRODUCTION] for release builds, [Mode.DEBUG] for development.
+         */
         fun mode(mode: Mode) = apply {
             _mode = mode
         }
 
+        /**
+         * Sets the Attentive domain. Required.
+         *
+         * @param domain Your Attentive domain (e.g. `"mybrand"`). Must not contain `attn.tv`,
+         *   `:`, or `/` — pass only the domain identifier, not a URL.
+         * @throws IllegalArgumentException if [domain] is empty or malformed.
+         */
         fun domain(domain: String) = apply {
             domain.verifyValidAttentiveDomain()
             _domain = domain
         }
 
+        /**
+         * Sets the drawable resource used as the small icon for Attentive push notifications.
+         *
+         * @param notificationIconId A drawable resource ID. Default is `0` (no custom icon).
+         */
         fun notificationIconId(notificationIconId: Int) =
             apply {
                 _notificationIconId = notificationIconId
             }
 
+        /**
+         * Sets the background color used behind the notification small icon.
+         *
+         * @param colorResourceId A color resource ID. Default is `0` (no custom color).
+         */
         fun notificationIconBackgroundColor(
             @ColorRes colorResourceId: Int,
         ) = apply {
@@ -186,6 +285,12 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
 
         private val allowApiVersionOverride = false
 
+        /**
+         * Overrides the event-API version. Internal/testing use only — the override is
+         * currently gated behind a private flag and is a no-op for integrators.
+         *
+         * @param apiVersion The [ApiVersion] to use.
+         */
         fun apiVersion(apiVersion: ApiVersion) =
             apply {
                 if (allowApiVersionOverride) {
@@ -194,20 +299,43 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
             }
 
 
+        /**
+         * Supplies a custom [OkHttpClient] for the SDK's HTTP traffic. Optional — the SDK
+         * constructs a default client if none is provided.
+         *
+         * @param okHttpClient A pre-configured [OkHttpClient].
+         */
         fun okHttpClient(okHttpClient: OkHttpClient) = apply {
             this.okHttpClient = okHttpClient
         }
 
+        /**
+         * Controls whether creatives bypass frequency-capping / fatigue rules. Useful for
+         * internal testing apps that want to display creatives on demand.
+         *
+         * @param skipFatigueOnCreatives `true` to skip fatigue checks, `false` (default) to respect them.
+         */
         fun skipFatigueOnCreatives(skipFatigueOnCreatives: Boolean) =
             apply {
                 this.skipFatigueOnCreatives = skipFatigueOnCreatives
             }
 
+        /**
+         * Sets the SDK log level. Default is [AttentiveLogLevel.STANDARD].
+         *
+         * @param logLevel The [AttentiveLogLevel] to use.
+         */
         fun logLevel(logLevel: AttentiveLogLevel) =
             apply {
                 this.logLevel = logLevel
             }
 
+        /**
+         * Builds the configured [AttentiveConfig].
+         *
+         * @return A new [AttentiveConfig] instance.
+         * @throws IllegalStateException if [applicationContext], [mode], or [domain] was not set.
+         */
         fun build(): AttentiveConfig {
             if (this::_context.isInitialized.not()) {
                 throw IllegalStateException("A valid context must be provided.")
@@ -228,8 +356,14 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
     }
 
 
+    /**
+     * SDK runtime mode.
+     */
     enum class Mode {
+        /** Debug mode — verbose logging by default, intended for development. */
         DEBUG,
+
+        /** Production mode — standard logging, intended for release builds. */
         PRODUCTION,
     }
 }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveConfigInterface.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveConfigInterface.kt
@@ -2,22 +2,59 @@ package com.attentive.androidsdk
 
 import android.app.Application
 
+/**
+ * Public contract exposed by [AttentiveConfig]. Exists primarily so tests and alternate
+ * implementations can substitute for the real config.
+ */
 interface AttentiveConfigInterface {
+    /** The configured SDK runtime mode. */
     val mode: AttentiveConfig.Mode
+
+    /** The configured Attentive domain. */
     val domain: String
+
+    /** The current [UserIdentifiers] attached to this visitor. */
     var userIdentifiers: UserIdentifiers
+
+    /** The host [Application] context. */
     val applicationContext: Application
+
+    /** Drawable resource ID for the notification small icon. `0` means none. */
     var notificationIconId: Int
+
+    /** Color resource ID for the notification icon background. `0` means none. */
     var notificationIconBackgroundColorResource: Int
+
+    /** Current log level, or `null` to use the SDK default. */
     var logLevel: AttentiveLogLevel?
 
+    /** @return `true` if creatives should bypass frequency-capping / fatigue rules. */
     fun skipFatigueOnCreatives(): Boolean
 
+    /**
+     * Associates a client-provided user ID with the current visitor.
+     *
+     * @param clientUserId Non-empty user ID from the host app's system.
+     */
     fun identify(clientUserId: String)
 
+    /**
+     * Merges the given identifiers into the current visitor and notifies the backend.
+     *
+     * @param userIdentifiers Identifiers to merge.
+     */
     fun identify(userIdentifiers: UserIdentifiers)
 
+    /**
+     * Clears local user identifiers. See [AttentiveConfig.clearUser] for deprecation details —
+     * prefer [com.attentive.androidsdk.AttentiveSdk.clearUser] for full-logout semantics.
+     */
     fun clearUser()
 
+    /**
+     * Changes the Attentive domain at runtime.
+     *
+     * @param domain The new domain.
+     */
     fun changeDomain(domain: String)
 }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveConfigInterface.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveConfigInterface.kt
@@ -7,54 +7,25 @@ import android.app.Application
  * implementations can substitute for the real config.
  */
 interface AttentiveConfigInterface {
-    /** The configured SDK runtime mode. */
     val mode: AttentiveConfig.Mode
-
-    /** The configured Attentive domain. */
     val domain: String
-
-    /** The current [UserIdentifiers] attached to this visitor. */
     var userIdentifiers: UserIdentifiers
-
-    /** The host [Application] context. */
     val applicationContext: Application
-
-    /** Drawable resource ID for the notification small icon. `0` means none. */
     var notificationIconId: Int
-
-    /** Color resource ID for the notification icon background. `0` means none. */
     var notificationIconBackgroundColorResource: Int
-
-    /** Current log level, or `null` to use the SDK default. */
     var logLevel: AttentiveLogLevel?
 
-    /** @return `true` if creatives should bypass frequency-capping / fatigue rules. */
     fun skipFatigueOnCreatives(): Boolean
 
-    /**
-     * Associates a client-provided user ID with the current visitor.
-     *
-     * @param clientUserId Non-empty user ID from the host app's system.
-     */
     fun identify(clientUserId: String)
 
-    /**
-     * Merges the given identifiers into the current visitor and notifies the backend.
-     *
-     * @param userIdentifiers Identifiers to merge.
-     */
     fun identify(userIdentifiers: UserIdentifiers)
 
     /**
-     * Clears local user identifiers. See [AttentiveConfig.clearUser] for deprecation details —
-     * prefer [com.attentive.androidsdk.AttentiveSdk.clearUser] for full-logout semantics.
+     * Clears local user identifiers only. For full-logout semantics (including detaching the
+     * push token on the backend), prefer [com.attentive.androidsdk.AttentiveSdk.clearUser].
      */
     fun clearUser()
 
-    /**
-     * Changes the Attentive domain at runtime.
-     *
-     * @param domain The new domain.
-     */
     fun changeDomain(domain: String)
 }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveLogLevel.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveLogLevel.kt
@@ -1,11 +1,25 @@
 package com.attentive.androidsdk
 
+/**
+ * Log level for the Attentive SDK's Timber tree.
+ *
+ * @property id A stable numeric identifier, used for persisting the log level in SharedPreferences.
+ */
 enum class AttentiveLogLevel(val id: Int) {
+    /** All SDK logs, including debug and verbose messages. */
     VERBOSE(1),
+
+    /** Default log level — info, warnings, and errors only. */
     STANDARD(2),
     ;
 
     companion object {
+        /**
+         * Looks up an [AttentiveLogLevel] by its persistent [id].
+         *
+         * @param logLevelId The [id] value previously returned from this enum.
+         * @return The matching [AttentiveLogLevel], or `null` if no level matches [logLevelId].
+         */
         fun fromId(logLevelId: Int): AttentiveLogLevel? {
             val values = entries.toTypedArray()
             for (value in values) {

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -276,8 +276,9 @@ object AttentiveSdk {
      * Opts the user into Attentive marketing subscriptions on email and/or SMS.
      *
      * Unlike [updateUser] and [clearUser], this call does not change the visitor ID. It
-     * creates a subscription record on the backend idempotently. At least one of [email]
-     * or [phoneNumber] must be provided.
+     * creates a subscription record on the backend; repeated calls with the same email or
+     * phone are safe and will not create duplicates. At least one of [email] or [phoneNumber]
+     * must be provided.
      *
      * @param email The user's email address. Optional if [phoneNumber] is provided.
      * @param phoneNumber The user's phone number in E.164 format. Optional if [email] is provided.
@@ -296,7 +297,8 @@ object AttentiveSdk {
     /**
      * Opts the user out of Attentive marketing subscriptions on email and/or SMS.
      *
-     * Idempotent. At least one of [email] or [phoneNumber] must be provided.
+     * Safe to call repeatedly with the same identifier. At least one of [email] or
+     * [phoneNumber] must be provided.
      *
      * @param email The user's email address. Optional if [phoneNumber] is provided.
      * @param phoneNumber The user's phone number in E.164 format. Optional if [email] is provided.

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -234,12 +234,28 @@ object AttentiveSdk {
         }
     }
 
+    /**
+     * Records an analytics event with Attentive.
+     *
+     * Fire-and-forget: errors are logged but not surfaced to the caller. For coroutine-aware
+     * error handling, use [AttentiveEventTracker.instance] APIs directly.
+     *
+     * @param event The [Event] to record (e.g. [com.attentive.androidsdk.events.ProductViewEvent],
+     *   [com.attentive.androidsdk.events.AddToCartEvent], [com.attentive.androidsdk.events.PurchaseEvent]).
+     */
     fun recordEvent(event: Event) {
         AttentiveEventTracker.instance.recordEvent(event)
     }
 
     /**
-     * Determines whether the given Firebase RemoteMessage is from Attentive.
+     * Determines whether the given Firebase [RemoteMessage] was sent by Attentive.
+     *
+     * Use this in your [com.google.firebase.messaging.FirebaseMessagingService.onMessageReceived]
+     * implementation to route Attentive messages to [sendNotification] while leaving other
+     * push messages to your own handling.
+     *
+     * @param remoteMessage The message received from Firebase Cloud Messaging.
+     * @return `true` if the message originated from Attentive, `false` otherwise.
      */
     fun isAttentiveFirebaseMessage(remoteMessage: RemoteMessage): Boolean {
         Timber.d(
@@ -256,6 +272,16 @@ object AttentiveSdk {
         return isAttentiveMessage
     }
 
+    /**
+     * Opts the user into Attentive marketing subscriptions on email and/or SMS.
+     *
+     * Unlike [updateUser] and [clearUser], this call does not change the visitor ID. It
+     * creates a subscription record on the backend idempotently. At least one of [email]
+     * or [phoneNumber] must be provided.
+     *
+     * @param email The user's email address. Optional if [phoneNumber] is provided.
+     * @param phoneNumber The user's phone number in E.164 format. Optional if [email] is provided.
+     */
     suspend fun optUserIntoMarketingSubscription(
         email: String = "",
         phoneNumber: String = "",
@@ -267,6 +293,14 @@ object AttentiveSdk {
         AttentiveEventTracker.instance.optIn(email, phoneNumber)
     }
 
+    /**
+     * Opts the user out of Attentive marketing subscriptions on email and/or SMS.
+     *
+     * Idempotent. At least one of [email] or [phoneNumber] must be provided.
+     *
+     * @param email The user's email address. Optional if [phoneNumber] is provided.
+     * @param phoneNumber The user's phone number in E.164 format. Optional if [email] is provided.
+     */
     suspend fun optUserOutOfMarketingSubscription(
         email: String = "",
         phoneNumber: String = "",
@@ -278,7 +312,12 @@ object AttentiveSdk {
     }
 
     /**
-     * Forwards a push message to the SDK to display the notification.
+     * Forwards an Attentive push message to the SDK to build and display the notification.
+     *
+     * Typically called from your [com.google.firebase.messaging.FirebaseMessagingService.onMessageReceived]
+     * after [isAttentiveFirebaseMessage] returns `true`.
+     *
+     * @param remoteMessage The Attentive push message received from Firebase Cloud Messaging.
      */
     fun sendNotification(remoteMessage: RemoteMessage) {
         AttentivePush.getInstance().sendNotification(remoteMessage)
@@ -302,7 +341,13 @@ object AttentiveSdk {
     }
 
     /**
-     * Fetches the push token from Firebase, requesting permission if needed.
+     * Fetches the current FCM push token, optionally prompting the user for notification
+     * permission first.
+     *
+     * @param application The application context, used to request permission if needed.
+     * @param requestPermission If `true`, prompts the user for `POST_NOTIFICATIONS` permission
+     *   on Android 13+ before fetching the token. If `false`, fetches without prompting.
+     * @return A [Result] wrapping a [TokenFetchResult] on success, or an exception on failure.
      */
     suspend fun getPushToken(
         application: Application,
@@ -311,8 +356,14 @@ object AttentiveSdk {
         return AttentivePush.getInstance().fetchPushToken(application, requestPermission)
     }
 
-    /***
-     * Does the same as [getPushToken] but uses a callback instead of coroutines for Java interop.
+    /**
+     * Callback-based variant of [getPushToken] for Java interop.
+     *
+     * @param application The application context.
+     * @param requestPermission If `true`, prompts the user for `POST_NOTIFICATIONS` permission
+     *   on Android 13+ before fetching the token.
+     * @param callback Invoked on success with the [TokenFetchResult], or on failure with the
+     *   thrown exception.
      */
     @JvmStatic
     fun getPushTokenWithCallback(
@@ -339,6 +390,26 @@ object AttentiveSdk {
         }
     }
 
+    /**
+     * Switches the current device identity to a different user.
+     *
+     * Semantically this is a "login as different user" operation (Bonni surfaces it as
+     * "Switch User with email/phone"). The SDK will:
+     *
+     * 1. Reset local identifiers and generate a new visitor ID.
+     * 2. Fire `POST /user-update` with the new visitor ID + push token + email/phone, which
+     *    detaches the push token from the prior user and re-associates it with the new user.
+     * 3. Fire `POST /e?t=idn` (identity event) merging the new email/phone into the new visitor.
+     *
+     * At least one of [email] or [phoneNumber] must be non-null and non-blank after validation.
+     * Invalid phone numbers are dropped.
+     *
+     * **Requires an FCM push token** — if none is available, the network call is skipped
+     * (see [MSDK-345](https://attentivemobile.atlassian.net/browse/MSDK-345)).
+     *
+     * @param email The new user's email address, or `null`.
+     * @param phoneNumber The new user's phone number in E.164 format, or `null`.
+     */
     fun updateUser(email: String? = null, phoneNumber: String? = null) {
         val trimmedEmail = email?.trim()?.ifBlank { null }
         val trimmedPhone = phoneNumber?.trim()?.ifBlank { null }
@@ -375,6 +446,25 @@ object AttentiveSdk {
     }
 
 
+    /**
+     * Logs the current user out. Resets local visitor identity and tells the backend to
+     * detach the push token from the prior user.
+     *
+     * The SDK will:
+     * 1. Reset local identifiers and generate a new visitor ID.
+     * 2. Fire `POST /user-update` with empty metadata, which detaches the push token from
+     *    the previous user and re-associates it with the new anonymous visitor.
+     *
+     * **Strongly recommended on logout.** Without this, the push token remains associated
+     * with the logged-out user on the backend, and they may continue to receive targeted
+     * marketing on this device.
+     *
+     * **Requires an FCM push token** — if none is available, the network call is skipped
+     * (see [MSDK-345](https://attentivemobile.atlassian.net/browse/MSDK-345)).
+     *
+     * **Prefer this over the deprecated `AttentiveConfig.clearUser()`**, which only clears
+     * local state without notifying the backend.
+     */
     fun clearUser() {
         config.resetIdentifiers()
         val domain = config.domain
@@ -389,16 +479,44 @@ object AttentiveSdk {
         }
     }
 
+    /**
+     * Callback interface for [getPushTokenWithCallback] (Java interop).
+     */
     interface PushTokenCallback {
+        /**
+         * Invoked when the push token has been successfully fetched.
+         *
+         * @param result The [TokenFetchResult] containing the fetched token and permission state.
+         */
         fun onSuccess(result: TokenFetchResult)
 
+        /**
+         * Invoked when fetching the push token fails.
+         *
+         * @param exception The exception thrown while fetching the token.
+         */
         fun onFailure(exception: Exception)
     }
 
+    /**
+     * Checks whether the user has granted notification permission to the app.
+     *
+     * @param context A context used to query permission state.
+     * @return `true` if notifications are permitted, `false` otherwise.
+     */
     fun isPushPermissionGranted(context: Context): Boolean {
         return AttentivePush.getInstance().checkPushPermission(context)
     }
 
+    /**
+     * Re-registers the current push token with Attentive to reflect the latest permission state.
+     *
+     * Call this after the user changes notification permission (e.g., returning from system
+     * settings). This is also called automatically when the app is brought to the foreground,
+     * so manual invocation is only needed when you want immediate sync.
+     *
+     * @param context A context used to register the push token.
+     */
     fun updatePushPermissionStatus(context: Context) {
         CoroutineScope(Dispatchers.IO).launch {
             AttentiveEventTracker.instance.registerPushToken(context)

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -483,18 +483,8 @@ object AttentiveSdk {
      * Callback interface for [getPushTokenWithCallback] (Java interop).
      */
     interface PushTokenCallback {
-        /**
-         * Invoked when the push token has been successfully fetched.
-         *
-         * @param result The [TokenFetchResult] containing the fetched token and permission state.
-         */
         fun onSuccess(result: TokenFetchResult)
 
-        /**
-         * Invoked when fetching the push token fails.
-         *
-         * @param exception The exception thrown while fetching the token.
-         */
         fun onFailure(exception: Exception)
     }
 

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/UserIdentifiers.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/UserIdentifiers.kt
@@ -45,10 +45,7 @@ data class UserIdentifiers(
         private var customIdentifiers: Map<String, String> = emptyMap()
 
         /**
-         * Sets the device-scoped anonymous visitor ID. Typically only used internally —
-         * the SDK generates and manages the visitor ID automatically.
-         *
-         * @param visitorId The visitor ID.
+         * Typically only used internally — the SDK generates and manages the visitor ID automatically.
          */
         fun withVisitorId(visitorId: String): Builder =
             apply {
@@ -56,80 +53,41 @@ data class UserIdentifiers(
                 this.visitorId = visitorId
             }
 
-        /**
-         * Sets the user's ID in your own system.
-         *
-         * @param clientUserId A non-empty identifier from your backend.
-         * @throws IllegalArgumentException if [clientUserId] is empty.
-         */
         fun withClientUserId(clientUserId: String): Builder =
             apply {
                 ParameterValidation.verifyNotEmpty(clientUserId, "clientUserId")
                 this.clientUserId = clientUserId
             }
 
-        /**
-         * Sets the user's phone number.
-         *
-         * @param phone The phone number in E.164 format (e.g. `"+15551234567"`).
-         */
+        /** @param phone E.164 format (e.g. `"+15551234567"`). */
         fun withPhone(phone: String): Builder =
             apply {
                 this.phone = phone
             }
 
-        /**
-         * Sets the user's email address.
-         *
-         * @param email The email address.
-         */
         fun withEmail(email: String): Builder =
             apply {
                 this.email = email
             }
 
-        /**
-         * Sets the user's Shopify customer ID.
-         *
-         * @param shopifyId A non-empty Shopify customer ID.
-         * @throws IllegalArgumentException if [shopifyId] is empty.
-         */
         fun withShopifyId(shopifyId: String): Builder =
             apply {
                 ParameterValidation.verifyNotEmpty(shopifyId, "shopifyId")
                 this.shopifyId = shopifyId
             }
 
-        /**
-         * Sets the user's Klaviyo profile ID.
-         *
-         * @param klaviyoId A non-empty Klaviyo ID.
-         * @throws IllegalArgumentException if [klaviyoId] is empty.
-         */
         fun withKlaviyoId(klaviyoId: String): Builder =
             apply {
                 ParameterValidation.verifyNotEmpty(klaviyoId, "klaviyoId")
                 this.klaviyoId = klaviyoId
             }
 
-        /**
-         * Sets additional custom identifiers (vendor IDs, etc.) keyed by identifier name.
-         *
-         * The map is defensively copied to preserve immutability.
-         *
-         * @param customIdentifiers A map of identifier name to value.
-         */
         fun withCustomIdentifiers(customIdentifiers: Map<String, String>): Builder =
             apply {
                 ParameterValidation.verifyNotNull(customIdentifiers, "customIdentifiers")
                 this.customIdentifiers = customIdentifiers.toMap() // Ensures immutability
             }
 
-        /**
-         * Builds the configured [UserIdentifiers].
-         *
-         * @return A new immutable [UserIdentifiers] instance.
-         */
         fun build(): UserIdentifiers =
             UserIdentifiers(
                 visitorId,

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/UserIdentifiers.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/UserIdentifiers.kt
@@ -2,6 +2,25 @@ package com.attentive.androidsdk
 
 import kotlinx.serialization.Serializable
 
+/**
+ * A set of identifiers describing a single user on this device.
+ *
+ * Held on [AttentiveConfig.userIdentifiers] and passed to [AttentiveConfigInterface.identify]
+ * to associate contact info and vendor IDs with the current visitor. All fields are optional
+ * except that a visitor must have a [visitorId] — the SDK generates one automatically on
+ * first launch.
+ *
+ * Instances are immutable; use [Builder] to construct and [merge] to combine.
+ *
+ * @property visitorId The auto-generated, device-scoped anonymous ID. Persists in
+ *   SharedPreferences and is regenerated on logout or user switch.
+ * @property clientUserId The user's ID in your own system. Optional.
+ * @property phone The user's phone number in E.164 format. Optional.
+ * @property email The user's email address. Optional.
+ * @property shopifyId The user's Shopify customer ID. Optional.
+ * @property klaviyoId The user's Klaviyo profile ID. Optional.
+ * @property customIdentifiers Additional vendor or custom IDs keyed by an identifier name.
+ */
 @Serializable
 data class UserIdentifiers(
     val visitorId: String? = null,
@@ -12,6 +31,9 @@ data class UserIdentifiers(
     val klaviyoId: String? = null,
     val customIdentifiers: Map<String, String> = emptyMap(),
 ) {
+    /**
+     * Fluent builder for [UserIdentifiers]. All fields are optional.
+     */
     @Serializable
     class Builder {
         private var visitorId: String? = null
@@ -22,46 +44,92 @@ data class UserIdentifiers(
         private var klaviyoId: String? = null
         private var customIdentifiers: Map<String, String> = emptyMap()
 
+        /**
+         * Sets the device-scoped anonymous visitor ID. Typically only used internally —
+         * the SDK generates and manages the visitor ID automatically.
+         *
+         * @param visitorId The visitor ID.
+         */
         fun withVisitorId(visitorId: String): Builder =
             apply {
                 ParameterValidation.verifyNotNull(visitorId, "visitorId")
                 this.visitorId = visitorId
             }
 
+        /**
+         * Sets the user's ID in your own system.
+         *
+         * @param clientUserId A non-empty identifier from your backend.
+         * @throws IllegalArgumentException if [clientUserId] is empty.
+         */
         fun withClientUserId(clientUserId: String): Builder =
             apply {
                 ParameterValidation.verifyNotEmpty(clientUserId, "clientUserId")
                 this.clientUserId = clientUserId
             }
 
+        /**
+         * Sets the user's phone number.
+         *
+         * @param phone The phone number in E.164 format (e.g. `"+15551234567"`).
+         */
         fun withPhone(phone: String): Builder =
             apply {
                 this.phone = phone
             }
 
+        /**
+         * Sets the user's email address.
+         *
+         * @param email The email address.
+         */
         fun withEmail(email: String): Builder =
             apply {
                 this.email = email
             }
 
+        /**
+         * Sets the user's Shopify customer ID.
+         *
+         * @param shopifyId A non-empty Shopify customer ID.
+         * @throws IllegalArgumentException if [shopifyId] is empty.
+         */
         fun withShopifyId(shopifyId: String): Builder =
             apply {
                 ParameterValidation.verifyNotEmpty(shopifyId, "shopifyId")
                 this.shopifyId = shopifyId
             }
 
+        /**
+         * Sets the user's Klaviyo profile ID.
+         *
+         * @param klaviyoId A non-empty Klaviyo ID.
+         * @throws IllegalArgumentException if [klaviyoId] is empty.
+         */
         fun withKlaviyoId(klaviyoId: String): Builder =
             apply {
                 ParameterValidation.verifyNotEmpty(klaviyoId, "klaviyoId")
                 this.klaviyoId = klaviyoId
             }
 
+        /**
+         * Sets additional custom identifiers (vendor IDs, etc.) keyed by identifier name.
+         *
+         * The map is defensively copied to preserve immutability.
+         *
+         * @param customIdentifiers A map of identifier name to value.
+         */
         fun withCustomIdentifiers(customIdentifiers: Map<String, String>): Builder =
             apply {
                 ParameterValidation.verifyNotNull(customIdentifiers, "customIdentifiers")
                 this.customIdentifiers = customIdentifiers.toMap() // Ensures immutability
             }
 
+        /**
+         * Builds the configured [UserIdentifiers].
+         *
+         * @return A new immutable [UserIdentifiers] instance.
+         */
         fun build(): UserIdentifiers =
             UserIdentifiers(
                 visitorId,
@@ -75,6 +143,16 @@ data class UserIdentifiers(
     }
 
     companion object {
+        /**
+         * Merges two [UserIdentifiers], with [second] taking precedence on conflict.
+         *
+         * For each field: if [second] has a value it's used, otherwise [first]'s value is used.
+         * Custom identifiers are combined (second's entries override first's for matching keys).
+         *
+         * @param first The base identifiers.
+         * @param second The override identifiers.
+         * @return A new [UserIdentifiers] with merged values.
+         */
         fun merge(
             first: UserIdentifiers,
             second: UserIdentifiers,

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/creatives/Creative.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/creatives/Creative.kt
@@ -33,6 +33,19 @@ import timber.log.Timber
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 
+/**
+ * Displays and controls an Attentive creative (a webview-based UI served from
+ * `creatives.attn.tv`). Host a single [Creative] per [parentView] and call [trigger] to
+ * display it.
+ *
+ * The creative lifecycle:
+ * 1. Instantiate — a hidden [WebView] is created and attached to [parentView].
+ * 2. Call [trigger] — the URL is loaded; [CreativeTriggerCallback.onOpen] fires when the
+ *    creative has rendered, or [CreativeTriggerCallback.onCreativeNotOpened] if it fails.
+ * 3. The user interacts or closes — [CreativeTriggerCallback.onClose] fires.
+ * 4. [destroy] — cleans up the [WebView]. On Android Q+ this is called automatically when
+ *    the host activity is destroyed; on older versions you must call it manually.
+ */
 class Creative internal constructor(
     private var attentiveConfig: AttentiveConfig,
     private var parentView: View,
@@ -175,9 +188,15 @@ class Creative internal constructor(
     }
 
     /**
-     * Triggers to show the creative.
-     * @param callback [CreativeTriggerCallback] to be called when the creative updates it's state.
-     * @param creativeId The creative ID to use. If not provided it will render the creative determined by online configuration.
+     * Triggers the creative to load and display.
+     *
+     * Safe to call before the underlying [WebView] has finished initializing — the trigger
+     * will be queued and fired once it's ready. Calling this on a destroyed [Creative] is a
+     * no-op; [CreativeTriggerCallback.onCreativeNotOpened] is invoked.
+     *
+     * @param callback [CreativeTriggerCallback] to observe open/close state changes.
+     * @param creativeId Optional creative ID to render a specific creative. If `null`, the
+     *   creative served by the online configuration is used.
      */
     fun trigger(
         callback: CreativeTriggerCallback? = null,

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/creatives/CreativeTriggerCallback.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/creatives/CreativeTriggerCallback.kt
@@ -1,17 +1,30 @@
 package com.attentive.androidsdk.creatives
 
+/**
+ * Callback for [Creative.trigger] lifecycle events. Implement any subset of methods you care
+ * about — all defaults are no-ops.
+ */
 interface CreativeTriggerCallback {
-    // Called when the Creative has been triggered but it is not opened successfully.
-    // This can happen if there is no available mobile app creative, if the creative is fatigued,
-    // if the creative call has been timed out, or if an unknown exception occurs.
+    /**
+     * Invoked when [Creative.trigger] was called but the creative did not open successfully.
+     * This can happen if no creative is configured for the app, the creative was fatigued,
+     * the load timed out (5 seconds), or an unknown exception occurred.
+     */
     fun onCreativeNotOpened() {}
 
-    // Called when the Creative is opened successfully
+    /**
+     * Invoked when the creative has opened and is visible to the user.
+     */
     fun onOpen() {}
 
-    // Called when the creative is not closed successfully due to an unknown exception
+    /**
+     * Invoked when the creative did not close successfully (e.g. [WebView] was null at
+     * close time).
+     */
     fun onCreativeNotClosed() {}
 
-    // Called when the Creative is closed successfully
+    /**
+     * Invoked when the creative has closed successfully.
+     */
     fun onClose() {}
 }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/AddToCartEvent.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/AddToCartEvent.kt
@@ -3,6 +3,13 @@ package com.attentive.androidsdk.events
 import com.attentive.androidsdk.ParameterValidation
 import kotlinx.serialization.Serializable
 
+/**
+ * An add-to-cart event. Fires when a user adds one or more items to their cart.
+ *
+ * @property items The items added to the cart. Must be non-empty.
+ * @property deeplink Optional deeplink associated with the event. Propagated to the backend
+ *   so campaigns can re-target the user with the same URL.
+ */
 @Serializable
 data class AddToCartEvent(
     val items: List<Item>,
@@ -13,6 +20,11 @@ data class AddToCartEvent(
     }
 
     companion object {
+        /**
+         * Deprecated factory method. Use [Builder] instead.
+         *
+         * @param items The items added to the cart.
+         */
         @Deprecated(
             "As of release 1.0.0-beta01, replaced by standard builder methods",
             ReplaceWith("AddToCartEvent.Builder().items(items).build()"),
@@ -23,6 +35,9 @@ data class AddToCartEvent(
         }
     }
 
+    /**
+     * Builder for [AddToCartEvent].
+     */
     @Serializable
     class Builder {
         var items: List<Item> = emptyList()
@@ -30,16 +45,31 @@ data class AddToCartEvent(
         var deeplink: String? = null
             private set
 
+        /**
+         * Sets the items added to the cart. Required.
+         *
+         * @param items A non-empty list of [Item]s.
+         */
         fun items(items: List<Item>): Builder {
             this.items = items
             return this
         }
 
+        /**
+         * Sets an optional deeplink for the event.
+         *
+         * @param deeplink A deeplink URL, or `null`.
+         */
         fun deeplink(deeplink: String?): Builder {
             this.deeplink = deeplink
             return this
         }
 
+        /**
+         * Builds the [AddToCartEvent].
+         *
+         * @throws IllegalArgumentException if [items] is empty.
+         */
         fun build(): AddToCartEvent {
             return AddToCartEvent(items, deeplink)
         }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/AddToCartEvent.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/AddToCartEvent.kt
@@ -20,11 +20,6 @@ data class AddToCartEvent(
     }
 
     companion object {
-        /**
-         * Deprecated factory method. Use [Builder] instead.
-         *
-         * @param items The items added to the cart.
-         */
         @Deprecated(
             "As of release 1.0.0-beta01, replaced by standard builder methods",
             ReplaceWith("AddToCartEvent.Builder().items(items).build()"),
@@ -35,9 +30,6 @@ data class AddToCartEvent(
         }
     }
 
-    /**
-     * Builder for [AddToCartEvent].
-     */
     @Serializable
     class Builder {
         var items: List<Item> = emptyList()
@@ -45,29 +37,17 @@ data class AddToCartEvent(
         var deeplink: String? = null
             private set
 
-        /**
-         * Sets the items added to the cart. Required.
-         *
-         * @param items A non-empty list of [Item]s.
-         */
         fun items(items: List<Item>): Builder {
             this.items = items
             return this
         }
 
-        /**
-         * Sets an optional deeplink for the event.
-         *
-         * @param deeplink A deeplink URL, or `null`.
-         */
         fun deeplink(deeplink: String?): Builder {
             this.deeplink = deeplink
             return this
         }
 
         /**
-         * Builds the [AddToCartEvent].
-         *
          * @throws IllegalArgumentException if [items] is empty.
          */
         fun build(): AddToCartEvent {

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Cart.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Cart.kt
@@ -3,6 +3,12 @@ package com.attentive.androidsdk.events
 import com.attentive.androidsdk.ParameterValidation
 import kotlinx.serialization.Serializable
 
+/**
+ * Cart state associated with a [PurchaseEvent].
+ *
+ * @property cartId Your canonical cart identifier. Required, non-empty.
+ * @property cartCoupon A promotion code applied to the cart, if any.
+ */
 @Serializable
 data class Cart(
     val cartId: String,
@@ -12,21 +18,39 @@ data class Cart(
         ParameterValidation.verifyNotEmpty(cartId, "cartId")
     }
 
+    /**
+     * Builder for [Cart].
+     */
     @Serializable
     class Builder {
         lateinit var cartId: String
         private var cartCoupon: String? = null
 
+        /**
+         * Sets the cart ID. Required.
+         *
+         * @param id A non-empty cart identifier.
+         */
         fun cartId(id: String): Builder {
             cartId = id
             return this
         }
 
+        /**
+         * Sets an applied coupon code.
+         *
+         * @param id The coupon code, or `null`.
+         */
         fun cartCoupon(id: String?): Builder {
             cartCoupon = id
             return this
         }
 
+        /**
+         * Builds the [Cart].
+         *
+         * @throws UninitializedPropertyAccessException if [cartId] was not set.
+         */
         fun build(): Cart {
             return Cart(
                 cartId = cartId,

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Cart.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Cart.kt
@@ -18,37 +18,22 @@ data class Cart(
         ParameterValidation.verifyNotEmpty(cartId, "cartId")
     }
 
-    /**
-     * Builder for [Cart].
-     */
     @Serializable
     class Builder {
         lateinit var cartId: String
         private var cartCoupon: String? = null
 
-        /**
-         * Sets the cart ID. Required.
-         *
-         * @param id A non-empty cart identifier.
-         */
         fun cartId(id: String): Builder {
             cartId = id
             return this
         }
 
-        /**
-         * Sets an applied coupon code.
-         *
-         * @param id The coupon code, or `null`.
-         */
         fun cartCoupon(id: String?): Builder {
             cartCoupon = id
             return this
         }
 
         /**
-         * Builds the [Cart].
-         *
          * @throws UninitializedPropertyAccessException if [cartId] was not set.
          */
         fun build(): Cart {

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/CustomEvent.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/CustomEvent.kt
@@ -3,6 +3,17 @@ package com.attentive.androidsdk.events
 import com.attentive.androidsdk.ParameterValidation
 import kotlinx.serialization.Serializable
 
+/**
+ * A custom, app-specific event. Use this when no built-in event type matches your use case.
+ *
+ * Each custom event has a [type] (e.g. `"User Logged In"`) and a map of string [properties]
+ * for any associated metadata.
+ *
+ * @property type The type/name of the event. Case-sensitive. Must not contain any of:
+ *   `"`, `'`, `(`, `)`, `{`, `}`, `[`, `]`, `\`, `|`, `,`.
+ * @property properties Metadata associated with the event. Keys and values are case-sensitive.
+ *   Keys must not contain any of: `"`, `{`, `}`, `[`, `]`, `\`, `|`.
+ */
 @Serializable
 data class CustomEvent(
     val type: String,
@@ -36,27 +47,41 @@ data class CustomEvent(
         }
     }
 
+    /**
+     * Builder for [CustomEvent].
+     */
     @Serializable
     class Builder(
         private var type: String? = null,
         private var properties: Map<String, String> = emptyMap(),
     ) {
         /**
-         * @param type The type (aka name) of the CustomEvent e.g. "User Logged In".
-         * The type is case-sensitive - "User Logged In" and "User logged in" are different events.
-         * @param properties Any metadata associated with the event.
-         * Keys and values are case-sensitive.
+         * Sets the event type (aka name). Required. The type is case-sensitive —
+         * `"User Logged In"` and `"User logged in"` are different events.
+         *
+         * @param type The event name.
          */
         fun type(type: String): Builder {
             this.type = type
             return this
         }
 
+        /**
+         * Sets the event properties. Keys and values are case-sensitive.
+         *
+         * @param properties Event metadata.
+         */
         fun properties(properties: Map<String, String>): Builder {
             this.properties = properties
             return this
         }
 
+        /**
+         * Builds the [CustomEvent].
+         *
+         * @throws IllegalStateException if [type] was not set.
+         * @throws IllegalArgumentException if [type] or any property key contains an invalid character.
+         */
         fun build(): CustomEvent {
             val type = this.type ?: throw IllegalStateException("Type must be set")
             return CustomEvent(type, properties)

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/CustomEvent.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/CustomEvent.kt
@@ -47,38 +47,22 @@ data class CustomEvent(
         }
     }
 
-    /**
-     * Builder for [CustomEvent].
-     */
     @Serializable
     class Builder(
         private var type: String? = null,
         private var properties: Map<String, String> = emptyMap(),
     ) {
-        /**
-         * Sets the event type (aka name). Required. The type is case-sensitive —
-         * `"User Logged In"` and `"User logged in"` are different events.
-         *
-         * @param type The event name.
-         */
         fun type(type: String): Builder {
             this.type = type
             return this
         }
 
-        /**
-         * Sets the event properties. Keys and values are case-sensitive.
-         *
-         * @param properties Event metadata.
-         */
         fun properties(properties: Map<String, String>): Builder {
             this.properties = properties
             return this
         }
 
         /**
-         * Builds the [CustomEvent].
-         *
          * @throws IllegalStateException if [type] was not set.
          * @throws IllegalArgumentException if [type] or any property key contains an invalid character.
          */

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Event.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Event.kt
@@ -2,5 +2,10 @@ package com.attentive.androidsdk.events
 
 import kotlinx.serialization.Serializable
 
+/**
+ * Base class for all events recorded via [com.attentive.androidsdk.AttentiveSdk.recordEvent].
+ *
+ * Concrete subclasses: [PurchaseEvent], [AddToCartEvent], [ProductViewEvent], [CustomEvent].
+ */
 @Serializable
 abstract class Event

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Item.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Item.kt
@@ -3,6 +3,17 @@ package com.attentive.androidsdk.events
 import com.attentive.androidsdk.ParameterValidation
 import kotlinx.serialization.Serializable
 
+/**
+ * A product item within a [PurchaseEvent], [AddToCartEvent], or [ProductViewEvent].
+ *
+ * @property productId Your canonical product identifier. Required, non-empty.
+ * @property productVariantId The variant identifier (e.g. size/color SKU). Required, non-empty.
+ * @property price The price (with currency). Required.
+ * @property productImage URL of a product image. Optional.
+ * @property name The product display name. Optional.
+ * @property quantity The quantity. Defaults to 1.
+ * @property category The product category. Optional.
+ */
 @Serializable
 data class Item(
     val productId: String,
@@ -19,6 +30,13 @@ data class Item(
         ParameterValidation.verifyNotNull(price, "price")
     }
 
+    /**
+     * Builder for [Item]. Required fields are provided via the constructor.
+     *
+     * @param productId Canonical product identifier. Required, non-empty.
+     * @param productVariantId Variant identifier. Required, non-empty.
+     * @param price The price. Required.
+     */
     @Serializable
     class Builder(
         private val productId: String,
@@ -36,26 +54,31 @@ data class Item(
             ParameterValidation.verifyNotNull(price, "price")
         }
 
+        /** Sets the product image URL. */
         fun productImage(`val`: String?): Builder {
             productImage = `val`
             return this
         }
 
+        /** Sets the product display name. */
         fun name(`val`: String?): Builder {
             name = `val`
             return this
         }
 
+        /** Sets the quantity. Defaults to 1. */
         fun quantity(`val`: Int): Builder {
             quantity = `val`
             return this
         }
 
+        /** Sets the product category. */
         fun category(`val`: String?): Builder {
             category = `val`
             return this
         }
 
+        /** Builds the [Item]. */
         fun build(): Item {
             return Item(
                 productId = productId,

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Item.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Item.kt
@@ -30,13 +30,6 @@ data class Item(
         ParameterValidation.verifyNotNull(price, "price")
     }
 
-    /**
-     * Builder for [Item]. Required fields are provided via the constructor.
-     *
-     * @param productId Canonical product identifier. Required, non-empty.
-     * @param productVariantId Variant identifier. Required, non-empty.
-     * @param price The price. Required.
-     */
     @Serializable
     class Builder(
         private val productId: String,
@@ -54,31 +47,26 @@ data class Item(
             ParameterValidation.verifyNotNull(price, "price")
         }
 
-        /** Sets the product image URL. */
         fun productImage(`val`: String?): Builder {
             productImage = `val`
             return this
         }
 
-        /** Sets the product display name. */
         fun name(`val`: String?): Builder {
             name = `val`
             return this
         }
 
-        /** Sets the quantity. Defaults to 1. */
         fun quantity(`val`: Int): Builder {
             quantity = `val`
             return this
         }
 
-        /** Sets the product category. */
         fun category(`val`: String?): Builder {
             category = `val`
             return this
         }
 
-        /** Builds the [Item]. */
         fun build(): Item {
             return Item(
                 productId = productId,

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Order.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Order.kt
@@ -16,26 +16,16 @@ data class Order(
         ParameterValidation.verifyNotEmpty(orderId, "orderId")
     }
 
-    /**
-     * Builder for [Order].
-     */
     @Serializable
     class Builder {
         private lateinit var orderId: String
 
-        /**
-         * Sets the order ID. Required.
-         *
-         * @param orderId A non-empty order identifier.
-         */
         fun orderId(orderId: String): Builder {
             this.orderId = orderId
             return this
         }
 
         /**
-         * Builds the [Order].
-         *
          * @throws UninitializedPropertyAccessException if [orderId] was not set.
          */
         fun build(): Order {

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Order.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Order.kt
@@ -3,6 +3,11 @@ package com.attentive.androidsdk.events
 import com.attentive.androidsdk.ParameterValidation
 import kotlinx.serialization.Serializable
 
+/**
+ * Order identifier attached to a [PurchaseEvent].
+ *
+ * @property orderId Your canonical order identifier. Required, non-empty.
+ */
 @Serializable
 data class Order(
     val orderId: String,
@@ -11,15 +16,28 @@ data class Order(
         ParameterValidation.verifyNotEmpty(orderId, "orderId")
     }
 
+    /**
+     * Builder for [Order].
+     */
     @Serializable
     class Builder {
         private lateinit var orderId: String
 
+        /**
+         * Sets the order ID. Required.
+         *
+         * @param orderId A non-empty order identifier.
+         */
         fun orderId(orderId: String): Builder {
             this.orderId = orderId
             return this
         }
 
+        /**
+         * Builds the [Order].
+         *
+         * @throws UninitializedPropertyAccessException if [orderId] was not set.
+         */
         fun build(): Order {
             return Order(orderId)
         }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Price.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Price.kt
@@ -69,9 +69,6 @@ data class Price(
         this.price = this.price.setScale(2, RoundingMode.DOWN)
     }
 
-    /**
-     * Builder for [Price]. Both [price] and [currency] are required.
-     */
     @Serializable
     class Builder {
         @Serializable(with = BigDecimalSerializer::class)
@@ -80,29 +77,17 @@ data class Price(
         @Serializable(with = CurrencySerializer::class)
         var currency: Currency? = null
 
-        /**
-         * Sets the price amount. Required.
-         *
-         * @param price The price as a [BigDecimal].
-         */
         fun price(price: BigDecimal): Builder {
             this.price = price
             return this
         }
 
-        /**
-         * Sets the currency. Required.
-         *
-         * @param currency The [Currency].
-         */
         fun currency(currency: Currency): Builder {
             this.currency = currency
             return this
         }
 
         /**
-         * Builds the [Price].
-         *
          * @throws IllegalArgumentException if [price] or [currency] was not set.
          */
         fun build(): Price {

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Price.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Price.kt
@@ -11,6 +11,9 @@ import java.math.BigDecimal
 import java.math.RoundingMode
 import java.util.Currency
 
+/**
+ * Kotlinx.serialization serializer that encodes [BigDecimal] as its plain string representation.
+ */
 object BigDecimalSerializer : KSerializer<BigDecimal> {
     override val descriptor: SerialDescriptor =
         PrimitiveSerialDescriptor("BigDecimal", PrimitiveKind.STRING)
@@ -27,6 +30,9 @@ object BigDecimalSerializer : KSerializer<BigDecimal> {
     }
 }
 
+/**
+ * Kotlinx.serialization serializer that encodes [Currency] as its ISO 4217 currency code.
+ */
 object CurrencySerializer : KSerializer<Currency> {
 // Custom serializer for Currency
     override val descriptor: SerialDescriptor =
@@ -44,6 +50,14 @@ object CurrencySerializer : KSerializer<Currency> {
     }
 }
 
+/**
+ * A monetary price: amount + currency.
+ *
+ * The amount is normalized to two decimal places, rounded down, at construction.
+ *
+ * @property price The price amount. Rounded to 2 decimal places with [RoundingMode.DOWN] at init.
+ * @property currency The currency.
+ */
 @Serializable
 data class Price(
     @Serializable(with = BigDecimalSerializer::class)
@@ -55,6 +69,9 @@ data class Price(
         this.price = this.price.setScale(2, RoundingMode.DOWN)
     }
 
+    /**
+     * Builder for [Price]. Both [price] and [currency] are required.
+     */
     @Serializable
     class Builder {
         @Serializable(with = BigDecimalSerializer::class)
@@ -63,16 +80,31 @@ data class Price(
         @Serializable(with = CurrencySerializer::class)
         var currency: Currency? = null
 
+        /**
+         * Sets the price amount. Required.
+         *
+         * @param price The price as a [BigDecimal].
+         */
         fun price(price: BigDecimal): Builder {
             this.price = price
             return this
         }
 
+        /**
+         * Sets the currency. Required.
+         *
+         * @param currency The [Currency].
+         */
         fun currency(currency: Currency): Builder {
             this.currency = currency
             return this
         }
 
+        /**
+         * Builds the [Price].
+         *
+         * @throws IllegalArgumentException if [price] or [currency] was not set.
+         */
         fun build(): Price {
             val price = this.price ?: throw IllegalArgumentException("Price must not be null")
             val currency = this.currency ?: throw IllegalArgumentException("Currency must not be null")

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/ProductViewEvent.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/ProductViewEvent.kt
@@ -20,11 +20,6 @@ data class ProductViewEvent(
     }
 
     companion object {
-        /**
-         * Deprecated factory method. Use [Builder] instead.
-         *
-         * @param items The items viewed.
-         */
         @Deprecated(
             "As of release 1.0.0-beta01, replaced by standard builder methods",
             ReplaceWith("ProductViewEvent.Builder().items(items).build()"),
@@ -35,9 +30,6 @@ data class ProductViewEvent(
         }
     }
 
-    /**
-     * Builder for [ProductViewEvent].
-     */
     @Serializable
     class Builder {
         var items: List<Item> = emptyList()
@@ -45,29 +37,17 @@ data class ProductViewEvent(
         var deeplink: String? = null
             private set
 
-        /**
-         * Sets the items viewed. Required.
-         *
-         * @param items A non-empty list of [Item]s.
-         */
         fun items(items: List<Item>): Builder {
             this.items = items
             return this
         }
 
-        /**
-         * Sets an optional deeplink for the event.
-         *
-         * @param deeplink A deeplink URL, or `null`.
-         */
         fun deeplink(deeplink: String?): Builder {
             this.deeplink = deeplink
             return this
         }
 
         /**
-         * Builds the [ProductViewEvent].
-         *
          * @throws IllegalArgumentException if [items] is empty.
          */
         fun build(): ProductViewEvent {

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/ProductViewEvent.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/ProductViewEvent.kt
@@ -3,6 +3,13 @@ package com.attentive.androidsdk.events
 import com.attentive.androidsdk.ParameterValidation
 import kotlinx.serialization.Serializable
 
+/**
+ * A product view event. Fires when the user views one or more products (e.g. lands on a PDP).
+ *
+ * @property items The items viewed. Must be non-empty.
+ * @property deeplink Optional deeplink associated with the event. Propagated to the backend
+ *   so campaigns can re-target the user with the same URL.
+ */
 @Serializable
 data class ProductViewEvent(
     val items: List<Item>,
@@ -13,6 +20,11 @@ data class ProductViewEvent(
     }
 
     companion object {
+        /**
+         * Deprecated factory method. Use [Builder] instead.
+         *
+         * @param items The items viewed.
+         */
         @Deprecated(
             "As of release 1.0.0-beta01, replaced by standard builder methods",
             ReplaceWith("ProductViewEvent.Builder().items(items).build()"),
@@ -23,6 +35,9 @@ data class ProductViewEvent(
         }
     }
 
+    /**
+     * Builder for [ProductViewEvent].
+     */
     @Serializable
     class Builder {
         var items: List<Item> = emptyList()
@@ -30,16 +45,31 @@ data class ProductViewEvent(
         var deeplink: String? = null
             private set
 
+        /**
+         * Sets the items viewed. Required.
+         *
+         * @param items A non-empty list of [Item]s.
+         */
         fun items(items: List<Item>): Builder {
             this.items = items
             return this
         }
 
+        /**
+         * Sets an optional deeplink for the event.
+         *
+         * @param deeplink A deeplink URL, or `null`.
+         */
         fun deeplink(deeplink: String?): Builder {
             this.deeplink = deeplink
             return this
         }
 
+        /**
+         * Builds the [ProductViewEvent].
+         *
+         * @throws IllegalArgumentException if [items] is empty.
+         */
         fun build(): ProductViewEvent {
             return ProductViewEvent(items, deeplink)
         }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/PurchaseEvent.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/PurchaseEvent.kt
@@ -3,12 +3,28 @@ package com.attentive.androidsdk.events
 import kotlinx.serialization.Serializable
 import timber.log.Timber
 
+/**
+ * A purchase event. Fires when the user completes an order.
+ *
+ * One [PurchaseEvent] with N items produces N `Purchase` requests plus one `OrderConfirmed`
+ * request on the backend.
+ *
+ * @property items The items in the order. Must be non-empty for the event to produce any requests.
+ * @property order The order identifier.
+ * @property cart The cart state at checkout. Optional.
+ */
 @Serializable
 data class PurchaseEvent(
     val items: List<Item>,
     val order: Order,
     val cart: Cart? = null,
 ) : Event() {
+    /**
+     * Builder for [PurchaseEvent].
+     *
+     * @param items The items in the order. Required.
+     * @param order The order identifier. Required.
+     */
     @Serializable
     class Builder(
         private val items: List<Item>,
@@ -16,11 +32,19 @@ data class PurchaseEvent(
     ) {
         private var cart: Cart? = null
 
+        /**
+         * Sets the cart state at checkout.
+         *
+         * @param `val` The cart, or `null` if unavailable.
+         */
         fun cart(`val`: Cart?): Builder {
             cart = `val`
             return this
         }
 
+        /**
+         * Builds the [PurchaseEvent].
+         */
         fun build(): PurchaseEvent {
             Timber.d("PurchaseEvent: items: $items, order: $order, cart: $cart")
             return PurchaseEvent(items, order, cart)

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/PurchaseEvent.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/PurchaseEvent.kt
@@ -19,12 +19,6 @@ data class PurchaseEvent(
     val order: Order,
     val cart: Cart? = null,
 ) : Event() {
-    /**
-     * Builder for [PurchaseEvent].
-     *
-     * @param items The items in the order. Required.
-     * @param order The order identifier. Required.
-     */
     @Serializable
     class Builder(
         private val items: List<Item>,
@@ -32,19 +26,11 @@ data class PurchaseEvent(
     ) {
         private var cart: Cart? = null
 
-        /**
-         * Sets the cart state at checkout.
-         *
-         * @param `val` The cart, or `null` if unavailable.
-         */
         fun cart(`val`: Cart?): Builder {
             cart = `val`
             return this
         }
 
-        /**
-         * Builds the [PurchaseEvent].
-         */
         fun build(): PurchaseEvent {
             Timber.d("PurchaseEvent: items: $items, order: $order, cart: $cart")
             return PurchaseEvent(items, order, cart)

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/ApiVersion.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/ApiVersion.kt
@@ -1,6 +1,12 @@
 package com.attentive.androidsdk.internal.network
 
+/**
+ * Event-API version used by the SDK. Internal/testing use.
+ */
 enum class ApiVersion {
+    /** Legacy callback-based API using query-string parameters (`/e` endpoint). */
     OLD,
+
+    /** Current suspend-based API using JSON bodies via Retrofit (`/mobile` endpoint). */
     NEW,
 }


### PR DESCRIPTION
## Ticket
[MSDK-340](https://attentivemobile.atlassian.net/browse/MSDK-340)

## Summary
Add KDoc to every public-facing type, method, and property across the SDK's core public surface. Incorporates context from the identity docs work (MSDK-346) — `updateUser()` and `clearUser()` KDocs flag their visitor-ID reset semantics, their dependency on an FCM push token, and link to MSDK-345.

Covered files:
- **`AttentiveSdk`** — every public method + `PushTokenCallback` interface
- **`AttentiveConfig`** + `Builder` + `Mode` enum
- **`AttentiveConfigInterface`** — all properties and methods
- **`UserIdentifiers`** + `Builder` + `merge()` companion
- **`AttentiveLogLevel`** + `fromId()`
- **`AttentiveApiCallback`**
- **`ApiVersion`** (internal enum, documented for completeness)
- **Events package:** `Event`, `PurchaseEvent`, `AddToCartEvent`, `ProductViewEvent`, `CustomEvent`, `Item`, `Cart`, `Order`, `Price` + their `Builder`s and `BigDecimalSerializer`/`CurrencySerializer`
- **Creatives:** class-level lifecycle KDoc on `Creative`, enhanced `trigger()` docs, full KDoc on `CreativeTriggerCallback`

Deliberately skipped:
- Inbox types (`Message`, `Style`, `InboxState`) — `@RestrictTo(LIBRARY_GROUP)` and marked deprecated
- Internal / test-only types

## Test plan
- [ ] `./gradlew :attentive-android-sdk:compileDebugKotlin` passes (verified locally)
- [ ] Spot-check KDoc rendering in Android Studio — hover over `AttentiveSdk.updateUser`, `clearUser`, `AttentiveConfig.Builder.domain`, `PurchaseEvent` and confirm the tooltip shows the new docs
- [ ] Confirm no behavior changes — this PR is pure documentation

Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-340]: https://attentivemobile.atlassian.net/browse/MSDK-340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ