### PR TITLE
MSDK-347: Reorganize Bonni settings labels to match identity doc

### DIFF
--- a/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
+++ b/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
@@ -340,7 +340,7 @@ fun SettingsList(
             SettingGroup(creativeSettings)
             SectionHeader("Push notifications")
             PushPermissionRequest()
-            SettingGroup(pushSettings, showDivider = false)
+            SettingGroup(pushSettings)
             SettingGroup(deepLinkSettings)
             AboutSection()
             Spacer(modifier = Modifier.padding(8.dp))
@@ -350,6 +350,7 @@ fun SettingsList(
 
 @Composable
 fun SectionHeader(title: String) {
+    HorizontalLine(color = Color.Black, Modifier.padding(horizontal = 4.dp))
     Text(
         text = title,
         fontSize = 14.sp,
@@ -729,7 +730,6 @@ fun SettingGroup(
     titlesToDestinations: List<Pair<String, () -> Unit>>,
     enabled: Boolean = true,
     editable: Boolean = false,
-    showDivider: Boolean = true,
 ) {
     Column {
         for (titleToDestination in titlesToDestinations) {
@@ -743,9 +743,6 @@ fun SettingGroup(
             )
         }
         // }
-    }
-    if (showDivider) {
-        HorizontalLine(color = Color.Black, Modifier.padding(4.dp))
     }
 }
 

--- a/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
+++ b/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
@@ -251,15 +251,15 @@ fun SettingsList(
     )
     lifecycleSettings.add(
         "Log in as different user" to {
-            viewModel.saveEmail()
-            viewModel.savePhoneNumber()
-            viewModel.switchUser()
-            val email = viewModel.email.value.takeIf { it.isNotBlank() }
-            val phone = viewModel.phone.value.takeIf { it.isNotBlank() }
+            val savedEmail = viewModel.saveEmail()
+            val savedPhone = viewModel.savePhoneNumber()
+            val email = viewModel.email.value.takeIf { it.isNotBlank() && savedEmail }
+            val phone = viewModel.phone.value.takeIf { it.isNotBlank() && savedPhone }
             val identifier = listOfNotNull(email, phone).joinToString(", ")
             val message = if (identifier.isBlank()) {
-                "No email or phone set, can't switch user"
+                "No valid email or phone, can't switch user"
             } else {
+                viewModel.switchUser()
                 "Logged in as $identifier"
             }
             Toast.makeText(context, message, Toast.LENGTH_SHORT).show()

--- a/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
+++ b/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
@@ -54,7 +54,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import com.attentive.androidsdk.AttentiveEventTracker
 import com.attentive.androidsdk.AttentiveSdk
-import com.attentive.androidsdk.UserIdentifiers
 import com.attentive.androidsdk.creatives.Creative
 import com.attentive.androidsdk.internal.util.Constants
 import com.attentive.bonni.BonniApp
@@ -145,7 +144,7 @@ fun SettingsList(
 
     val changeEmailSetting =
         SettingItem(
-            title = "Change Email",
+            title = "Email",
             enabled = true,
             editable = true,
             onClick = { email -> changeEmail(viewModel) },
@@ -153,32 +152,10 @@ fun SettingsList(
 
     val changePhoneNumberSetting =
         SettingItem(
-            title = "Change Phone Number",
+            title = "Phone",
             enabled = true,
             editable = true,
             onClick = { phone -> changePhoneNumber(viewModel) },
-        )
-
-    val switchUserWithEmailSetting =
-        SettingItem(
-            title = "Switch User with email",
-            enabled = true,
-            editable = true,
-            onClick = {
-                viewModel.saveEmail()
-                viewModel.switchUser()
-            },
-        )
-
-    val switchUserWithPhoneSetting =
-        SettingItem(
-            title = "Switch User with phone",
-            enabled = true,
-            editable = true,
-            onClick = {
-                viewModel.savePhoneNumber()
-                viewModel.switchUser()
-            },
         )
 
     val apiVersionSetting =
@@ -255,9 +232,19 @@ fun SettingsList(
         },
     )
 
-    val userSettings = mutableListOf<Pair<String, () -> Unit>>()
-    userSettings.add(
-        "Opt-In User email" to {
+    val lifecycleSettings = mutableListOf<Pair<String, () -> Unit>>()
+    lifecycleSettings.add(
+        "Log in as different user" to {
+            viewModel.saveEmail()
+            viewModel.savePhoneNumber()
+            viewModel.switchUser()
+        },
+    )
+    lifecycleSettings.add("Log out" to { clearUsers(viewModel) })
+
+    val subscriptionSettings = mutableListOf<Pair<String, () -> Unit>>()
+    subscriptionSettings.add(
+        "Subscribe email" to {
             CoroutineScope(Dispatchers.IO).launch {
                 val email = AttentiveEventTracker.instance.config.userIdentifiers.email
                 email?.let {
@@ -266,11 +253,11 @@ fun SettingsList(
 
                 withContext(Dispatchers.Main) {
                     if (email == null) {
-                        Toast.makeText(context, "No email, can't opt in", Toast.LENGTH_SHORT)
+                        Toast.makeText(context, "No email, can't subscribe", Toast.LENGTH_SHORT)
                             .show()
                         return@withContext
                     } else {
-                        Toast.makeText(context, "Opted in user with email: $email", Toast.LENGTH_SHORT)
+                        Toast.makeText(context, "Subscribed email: $email", Toast.LENGTH_SHORT)
                             .show()
                     }
                 }
@@ -278,8 +265,8 @@ fun SettingsList(
         },
     )
 
-    userSettings.add(
-        "Opt-Out User email" to {
+    subscriptionSettings.add(
+        "Unsubscribe email" to {
             CoroutineScope(Dispatchers.IO).launch {
                 val email = AttentiveEventTracker.instance.config.userIdentifiers.email
                 email?.let {
@@ -287,11 +274,11 @@ fun SettingsList(
                 }
                 withContext(Dispatchers.Main) {
                     if (email == null) {
-                        Toast.makeText(context, "No email, can't opt out", Toast.LENGTH_SHORT)
+                        Toast.makeText(context, "No email, can't unsubscribe", Toast.LENGTH_SHORT)
                             .show()
                         return@withContext
                     } else {
-                        Toast.makeText(context, "Opted out user with email: $email", Toast.LENGTH_SHORT)
+                        Toast.makeText(context, "Unsubscribed email: $email", Toast.LENGTH_SHORT)
                             .show()
                     }
                 }
@@ -299,8 +286,8 @@ fun SettingsList(
         },
     )
 
-    userSettings.add(
-        "Opt-In User Phone Number" to {
+    subscriptionSettings.add(
+        "Subscribe SMS" to {
             CoroutineScope(Dispatchers.IO).launch {
                 val phone = AttentiveEventTracker.instance.config.userIdentifiers.phone
                 phone?.let {
@@ -308,10 +295,10 @@ fun SettingsList(
                 }
                 withContext(Dispatchers.Main) {
                     if (phone == null) {
-                        Toast.makeText(context, "No number, can't opt in", Toast.LENGTH_SHORT)
+                        Toast.makeText(context, "No number, can't subscribe", Toast.LENGTH_SHORT)
                             .show()
                     } else {
-                        Toast.makeText(context, "Opted in user with phone: $phone", Toast.LENGTH_SHORT)
+                        Toast.makeText(context, "Subscribed SMS: $phone", Toast.LENGTH_SHORT)
                             .show()
                     }
                 }
@@ -319,8 +306,8 @@ fun SettingsList(
         },
     )
 
-    userSettings.add(
-        "Opt-Out User Phone Number" to {
+    subscriptionSettings.add(
+        "Unsubscribe SMS" to {
             CoroutineScope(Dispatchers.IO).launch {
                 val phone = AttentiveEventTracker.instance.config.userIdentifiers.phone
                 phone?.let {
@@ -328,19 +315,16 @@ fun SettingsList(
                 }
                 withContext(Dispatchers.Main) {
                     if (phone == null) {
-                        Toast.makeText(context, "No number, can't opt out", Toast.LENGTH_SHORT)
+                        Toast.makeText(context, "No number, can't unsubscribe", Toast.LENGTH_SHORT)
                             .show()
                     } else {
-                        Toast.makeText(context, "Opted out user with phone: $phone", Toast.LENGTH_SHORT)
+                        Toast.makeText(context, "Unsubscribed SMS: $phone", Toast.LENGTH_SHORT)
                             .show()
                     }
                 }
             }
         },
     )
-
-    userSettings.add("Identify User" to { identifyUser() })
-    userSettings.add("Clear Users" to { clearUsers(viewModel) })
 
     LazyColumn(modifier = Modifier.padding(bottom = 32.dp)) {
         items(count = 1) {
@@ -356,211 +340,14 @@ fun SettingsList(
             EditableDomainSetting(changeDomainSetting)
             EditableEmailSetting(changeEmailSetting)
             EditablePhoneNumberSetting(changePhoneNumberSetting)
-            SwitchUserWithEmailSetting(switchUserWithEmailSetting)
-            SwitchUserWithPhoneSetting(switchUserWithPhoneSetting)
-            SettingGroup(userSettings)
+            SettingGroup(lifecycleSettings)
+            SettingGroup(subscriptionSettings)
             ApiVersionSetting(apiVersionSetting)
             SettingGroup(creativeSettings)
             PushPermissionRequest()
             SettingGroup(pushSettings)
             SettingGroup(deepLinkSettings)
             Spacer(modifier = Modifier.padding(8.dp))
-        }
-    }
-}
-
-@Composable
-private fun SwitchUserSetting(
-    settingItem: SettingItem,
-    value: String,
-    displayLabel: String,
-    onValueChange: (String) -> Unit,
-) {
-    var isEditing by remember { mutableStateOf(false) }
-
-    AnimatedContent(targetState = isEditing) { editing ->
-        if (editing) {
-            Row(modifier = Modifier.padding(8.dp)) {
-                OutlinedTextField(
-                    value = value,
-                    onValueChange = onValueChange,
-                    label = { Text(settingItem.title) },
-                    singleLine = true,
-                    colors =
-                        OutlinedTextFieldDefaults.colors(
-                            focusedBorderColor = BonniPink,
-                            unfocusedBorderColor = Color.Gray,
-                            focusedTextColor = Color.Black,
-                        ),
-                    trailingIcon = {
-                        IconButton(onClick = {
-                            settingItem.onClick(value)
-                            isEditing = false
-                        }) {
-                            Icon(
-                                Icons.Filled.Check,
-                                contentDescription = "Submit",
-                                tint = BonniPink,
-                            )
-                        }
-                    },
-                )
-            }
-        } else {
-            Text(
-                text =
-                    buildAnnotatedString {
-                        append("$displayLabel: ")
-                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                            append(value)
-                        }
-                    },
-                fontFamily = FontFamily(Font(R.font.degulardisplay_regular)),
-                modifier =
-                    Modifier
-                        .padding(8.dp)
-                        .clickable { isEditing = true },
-            )
-        }
-    }
-}
-
-@Composable
-fun SwitchUserWithEmailSetting(
-    settingItem: SettingItem,
-    viewModel: SettingsViewModel = viewModel(),
-) {
-    var isEditing by remember { mutableStateOf(false) }
-    var isError by remember { mutableStateOf(false) }
-    val email by viewModel.email.collectAsState()
-
-    AnimatedContent(targetState = isEditing) { editing ->
-        if (editing) {
-            Row(modifier = Modifier.padding(8.dp)) {
-                OutlinedTextField(
-                    value = email,
-                    onValueChange = {
-                        viewModel.updateEmail(it)
-                        isError = false
-                    },
-                    label = { Text(settingItem.title) },
-                    supportingText = if (isError) {
-                        { Text("Please enter a valid email address") }
-                    } else {
-                        null
-                    },
-                    isError = isError,
-                    singleLine = true,
-                    colors =
-                        OutlinedTextFieldDefaults.colors(
-                            focusedBorderColor = BonniPink,
-                            unfocusedBorderColor = Color.Gray,
-                            focusedTextColor = Color.Black,
-                        ),
-                    trailingIcon = {
-                        IconButton(onClick = {
-                            if (viewModel.saveEmail()) {
-                                isError = false
-                                isEditing = false
-                                viewModel.switchUser()
-                            } else {
-                                isError = true
-                            }
-                        }) {
-                            Icon(
-                                Icons.Filled.Check,
-                                contentDescription = "Submit",
-                                tint = BonniPink,
-                            )
-                        }
-                    },
-                )
-            }
-        } else {
-            Text(
-                text =
-                    buildAnnotatedString {
-                        append("Switch user with email: ")
-                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                            append(email)
-                        }
-                    },
-                fontFamily = FontFamily(Font(R.font.degulardisplay_regular)),
-                modifier =
-                    Modifier
-                        .padding(8.dp)
-                        .clickable { isEditing = true },
-            )
-        }
-    }
-}
-
-@Composable
-fun SwitchUserWithPhoneSetting(
-    settingItem: SettingItem,
-    viewModel: SettingsViewModel = viewModel(),
-) {
-    var isEditing by remember { mutableStateOf(false) }
-    var isError by remember { mutableStateOf(false) }
-    val phone by viewModel.phone.collectAsState()
-
-    AnimatedContent(targetState = isEditing) { editing ->
-        if (editing) {
-            Row(modifier = Modifier.padding(8.dp)) {
-                OutlinedTextField(
-                    value = phone,
-                    onValueChange = {
-                        viewModel.updatePhone(it)
-                        isError = false
-                    },
-                    label = { Text(settingItem.title) },
-                    supportingText = if (isError) {
-                        { Text("Please enter a valid phone number (E.164 format, e.g. +14155551234)") }
-                    } else {
-                        null
-                    },
-                    isError = isError,
-                    singleLine = true,
-                    colors =
-                        OutlinedTextFieldDefaults.colors(
-                            focusedBorderColor = BonniPink,
-                            unfocusedBorderColor = Color.Gray,
-                            focusedTextColor = Color.Black,
-                        ),
-                    trailingIcon = {
-                        IconButton(onClick = {
-                            if (viewModel.savePhoneNumber()) {
-                                isError = false
-                                isEditing = false
-                                viewModel.switchUser()
-                            } else {
-                                isError = true
-                            }
-                        }) {
-                            Icon(
-                                Icons.Filled.Check,
-                                contentDescription = "Submit",
-                                tint = BonniPink,
-                            )
-                        }
-                    },
-                )
-            }
-        } else {
-            Text(
-                text =
-                    buildAnnotatedString {
-                        append("Switch user with phone: ")
-                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                            append(phone)
-                        }
-                    },
-                fontFamily = FontFamily(Font(R.font.degulardisplay_regular)),
-                modifier =
-                    Modifier
-                        .padding(8.dp)
-                        .clickable { isEditing = true },
-            )
         }
     }
 }
@@ -671,7 +458,7 @@ fun EditableEmailSetting(
             Text(
                 text =
                     buildAnnotatedString {
-                        append("Change current email: ")
+                        append("Email: ")
                         withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
                             append(email)
                         }
@@ -744,64 +531,9 @@ fun EditablePhoneNumberSetting(
             Text(
                 text =
                     buildAnnotatedString {
-                        append("Change current phone number: ")
+                        append("Phone: ")
                         withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
                             append(phone)
-                        }
-                    },
-                fontFamily = FontFamily(Font(R.font.degulardisplay_regular)),
-                modifier =
-                    Modifier
-                        .padding(8.dp)
-                        .clickable { isEditing = true },
-            )
-        }
-    }
-}
-
-@Composable
-fun EditableSwitchUserSetting(
-    settingItem: SettingItem,
-    viewModel: SettingsViewModel = viewModel(),
-) {
-    var isEditing by remember { mutableStateOf(false) }
-    val email by viewModel.email.collectAsState()
-
-    AnimatedContent(targetState = isEditing) { editing ->
-        if (editing) {
-            Row(modifier = Modifier.padding(8.dp)) {
-                OutlinedTextField(
-                    value = email,
-                    onValueChange = { viewModel.updateEmail(it) },
-                    label = { Text(settingItem.title) },
-                    singleLine = true,
-                    colors =
-                        OutlinedTextFieldDefaults.colors(
-                            focusedBorderColor = BonniPink,
-                            unfocusedBorderColor = Color.Gray,
-                            focusedTextColor = Color.Black,
-                        ),
-                    trailingIcon = {
-                        IconButton(onClick = {
-                            settingItem.onClick(email)
-                            isEditing = false
-                        }) {
-                            Icon(
-                                Icons.Filled.Check,
-                                contentDescription = "Submit",
-                                tint = BonniPink,
-                            )
-                        }
-                    },
-                )
-            }
-        } else {
-            Text(
-                text =
-                    buildAnnotatedString {
-                        append("Change current email: ")
-                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                            append(email)
                         }
                     },
                 fontFamily = FontFamily(Font(R.font.degulardisplay_regular)),
@@ -870,20 +602,6 @@ fun triggerMockDeepLinkNotification(
             BonniApp.getInstance(),
         )
     }
-}
-
-fun identifyUser() {
-    BonniApp
-        .getInstance()
-        .getSharedPreferences(ATTENTIVE_PREFS, MODE_PRIVATE)
-        .getString(ATTENTIVE_EMAIL_PREFS, "")
-        ?.let {
-            val identifiers =
-                UserIdentifiers.Builder()
-                    .withEmail(it).build()
-            AttentiveEventTracker.instance.config.identify(identifiers)
-            Toast.makeText(BonniApp.getInstance(), "User identified", Toast.LENGTH_SHORT).show()
-        }
 }
 
 fun clearUsers(viewModel: SettingsViewModel) {

--- a/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
+++ b/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
@@ -326,7 +326,7 @@ fun SettingsList(
 
     LazyColumn(modifier = Modifier.padding(bottom = 32.dp)) {
         items(count = 1) {
-            SectionHeader("Configuration")
+            SectionHeader("Configuration", showDivider = false)
             EditableDomainSetting(changeDomainSetting)
             SectionHeader("User")
             EditableEmailSetting(changeEmailSetting)
@@ -349,8 +349,10 @@ fun SettingsList(
 }
 
 @Composable
-fun SectionHeader(title: String) {
-    HorizontalLine(color = Color.Black, Modifier.padding(horizontal = 4.dp))
+fun SectionHeader(title: String, showDivider: Boolean = true) {
+    if (showDivider) {
+        HorizontalLine(color = Color.Black, Modifier.padding(horizontal = 4.dp))
+    }
     Text(
         text = title,
         fontSize = 14.sp,

--- a/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
+++ b/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
@@ -341,7 +341,6 @@ fun SettingsList(
             SectionHeader("Push notifications")
             PushPermissionRequest()
             SettingGroup(pushSettings)
-            SectionHeader("Deep links")
             SettingGroup(deepLinkSettings)
             AboutSection()
             Spacer(modifier = Modifier.padding(8.dp))

--- a/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
+++ b/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
@@ -235,6 +235,21 @@ fun SettingsList(
 
     val lifecycleSettings = mutableListOf<Pair<String, () -> Unit>>()
     lifecycleSettings.add(
+        "Identify current user" to {
+            val savedEmail = viewModel.saveEmail()
+            val savedPhone = viewModel.savePhoneNumber()
+            val email = viewModel.email.value.takeIf { it.isNotBlank() && savedEmail }
+            val phone = viewModel.phone.value.takeIf { it.isNotBlank() && savedPhone }
+            val identifier = listOfNotNull(email, phone).joinToString(", ")
+            val message = if (identifier.isBlank()) {
+                "No valid email or phone to identify"
+            } else {
+                "Identified current user: $identifier"
+            }
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        },
+    )
+    lifecycleSettings.add(
         "Log in as different user" to {
             viewModel.saveEmail()
             viewModel.savePhoneNumber()
@@ -424,6 +439,7 @@ fun EditableEmailSetting(
     var isEditing by remember { mutableStateOf(false) }
     var isError by remember { mutableStateOf(false) }
     val email by viewModel.email.collectAsState()
+    val context = LocalContext.current
 
     AnimatedContent(targetState = isEditing) { editing ->
         if (editing) {
@@ -453,6 +469,11 @@ fun EditableEmailSetting(
                             if (viewModel.saveEmail()) {
                                 isError = false
                                 isEditing = false
+                                Toast.makeText(
+                                    context,
+                                    "Identified current user: ${viewModel.email.value}",
+                                    Toast.LENGTH_SHORT,
+                                ).show()
                             } else {
                                 isError = true
                             }
@@ -493,11 +514,17 @@ fun EditablePhoneNumberSetting(
     var isEditing by remember { mutableStateOf(false) }
     var isError by remember { mutableStateOf(false) }
     val phone by viewModel.phone.collectAsState()
+    val context = LocalContext.current
 
     fun attemptSave(): Boolean {
         return if (viewModel.savePhoneNumber()) {
             isError = false
             isEditing = false
+            Toast.makeText(
+                context,
+                "Identified current user: ${viewModel.phone.value}",
+                Toast.LENGTH_SHORT,
+            ).show()
             true
         } else {
             isError = true

--- a/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
+++ b/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -110,7 +109,7 @@ fun SettingsScreenContent(navHostController: NavHostController) {
         }
 
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        SimpleToolbar(title = "", {}, navHostController)
+        SimpleToolbar(title = "Settings", {}, navHostController)
         Box(
             modifier =
                 Modifier
@@ -329,15 +328,6 @@ fun SettingsList(
 
     LazyColumn(modifier = Modifier.padding(bottom = 32.dp)) {
         items(count = 1) {
-            Text(
-                "Settings",
-                modifier =
-                    Modifier
-                        .padding(8.dp)
-                        .fillMaxWidth(),
-                textAlign = TextAlign.Start,
-                fontSize = 20.sp,
-            )
             EditableDomainSetting(changeDomainSetting)
             EditableEmailSetting(changeEmailSetting)
             EditablePhoneNumberSetting(changePhoneNumberSetting)

--- a/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
+++ b/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
@@ -326,20 +326,42 @@ fun SettingsList(
 
     LazyColumn(modifier = Modifier.padding(bottom = 32.dp)) {
         items(count = 1) {
+            SectionHeader("Configuration")
             EditableDomainSetting(changeDomainSetting)
+            SectionHeader("User")
             EditableEmailSetting(changeEmailSetting)
             EditablePhoneNumberSetting(changePhoneNumberSetting)
             SettingGroup(lifecycleSettings)
+            SectionHeader("Marketing subscriptions")
             SettingGroup(subscriptionSettings)
+            SectionHeader("Debug")
             ApiVersionSetting(apiVersionSetting)
+            SectionHeader("Creatives")
             SettingGroup(creativeSettings)
+            SectionHeader("Push notifications")
             PushPermissionRequest()
             SettingGroup(pushSettings)
+            SectionHeader("Deep links")
             SettingGroup(deepLinkSettings)
             AboutSection()
             Spacer(modifier = Modifier.padding(8.dp))
         }
     }
+}
+
+@Composable
+fun SectionHeader(title: String) {
+    Text(
+        text = title,
+        fontSize = 14.sp,
+        fontWeight = FontWeight.Bold,
+        color = BonniPink,
+        fontFamily = FontFamily(Font(R.font.degulardisplay_regular)),
+        modifier =
+            Modifier
+                .padding(start = 8.dp, end = 8.dp, top = 16.dp, bottom = 4.dp)
+                .fillMaxWidth(),
+    )
 }
 
 @Composable
@@ -358,12 +380,8 @@ fun AboutSection() {
         }
     val sdkVersion = AppInfo.attentiveSDKVersion
 
-    Column(modifier = Modifier.padding(8.dp)) {
-        Text(
-            "About",
-            fontSize = 16.sp,
-            fontFamily = FontFamily(Font(R.font.degulardisplay_regular)),
-        )
+    SectionHeader("About")
+    Column(modifier = Modifier.padding(start = 8.dp, end = 8.dp, bottom = 8.dp)) {
         Text(
             "Bonni $appVersion ($buildNumber)",
             fontSize = 12.sp,

--- a/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
+++ b/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
@@ -340,7 +340,7 @@ fun SettingsList(
             SettingGroup(creativeSettings)
             SectionHeader("Push notifications")
             PushPermissionRequest()
-            SettingGroup(pushSettings)
+            SettingGroup(pushSettings, showDivider = false)
             SettingGroup(deepLinkSettings)
             AboutSection()
             Spacer(modifier = Modifier.padding(8.dp))
@@ -729,6 +729,7 @@ fun SettingGroup(
     titlesToDestinations: List<Pair<String, () -> Unit>>,
     enabled: Boolean = true,
     editable: Boolean = false,
+    showDivider: Boolean = true,
 ) {
     Column {
         for (titleToDestination in titlesToDestinations) {
@@ -743,7 +744,9 @@ fun SettingGroup(
         }
         // }
     }
-    HorizontalLine(color = Color.Black, Modifier.padding(4.dp))
+    if (showDivider) {
+        HorizontalLine(color = Color.Black, Modifier.padding(4.dp))
+    }
 }
 
 @Composable

--- a/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
+++ b/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
@@ -235,16 +235,16 @@ fun SettingsList(
 
     val lifecycleSettings = mutableListOf<Pair<String, () -> Unit>>()
     lifecycleSettings.add(
-        "Identify current user" to {
+        "Login current user" to {
             val savedEmail = viewModel.saveEmail()
             val savedPhone = viewModel.savePhoneNumber()
             val email = viewModel.email.value.takeIf { it.isNotBlank() && savedEmail }
             val phone = viewModel.phone.value.takeIf { it.isNotBlank() && savedPhone }
             val identifier = listOfNotNull(email, phone).joinToString(", ")
             val message = if (identifier.isBlank()) {
-                "No valid email or phone to identify"
+                "No valid email or phone to login"
             } else {
-                "Identified current user: $identifier"
+                "Logged in current user: $identifier"
             }
             Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         },
@@ -471,7 +471,7 @@ fun EditableEmailSetting(
                                 isEditing = false
                                 Toast.makeText(
                                     context,
-                                    "Identified current user: ${viewModel.email.value}",
+                                    "Logged in current user: ${viewModel.email.value}",
                                     Toast.LENGTH_SHORT,
                                 ).show()
                             } else {
@@ -522,7 +522,7 @@ fun EditablePhoneNumberSetting(
             isEditing = false
             Toast.makeText(
                 context,
-                "Identified current user: ${viewModel.phone.value}",
+                "Logged in current user: ${viewModel.phone.value}",
                 Toast.LENGTH_SHORT,
             ).show()
             true

--- a/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
+++ b/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
@@ -206,9 +206,10 @@ fun SettingsList(
     pushSettings.add(
         "Update push permission status" to {
             AttentiveSdk.updatePushPermissionStatus(context)
+            val granted = AttentiveSdk.isPushPermissionGranted(context)
             Toast.makeText(
                 context,
-                "Updating push permission status: ${AttentiveSdk.isPushPermissionGranted(context)}",
+                "Re-registered push token. Permission: ${if (granted) "granted" else "denied"}",
                 Toast.LENGTH_SHORT,
             ).show()
         },
@@ -238,6 +239,15 @@ fun SettingsList(
             viewModel.saveEmail()
             viewModel.savePhoneNumber()
             viewModel.switchUser()
+            val email = viewModel.email.value.takeIf { it.isNotBlank() }
+            val phone = viewModel.phone.value.takeIf { it.isNotBlank() }
+            val identifier = listOfNotNull(email, phone).joinToString(", ")
+            val message = if (identifier.isBlank()) {
+                "No email or phone set, can't switch user"
+            } else {
+                "Logged in as $identifier"
+            }
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         },
     )
     lifecycleSettings.add("Log out" to { clearUsers(viewModel) })
@@ -247,20 +257,12 @@ fun SettingsList(
         "Subscribe email" to {
             CoroutineScope(Dispatchers.IO).launch {
                 val email = AttentiveEventTracker.instance.config.userIdentifiers.email
-                email?.let {
-                    AttentiveSdk.optUserIntoMarketingSubscription(email = email)
+                if (email == null) {
+                    showOnMain(context, "No email, can't subscribe")
+                    return@launch
                 }
-
-                withContext(Dispatchers.Main) {
-                    if (email == null) {
-                        Toast.makeText(context, "No email, can't subscribe", Toast.LENGTH_SHORT)
-                            .show()
-                        return@withContext
-                    } else {
-                        Toast.makeText(context, "Subscribed email: $email", Toast.LENGTH_SHORT)
-                            .show()
-                    }
-                }
+                val result = AttentiveSdk.optUserIntoMarketingSubscription(email = email)
+                showOnMain(context, subscriptionResultMessage(result, "Subscribed email", email))
             }
         },
     )
@@ -269,19 +271,12 @@ fun SettingsList(
         "Unsubscribe email" to {
             CoroutineScope(Dispatchers.IO).launch {
                 val email = AttentiveEventTracker.instance.config.userIdentifiers.email
-                email?.let {
-                    AttentiveSdk.optUserOutOfMarketingSubscription(email = it)
+                if (email == null) {
+                    showOnMain(context, "No email, can't unsubscribe")
+                    return@launch
                 }
-                withContext(Dispatchers.Main) {
-                    if (email == null) {
-                        Toast.makeText(context, "No email, can't unsubscribe", Toast.LENGTH_SHORT)
-                            .show()
-                        return@withContext
-                    } else {
-                        Toast.makeText(context, "Unsubscribed email: $email", Toast.LENGTH_SHORT)
-                            .show()
-                    }
-                }
+                val result = AttentiveSdk.optUserOutOfMarketingSubscription(email = email)
+                showOnMain(context, subscriptionResultMessage(result, "Unsubscribed email", email))
             }
         },
     )
@@ -290,18 +285,12 @@ fun SettingsList(
         "Subscribe SMS" to {
             CoroutineScope(Dispatchers.IO).launch {
                 val phone = AttentiveEventTracker.instance.config.userIdentifiers.phone
-                phone?.let {
-                    AttentiveSdk.optUserIntoMarketingSubscription(phoneNumber = it)
+                if (phone == null) {
+                    showOnMain(context, "No number, can't subscribe")
+                    return@launch
                 }
-                withContext(Dispatchers.Main) {
-                    if (phone == null) {
-                        Toast.makeText(context, "No number, can't subscribe", Toast.LENGTH_SHORT)
-                            .show()
-                    } else {
-                        Toast.makeText(context, "Subscribed SMS: $phone", Toast.LENGTH_SHORT)
-                            .show()
-                    }
-                }
+                val result = AttentiveSdk.optUserIntoMarketingSubscription(phoneNumber = phone)
+                showOnMain(context, subscriptionResultMessage(result, "Subscribed SMS", phone))
             }
         },
     )
@@ -310,18 +299,12 @@ fun SettingsList(
         "Unsubscribe SMS" to {
             CoroutineScope(Dispatchers.IO).launch {
                 val phone = AttentiveEventTracker.instance.config.userIdentifiers.phone
-                phone?.let {
-                    AttentiveSdk.optUserOutOfMarketingSubscription(phoneNumber = it)
+                if (phone == null) {
+                    showOnMain(context, "No number, can't unsubscribe")
+                    return@launch
                 }
-                withContext(Dispatchers.Main) {
-                    if (phone == null) {
-                        Toast.makeText(context, "No number, can't unsubscribe", Toast.LENGTH_SHORT)
-                            .show()
-                    } else {
-                        Toast.makeText(context, "Unsubscribed SMS: $phone", Toast.LENGTH_SHORT)
-                            .show()
-                    }
-                }
+                val result = AttentiveSdk.optUserOutOfMarketingSubscription(phoneNumber = phone)
+                showOnMain(context, subscriptionResultMessage(result, "Unsubscribed SMS", phone))
             }
         },
     )
@@ -645,7 +628,7 @@ fun clearUsers(viewModel: SettingsViewModel) {
             remove(ATTENTIVE_EMAIL_PREFS)
             remove(ATTENTIVE_PHONE_PREFS)
         }
-    Toast.makeText(BonniApp.getInstance(), "Users cleared", Toast.LENGTH_SHORT).show()
+    Toast.makeText(BonniApp.getInstance(), "Logged out", Toast.LENGTH_SHORT).show()
 }
 
 fun changeDomain(domain: String) {
@@ -808,5 +791,23 @@ private fun PushPermissionRequest() {
                         },
             )
         }
+    }
+}
+
+private suspend fun showOnMain(context: Context, message: String) {
+    withContext(Dispatchers.Main) {
+        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+    }
+}
+
+private fun subscriptionResultMessage(
+    result: Result<Unit>,
+    successPrefix: String,
+    identifier: String,
+): String {
+    return if (result.isSuccess) {
+        "$successPrefix: $identifier"
+    } else {
+        "Failed: ${result.exceptionOrNull()?.message ?: "unknown error"}"
     }
 }

--- a/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
+++ b/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
@@ -61,6 +61,7 @@ import com.attentive.bonni.BonniApp.Companion.ATTENTIVE_EMAIL_PREFS
 import com.attentive.bonni.BonniApp.Companion.ATTENTIVE_PHONE_PREFS
 import com.attentive.bonni.BonniApp.Companion.ATTENTIVE_PREFS
 import com.attentive.bonni.R
+import com.attentive.androidsdk.internal.util.AppInfo
 import com.attentive.bonni.SimpleToolbar
 import com.attentive.bonni.ui.theme.BonniPink
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -347,8 +348,46 @@ fun SettingsList(
             PushPermissionRequest()
             SettingGroup(pushSettings)
             SettingGroup(deepLinkSettings)
+            AboutSection()
             Spacer(modifier = Modifier.padding(8.dp))
         }
+    }
+}
+
+@Composable
+fun AboutSection() {
+    val context = LocalContext.current
+    val packageInfo = remember(context) {
+        context.packageManager.getPackageInfo(context.packageName, 0)
+    }
+    val appVersion = packageInfo.versionName ?: "?"
+    val buildNumber =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            packageInfo.longVersionCode.toString()
+        } else {
+            @Suppress("DEPRECATION")
+            packageInfo.versionCode.toString()
+        }
+    val sdkVersion = AppInfo.attentiveSDKVersion
+
+    Column(modifier = Modifier.padding(8.dp)) {
+        Text(
+            "About",
+            fontSize = 16.sp,
+            fontFamily = FontFamily(Font(R.font.degulardisplay_regular)),
+        )
+        Text(
+            "Bonni $appVersion ($buildNumber)",
+            fontSize = 12.sp,
+            color = Color.Gray,
+            fontFamily = FontFamily(Font(R.font.degulardisplay_regular)),
+        )
+        Text(
+            "Attentive SDK $sdkVersion",
+            fontSize = 12.sp,
+            color = Color.Gray,
+            fontFamily = FontFamily(Font(R.font.degulardisplay_regular)),
+        )
     }
 }
 

--- a/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
+++ b/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
@@ -110,7 +110,7 @@ fun SettingsScreenContent(navHostController: NavHostController) {
         }
 
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        SimpleToolbar(title = "Debug Screen", {}, navHostController)
+        SimpleToolbar(title = "", {}, navHostController)
         Box(
             modifier =
                 Modifier


### PR DESCRIPTION
## Ticket
[MSDK-347](https://attentivemobile.atlassian.net/browse/MSDK-347)

## Summary
Reorganize the Bonni debug settings screen to match the naming proposal in `docs/identity.md`, plus a handful of related UX cleanups. Bonni-only — no SDK public API changes.

### Field labels (edit-in-place)
- "Change Email" → **"Email"**
- "Change Phone Number" → **"Phone"**
- Display labels in collapsed state ("Change current email/phone") → "Email/Phone" to match.

### User lifecycle actions
- New **"Login current user"** button — calls `viewModel.saveEmail()` + `savePhoneNumber()` (which internally call `config.identify()`); does **not** change the visitor ID. Mirrors the SDK's `identify()` semantic. Wording uses "Login" since Bonni is also used by sales engineers and PMs; engineers know it maps to `identify()`.
- "Switch User with email" + "Switch User with phone" → single **"Log in as different user"** button that calls `updateUser()` (new visitor ID + push token detach), uses whichever fields are populated.
- "Identify User" → removed (duplicated edit-email-field behavior; replaced by the explicit Login button above).
- "Clear Users" → **"Log out"**.

### Marketing subscription
- "Opt-In User email" → "Subscribe email"
- "Opt-In User Phone Number" → "Subscribe SMS"
- "Opt-Out User email" → "Unsubscribe email"
- "Opt-Out User Phone Number" → "Unsubscribe SMS"

### Toast fixes
- **Subscribe / Unsubscribe (4 paths):** previously fired the success toast before `optUserInto/OutOfMarketingSubscription` returned, hiding failures. Now awaits the `Result<Unit>` and shows success or wrapped failure message.
- **"Update push permission status":** old toast said "Updating push permission status: true" — confusing tense, no real signal. Now: "Re-registered push token. Permission: granted/denied".
- **Field save (Email / Phone ✓):** new toast "Logged in current user: <value>" so the implicit `identify()` that happens during field save is visible.
- **"Login current user" button:** new toast confirming which identifier(s) were used.
- **"Log in as different user":** new toast naming the user that was switched to.
- **"Logged out"** (renamed from "Users cleared") for consistency with the menu label.

### Layout
- Toolbar now shows **"Settings"**; the in-list duplicate header is removed.
- Settings grouped under section headers (`SectionHeader` composable, 14sp bold pink): Configuration, User, Marketing subscriptions, Debug, Creatives, Push notifications, Deep links, About.
- New **About** section at the bottom: Bonni `<versionName>` (`<versionCode>`) + Attentive SDK `<attentiveSDKVersion>`.

### Cleanup
- Delete unused composables: private `SwitchUserSetting`, `SwitchUserWithEmailSetting`, `SwitchUserWithPhoneSetting`, `EditableSwitchUserSetting`.
- Delete `identifyUser()` helper.
- Remove unused `UserIdentifiers` and `TextAlign` imports.
- The validation feedback that MSDK-184 / MSDK-328 added to the deleted `SwitchUserWith*Setting` composables is **preserved** — it already exists in `EditableEmailSetting` and `EditablePhoneNumberSetting`, so the editable fields still show inline error UI.

## Test plan
- [x] `./gradlew :bonni:compileDebugKotlin` passes
- [x] `./gradlew :bonni:testDebugUnitTest` passes
- [ ] Manual verification: open settings, confirm the section headers are visible, exercise Login current user, Log in as different user, Log out, all four subscribe/unsubscribe paths, and verify toasts reflect actual outcomes (especially failure cases for subscribe/unsubscribe)
- [ ] Confirm About section shows correct Bonni version, build number, and SDK version

Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-347]: https://attentivemobile.atlassian.net/browse/MSDK-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ