### PR TITLE
MSDK-349: Add AGENTS.md for AI agent SDK integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,9 +114,13 @@ github.properties
 # Local dev tooling (mock server, scripts). Lives on develop but not intended for main.
 tools/
 
-# Claude
-.claude/
-# Exceptions for shared config (if applicable)
+# Claude — ignore everything under .claude/ except shared config files.
+# Note: `.claude/` (directory form) prunes the dir before negations evaluate,
+# so we ignore by glob and re-include directories explicitly.
+.claude/*
 !.claude/CLAUDE.md
 !.claude/settings.json
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/**/
 !.claude/skills/**/SKILL.md

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,10 @@ github.properties
 
 # Local dev tooling (mock server, scripts). Lives on develop but not intended for main.
 tools/
+
+# Claude
+.claude/
+# Exceptions for shared config (if applicable)
+!.claude/CLAUDE.md
+!.claude/settings.json
+!.claude/skills/**/SKILL.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,14 +8,14 @@ If you are an agent and the user has asked you to "set up Attentive", "integrate
 
 ## Scope
 
-This guide covers the **minimum viable integration**: dependency wiring, `AttentiveConfig` creation, and `AttentiveSdk.initialize` in the host `Application`. That is all.
+This guide covers:
+1. **Base integration** (always): dependency wiring, `AttentiveConfig` creation, and `AttentiveSdk.initialize` in the host `Application`.
+2. **Push setup** (conditional, after asking the user): see Step 5.
 
 Do **not**, in this pass:
 - Add identify/clearUser/updateUser calls (the user will wire those at their own login/logout sites)
 - Add event recording (PurchaseEvent, AddToCartEvent, etc.)
 - Add Creative rendering
-- Add or configure push notifications, Firebase, `google-services.json`, or any push manifest entries
-- Modify `AndroidManifest.xml` for push (no `tools:node="remove"` for the messaging service unless the user explicitly asks)
 
 If the user asks for more after the base case is working, refer them to `README.md` in the SDK repo.
 
@@ -24,9 +24,8 @@ If the user asks for more after the base case is working, refer them to `README.
 ## Inputs you must collect from the user before writing code
 
 1. **Attentive domain** — a short string identifying their Attentive account (e.g. `myshop`). If unknown, insert `"YOUR_ATTENTIVE_DOMAIN"` and tell the user to replace it.
-2. **Mode** — `PRODUCTION` or `DEBUG`. Default to `DEBUG` for first-time integration so the user gets verbose logs; tell them to switch to `PRODUCTION` for release builds.
 
-Do not invent a domain. If the user has not provided one, leave a clearly-marked placeholder.
+Do not invent a domain. If the user has not provided one, leave a clearly-marked placeholder. Always initialize the SDK in `Mode.DEBUG`; tell the user to switch to `Mode.PRODUCTION` for release builds.
 
 ---
 
@@ -94,14 +93,150 @@ AttentiveSdk.initialize(attentiveConfig);
 
 ---
 
-## Step 4 — Verify
+## Step 4 — Verify the base build
 
 1. Run a Gradle sync (`./gradlew :app:dependencies` or let the IDE sync).
 2. Build the app (`./gradlew :app:assembleDebug`).
-3. If the build succeeds, the base case is done. Tell the user:
+3. If the build fails, fix it before moving on. Once it succeeds, proceed to Step 5.
+
+Do not run the app on a device or emulator unless asked.
+
+---
+
+## Step 5 — Ask about push
+
+Push notifications are **enabled by default** in the SDK. Before doing anything else, ask the user a single question:
+
+> "Do you plan to send push notifications to your users via Attentive? (yes/no)"
+
+### If the user answers **no**
+
+Disable push in the config to keep the SDK from fetching FCM tokens or sending app-launch / direct-open events:
+
+```kotlin
+val attentiveConfig = AttentiveConfig.Builder()
+    .applicationContext(this)
+    .domain("YOUR_ATTENTIVE_DOMAIN")
+    .mode(AttentiveConfig.Mode.DEBUG)
+    .pushEnabled(false)
+    .build()
+```
+
+Stop here. Do not modify `AndroidManifest.xml`, do not add Firebase, do not add a notification icon. The base integration is complete.
+
+### If the user answers **yes**
+
+Walk through the following sub-questions in order. Ask one at a time and act on each before moving to the next.
+
+#### 5a. Firebase prerequisites — detect, do not install
+
+Check whether the project is already set up with Firebase Cloud Messaging:
+
+- Look for `google-services.json` in the **app module** root (`app/google-services.json` or equivalent).
+- Look for the Google Services Gradle plugin: `id("com.google.gms.google-services")` in the app module's `build.gradle(.kts)` and the classpath/`plugins {}` declaration in the project root or `settings.gradle(.kts)`.
+- Look for `com.google.firebase:firebase-messaging` (or a `firebase-bom` import) in the app module dependencies.
+
+If any of these are missing, **stop and tell the user**. Do not add Firebase yourself — adding it has implications (project registration, FCM credentials, app-side Firebase initialization order) that the user must own. Tell them:
+
+> "Before I can wire up push, this app needs Firebase Cloud Messaging set up: a `google-services.json` from the Firebase console, the `com.google.gms.google-services` plugin, and a `firebase-messaging` (or `firebase-bom`) dependency. Set those up via the Firebase console (https://firebase.google.com/docs/android/setup) and let me know once `./gradlew :app:assembleDebug` still builds. Then I'll continue."
+
+Wait for confirmation before proceeding.
+
+#### 5b. Existing `FirebaseMessagingService` subclass — detect and offer to forward
+
+Search the host app for an existing `FirebaseMessagingService` subclass:
+
+- Grep all source files (`.kt` and `.java`) under the app module's `src/main/java` and `src/main/kotlin` for `: FirebaseMessagingService` (Kotlin) or `extends FirebaseMessagingService` (Java).
+- Cross-check `AndroidManifest.xml` for a `<service>` whose `<intent-filter>` declares `com.google.firebase.MESSAGING_EVENT`.
+
+**If a subclass is found**, look at its `onMessageReceived` and check whether it already forwards Attentive messages (`AttentiveSdk.isAttentiveFirebaseMessage(...)` followed by `AttentiveSdk.sendNotification(...)`). If it does not, ask:
+
+> "I found `com.example.MyFirebaseMessagingService` extending `FirebaseMessagingService`. Want me to add the Attentive forwarding so push notifications from Attentive are displayed? It's a 3-line change inside `onMessageReceived`."
+
+If yes, add the forwarding inside `onMessageReceived` **after** `super.onMessageReceived(remoteMessage)` and **before** the host's existing message handling, so Attentive messages short-circuit before the host tries to render them:
+
+```kotlin
+override fun onMessageReceived(remoteMessage: RemoteMessage) {
+    super.onMessageReceived(remoteMessage)
+    if (AttentiveSdk.isAttentiveFirebaseMessage(remoteMessage)) {
+        AttentiveSdk.sendNotification(remoteMessage)
+        return
+    }
+    // existing host handling stays here
+}
+```
+
+Add the `AttentiveSdk` import. Match Kotlin/Java to the existing class. If the host's service has a higher `android:priority` than the SDK's (the SDK declares `-500`), this forwarding is what makes Attentive notifications still display.
+
+**If no subclass is found**, do nothing — the SDK's built-in `AttentiveFirebaseMessagingService` will receive Attentive messages directly. Skip to 5c.
+
+#### 5c. Notification icon
+
+Ask:
+
+> "Push notifications need a small monochrome icon (Android requires a flat white-on-transparent drawable for the status bar). Do you already have one in `res/drawable/`? If so, tell me its name and I'll wire it up. If not, I can leave a placeholder."
+
+If the user provides a drawable name, add it to the config:
+
+```kotlin
+.notificationIconId(R.drawable.your_icon_name)
+```
+
+If they don't have one, add a clearly-marked placeholder comment in the builder and tell them to set it before sending pushes:
+
+```kotlin
+// TODO(attentive): set a notification icon (small monochrome drawable in res/drawable/)
+// .notificationIconId(R.drawable.attentive_notification_icon)
+```
+
+Ask follow-up only if relevant: "Do you want to set a background color for the icon?" If yes, add `.notificationIconBackgroundColor(R.color.your_color)`.
+
+#### 5d. Push permission prompt (Android 13+)
+
+Ask:
+
+> "On Android 13+ apps must request `POST_NOTIFICATIONS` permission to show notifications. Do you want the SDK to handle this prompt for you the first time the user opens the app? (If you already manage notification permission yourself, say no.)"
+
+If **yes**, add a one-shot call in the launcher activity's `onCreate` (after `super.onCreate(savedInstanceState)`). Match the activity's language. Kotlin example:
+
+```kotlin
+lifecycleScope.launch {
+    AttentiveSdk.getPushToken(application = application, requestPermission = true)
+}
+```
+
+Add the `AttentiveSdk` import and `androidx.lifecycle:lifecycle-runtime-ktx` import for `lifecycleScope` if not present (it usually is via Compose / AppCompat). For Java, use `AttentiveSdk.getPushTokenWithCallback(application, true, callback)`.
+
+If **no**, tell the user to call `AttentiveSdk.updatePushPermissionStatus(context)` themselves after their own permission flow resolves so Attentive learns the result.
+
+#### 5e. `singleTask` launcher activity — detect and patch `onNewIntent`
+
+Inspect the manifest's launcher activity (the one whose `<intent-filter>` declares `android.intent.action.MAIN` + `android.intent.category.LAUNCHER`). Check `android:launchMode`.
+
+If it is `singleTask` or `singleInstance`, the SDK cannot detect notification taps when the app is brought from background unless the activity calls `setIntent(...)` on incoming intents. Look at the activity class for an existing `onNewIntent` override:
+
+- If `onNewIntent` exists and does not call `setIntent(intent)`, ask before editing — there may be a reason. If they say yes, add `setIntent(intent)` after `super.onNewIntent(intent)`.
+- If `onNewIntent` does not exist, add it:
+
+```kotlin
+override fun onNewIntent(intent: Intent?) {
+    super.onNewIntent(intent)
+    intent?.let { setIntent(it) }
+}
+```
+
+If the launch mode is the default (`standard`) or `singleTop`, skip this step.
+
+---
+
+## Step 6 — Re-verify
+
+1. Build the app (`./gradlew :app:assembleDebug`).
+2. If you added a `notificationIconId` placeholder TODO, remind the user to fill it in before testing.
+3. Tell the user:
    - Replace `"YOUR_ATTENTIVE_DOMAIN"` with their real domain if a placeholder was used.
    - Switch `Mode.DEBUG` to `Mode.PRODUCTION` for release builds (or wire it to `BuildConfig.DEBUG`).
-   - For identify, events, creatives, or push, see the SDK's `README.md`.
+   - For identify, events, and creatives, see the SDK's `README.md`.
 
 Do not run the app on a device or emulator unless asked.
 
@@ -110,9 +245,8 @@ Do not run the app on a device or emulator unless asked.
 ## Things NOT to do
 
 - Do not add `identify()`, `clearUser()`, `updateUser()`, `recordEvent()`, or `Creative` calls.
-- Do not touch Firebase, push permissions, or `google-services.json`.
-- Do not remove or add the `AttentiveFirebaseMessagingService` manifest entry.
-- Do not add `notificationIconId(...)` to the builder.
+- Do not install Firebase or create a `google-services.json` — only detect what's already there.
+- Do not add `<service tools:node="remove">` for `AttentiveFirebaseMessagingService`. Use `pushEnabled(false)` instead.
 - Do not create an `Application` subclass for the user. If one doesn't exist, ask them to add it themselves.
 - Do not bump the user's `minSdk`, `targetSdk`, AGP version, or Kotlin version.
 - Do not introduce DI frameworks (Hilt/Dagger/Koin) to wire this — direct construction in `onCreate` is correct here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,8 @@ If the launch mode is the default (`standard`) or `singleTop`, skip this step.
 3. Tell the user:
    - Replace `"YOUR_ATTENTIVE_DOMAIN"` with their real domain if a placeholder was used.
    - Switch `Mode.DEBUG` to `Mode.PRODUCTION` for release builds (or wire it to `BuildConfig.DEBUG`).
-   - For identify, events, and creatives, see the SDK's `README.md`.
+   - For everything this guide intentionally skipped (identify, events, creatives, push deep linking, subscription management, etc.), see the SDK README: https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md
+4. Then list the skipped features as clickable Markdown links to their README anchors — copy the bullets verbatim from the **What this guide intentionally skipped** section below. Do not summarize or omit them; the user needs the deep-links to find each feature.
 
 Do not run the app on a device or emulator unless asked.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,3 +271,22 @@ Do not run the app on a device or emulator unless asked.
 
 Full documentation: https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md
 Sample app: `bonni/` in the SDK repo.
+
+### What this guide intentionally skipped
+
+After the base integration is working, point the user at the README for any of the following — none of them are wired up by this guide:
+
+When you list these for the user, format each README reference as a Markdown link to the section anchor on GitHub (e.g. `[Step 2 - Identify the current user](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#step-2---identify-the-current-user)`) so they're clickable. GitHub anchors are the heading lowercased with spaces → `-` and punctuation stripped.
+
+- **Identifying the user** (`AttentiveSdk.identify(...)`) — call at login or whenever you learn the user's email, phone, `clientUserId`, Shopify ID, Klaviyo ID, or custom identifiers. → [Step 2 - Identify the current user](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#step-2---identify-the-current-user).
+- **Clearing user data** (`AttentiveSdk.clearUser()`) — call on logout. Resets identifiers and regenerates the visitor ID. → [Clearing user data](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#clearing-user-data).
+- **Updating identity post-login** (`updateUser`, `identify` merge semantics) → [Managing User Identity](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#managing-user-identity).
+- **Recording events** — `PurchaseEvent`, `AddToCartEvent`, `ProductViewEvent`, `CustomEvent`, plus the `Item` / `Price` / `Order` / `Cart` metadata models. → [Step 3 - Record user events](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#step-3---record-user-events).
+- **Creatives** — in-app messages rendered in a WebView. Create / trigger / destroy lifecycle, triggering a specific creative, and skipping fatigue rules. → [Step 3 (optional) - Show Creatives](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#step-3-optional---show-creatives).
+- **Push deep linking** — handling notification taps that open a specific screen. → [Deeplinking](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#deeplinking).
+- **`FirebaseMessagingService` priority** — what to do if multiple services are declared and Attentive's isn't winning. → [Service priority when multiple FirebaseMessagingService declarations exist](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#service-priority-when-multiple-firebasemessagingservice-declarations-exist).
+- **Subscription management** — email/SMS opt-in and opt-out helpers. → [Manage subscriptions for email and phone number](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#manage-subscriptions-for-email-and-phone-number).
+- **Changing domain at runtime** — for apps that switch Attentive accounts. → [Change domain](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#change-domain).
+- **Log level** — quieting or verbosing the SDK logger. → [Log Level](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#log-level).
+
+Tell the user: "The base integration is in. For identify/clearUser, event tracking, creatives, deep links, and subscription management, see the README — I left those out on purpose so you can wire them at the right call sites."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,9 +23,14 @@ If the user asks for more after the base case is working, refer them to `README.
 
 ## Inputs you must collect from the user before writing code
 
-1. **Attentive domain** — a short string identifying their Attentive account (e.g. `myshop`). If unknown, insert `"YOUR_ATTENTIVE_DOMAIN"` and tell the user to replace it.
+1. **Attentive domain** — a short string identifying their Attentive account (e.g. `myshop`). Ask:
 
-Do not invent a domain. If the user has not provided one, leave a clearly-marked placeholder. Always initialize the SDK in `Mode.DEBUG`; tell the user to switch to `Mode.PRODUCTION` for release builds.
+   > "Do you know your Attentive domain? It's the short identifier for your account (e.g. `myshop`)."
+
+   - If the user says **yes**, immediately follow up with: "What is it?" Wait for their answer and use that exact string in the config. Do not proceed until they've given you the domain.
+   - If the user says **no** (or doesn't know), insert `"YOUR_ATTENTIVE_DOMAIN"` as a placeholder and tell them to replace it before shipping.
+
+Do not invent a domain. Always initialize the SDK in `Mode.DEBUG`; tell the user to switch to `Mode.PRODUCTION` for release builds.
 
 ---
 
@@ -61,6 +66,14 @@ implementation("com.attentive:attentive-android-sdk:2.1.7")
 > Use `2.1.7` as the default version. If the client uses a version catalog (`libs.versions.toml`), add an entry there instead and reference it via `libs.attentive.android.sdk`.
 
 Ensure `mavenCentral()` is in the authoritative repositories block. If `dependencyResolutionManagement` exists in `settings.gradle`(.kts), add it there; otherwise add to the root `build.gradle` `allprojects { repositories { ... } }`.
+
+After editing the build file, **sync Gradle** so the SDK classes resolve before you write any code that imports them. Run:
+
+```bash
+./gradlew :app:dependencies --configuration debugRuntimeClasspath
+```
+
+(adjust the module name if it isn't `app`). The IDE's "Sync Now" prompt does the same thing — if the user is driving the IDE, ask them to sync. Do not move on to Step 3 until the sync succeeds; otherwise the `AttentiveConfig` / `AttentiveSdk` imports you add next will fail to resolve.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,151 @@
+# Attentive Android SDK — Agent Integration Guide
+
+This file is for AI coding agents (Claude Code, Cursor, Copilot, Codex, etc.) integrating the **Attentive Android SDK** into a host Android app. It is an alternative to reading the full `README.md` — it tells you exactly what to inspect in the client's codebase and what to write.
+
+If you are an agent and the user has asked you to "set up Attentive", "integrate the Attentive SDK", or similar, follow this guide top-to-bottom. Do not add features beyond the base case unless explicitly asked.
+
+---
+
+## Scope
+
+This guide covers the **minimum viable integration**: dependency wiring, `AttentiveConfig` creation, and `AttentiveSdk.initialize` in the host `Application`. That is all.
+
+Do **not**, in this pass:
+- Add identify/clearUser/updateUser calls (the user will wire those at their own login/logout sites)
+- Add event recording (PurchaseEvent, AddToCartEvent, etc.)
+- Add Creative rendering
+- Add or configure push notifications, Firebase, `google-services.json`, or any push manifest entries
+- Modify `AndroidManifest.xml` for push (no `tools:node="remove"` for the messaging service unless the user explicitly asks)
+
+If the user asks for more after the base case is working, refer them to `README.md` in the SDK repo.
+
+---
+
+## Inputs you must collect from the user before writing code
+
+1. **Attentive domain** — a short string identifying their Attentive account (e.g. `myshop`). If unknown, insert `"YOUR_ATTENTIVE_DOMAIN"` and tell the user to replace it.
+2. **Mode** — `PRODUCTION` or `DEBUG`. Default to `DEBUG` for first-time integration so the user gets verbose logs; tell them to switch to `PRODUCTION` for release builds.
+
+Do not invent a domain. If the user has not provided one, leave a clearly-marked placeholder.
+
+---
+
+## Step 1 — Inspect the client codebase
+
+Before editing anything, determine:
+
+1. **Build system**: Gradle Groovy (`build.gradle`) or Kotlin DSL (`build.gradle.kts`)? Check the app module.
+2. **Repositories**: Are repositories declared in the root `build.gradle`(.kts), in `settings.gradle`(.kts) under `dependencyResolutionManagement`, or both? Whichever is authoritative is where `mavenCentral()` must exist.
+3. **Application class**: Does the app already have a custom `Application` subclass?
+   - Look for `android:name=".SomeApp"` (or fully-qualified) on the `<application>` tag in `AndroidManifest.xml`.
+   - If yes, edit that class.
+   - If no, create one (e.g. `MainApplication.kt` in the app's root package) and register it in the manifest.
+4. **Language**: Is the existing Application class Kotlin or Java? Match it.
+5. **`minSdk`**: Note the value. The SDK supports API 26+; on lower API levels it no-ops but still builds. If the user's `minSdk < 26`, mention this once — do not raise their `minSdk` without permission.
+
+---
+
+## Step 2 — Add the dependency
+
+In the **app module's** `build.gradle` or `build.gradle.kts`, add to `dependencies`:
+
+**Groovy (`build.gradle`):**
+```groovy
+implementation 'com.attentive:attentive-android-sdk:2.1.7'
+```
+
+**Kotlin DSL (`build.gradle.kts`):**
+```kotlin
+implementation("com.attentive:attentive-android-sdk:2.1.7")
+```
+
+> Use `2.1.7` as the default version. If the client uses a version catalog (`libs.versions.toml`), add an entry there instead and reference it via `libs.attentive.android.sdk`.
+
+Ensure `mavenCentral()` is in the authoritative repositories block. If `dependencyResolutionManagement` exists in `settings.gradle`(.kts), add it there; otherwise add to the root `build.gradle` `allprojects { repositories { ... } }`.
+
+---
+
+## Step 3 — Initialize the SDK in `Application.onCreate`
+
+The SDK must be initialized as early as possible after process start so app-open events are tracked correctly.
+
+### If the client has no Application class
+
+Create `app/src/main/java/<their-package>/MainApplication.kt`:
+
+```kotlin
+package com.example.myapp
+
+import android.app.Application
+import com.attentive.androidsdk.AttentiveConfig
+import com.attentive.androidsdk.AttentiveSdk
+
+class MainApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+
+        val attentiveConfig = AttentiveConfig.Builder()
+            .applicationContext(this)
+            .domain("YOUR_ATTENTIVE_DOMAIN")
+            .mode(AttentiveConfig.Mode.DEBUG)
+            .build()
+
+        AttentiveSdk.initialize(attentiveConfig)
+    }
+}
+```
+
+Then register it in `AndroidManifest.xml` on the `<application>` tag:
+
+```xml
+<application
+    android:name=".MainApplication"
+    ...>
+```
+
+### If the client already has an Application class
+
+Add the same two blocks (`AttentiveConfig.Builder()...build()` and `AttentiveSdk.initialize(...)`) inside the existing `onCreate()`, **after** `super.onCreate()` and after any logging/crash-reporter initialization the client already has. Do not reorder existing initialization. Match the file's language (Kotlin or Java).
+
+**Java equivalent:**
+```java
+AttentiveConfig attentiveConfig = new AttentiveConfig.Builder()
+    .applicationContext(this)
+    .domain("YOUR_ATTENTIVE_DOMAIN")
+    .mode(AttentiveConfig.Mode.DEBUG)
+    .build();
+
+AttentiveSdk.initialize(attentiveConfig);
+```
+
+---
+
+## Step 4 — Verify
+
+1. Run a Gradle sync (`./gradlew :app:dependencies` or let the IDE sync).
+2. Build the app (`./gradlew :app:assembleDebug`).
+3. If the build succeeds, the base case is done. Tell the user:
+   - Replace `"YOUR_ATTENTIVE_DOMAIN"` with their real domain if a placeholder was used.
+   - Switch `Mode.DEBUG` to `Mode.PRODUCTION` for release builds (or wire it to `BuildConfig.DEBUG`).
+   - For identify, events, creatives, or push, see the SDK's `README.md`.
+
+Do not run the app on a device or emulator unless asked.
+
+---
+
+## Things NOT to do
+
+- Do not add `identify()`, `clearUser()`, `updateUser()`, `recordEvent()`, or `Creative` calls.
+- Do not touch Firebase, push permissions, or `google-services.json`.
+- Do not remove or add the `AttentiveFirebaseMessagingService` manifest entry.
+- Do not add `notificationIconId(...)` to the builder.
+- Do not bump the user's `minSdk`, `targetSdk`, AGP version, or Kotlin version.
+- Do not introduce DI frameworks (Hilt/Dagger/Koin) to wire this — direct construction in `onCreate` is correct here.
+- Do not write tests for the integration unless asked.
+
+---
+
+## Reference
+
+Full documentation: https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md
+Sample app: `bonni/` in the SDK repo.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,8 +248,23 @@ If the launch mode is the default (`standard`) or `singleTop`, skip this step.
 3. Tell the user:
    - Replace `"YOUR_ATTENTIVE_DOMAIN"` with their real domain if a placeholder was used.
    - Switch `Mode.DEBUG` to `Mode.PRODUCTION` for release builds (or wire it to `BuildConfig.DEBUG`).
-   - For everything this guide intentionally skipped (identify, events, creatives, push deep linking, subscription management, etc.), see the SDK README: https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md
-4. Then list the skipped features as clickable Markdown links to their README anchors — copy the bullets verbatim from the **What this guide intentionally skipped** section below. Do not summarize or omit them; the user needs the deep-links to find each feature.
+
+4. Then **emit the following block to the user, verbatim**, including every `[text](url)` link exactly as written. Do not rewrite, summarize, paraphrase, drop URLs, or convert links to plain titles. The user's terminal renders Markdown; without the `(url)` part, the links are dead.
+
+   ```
+   For everything this guide intentionally skipped, see the [SDK README](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md):
+
+   - [Identify the current user](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#step-2---identify-the-current-user) — call at login or whenever you learn the user's email, phone, `clientUserId`, Shopify ID, Klaviyo ID, or custom identifiers.
+   - [Clearing user data](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#clearing-user-data) — call on logout. Resets identifiers and regenerates the visitor ID.
+   - [Managing user identity](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#managing-user-identity) — `updateUser` / `identify` merge semantics post-login.
+   - [Recording events](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#step-3---record-user-events) — `PurchaseEvent`, `AddToCartEvent`, `ProductViewEvent`, `CustomEvent`, plus `Item` / `Price` / `Order` / `Cart` metadata models.
+   - [Showing Creatives](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#step-3-optional---show-creatives) — in-app messages rendered in a WebView; create / trigger / destroy lifecycle.
+   - [Push deep linking](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#deeplinking) — handling notification taps that open a specific screen.
+   - [FirebaseMessagingService priority](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#service-priority-when-multiple-firebasemessagingservice-declarations-exist) — what to do if multiple services are declared and Attentive's isn't winning.
+   - [Subscription management](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#manage-subscriptions-for-email-and-phone-number) — email / SMS opt-in and opt-out helpers.
+   - [Changing domain at runtime](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#change-domain) — for apps that switch Attentive accounts.
+   - [Log level](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#log-level) — quieting or verbosing the SDK logger.
+   ```
 
 Do not run the app on a device or emulator unless asked.
 
@@ -273,19 +288,4 @@ Sample app: `bonni/` in the SDK repo.
 
 ### What this guide intentionally skipped
 
-After the base integration is working, point the user at the README for any of the following — none of them are wired up by this guide:
-
-When you list these for the user, format each README reference as a Markdown link to the section anchor on GitHub (e.g. `[Step 2 - Identify the current user](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#step-2---identify-the-current-user)`) so they're clickable. GitHub anchors are the heading lowercased with spaces → `-` and punctuation stripped.
-
-- **Identifying the user** (`AttentiveSdk.identify(...)`) — call at login or whenever you learn the user's email, phone, `clientUserId`, Shopify ID, Klaviyo ID, or custom identifiers. → [Step 2 - Identify the current user](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#step-2---identify-the-current-user).
-- **Clearing user data** (`AttentiveSdk.clearUser()`) — call on logout. Resets identifiers and regenerates the visitor ID. → [Clearing user data](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#clearing-user-data).
-- **Updating identity post-login** (`updateUser`, `identify` merge semantics) → [Managing User Identity](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#managing-user-identity).
-- **Recording events** — `PurchaseEvent`, `AddToCartEvent`, `ProductViewEvent`, `CustomEvent`, plus the `Item` / `Price` / `Order` / `Cart` metadata models. → [Step 3 - Record user events](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#step-3---record-user-events).
-- **Creatives** — in-app messages rendered in a WebView. Create / trigger / destroy lifecycle, triggering a specific creative, and skipping fatigue rules. → [Step 3 (optional) - Show Creatives](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#step-3-optional---show-creatives).
-- **Push deep linking** — handling notification taps that open a specific screen. → [Deeplinking](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#deeplinking).
-- **`FirebaseMessagingService` priority** — what to do if multiple services are declared and Attentive's isn't winning. → [Service priority when multiple FirebaseMessagingService declarations exist](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#service-priority-when-multiple-firebasemessagingservice-declarations-exist).
-- **Subscription management** — email/SMS opt-in and opt-out helpers. → [Manage subscriptions for email and phone number](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#manage-subscriptions-for-email-and-phone-number).
-- **Changing domain at runtime** — for apps that switch Attentive accounts. → [Change domain](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#change-domain).
-- **Log level** — quieting or verbosing the SDK logger. → [Log Level](https://github.com/attentive-mobile/attentive-android-sdk/blob/main/README.md#log-level).
-
-Tell the user: "The base integration is in. For identify/clearUser, event tracking, creatives, deep links, and subscription management, see the README — I left those out on purpose so you can wire them at the right call sites."
+The base-integration guide does not wire up identify/clearUser, event recording, Creatives, push deep linking, FCM service priority handling, subscription management, runtime domain changes, or log level. Step 6 already emits the linked README pointers for these to the user — see that step for the canonical block.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,6 @@ Before editing anything, determine:
 3. **Application class**: Does the app already have a custom `Application` subclass?
    - Look for `android:name=".SomeApp"` (or fully-qualified) on the `<application>` tag in `AndroidManifest.xml`.
    - If yes, edit that class.
-   - If no, **stop and ask the user**. Do not create an `Application` subclass on their behalf — adding one has app-wide implications (lifecycle, DI, ContentProvider init order) that the user should own. Tell them they need a custom `Application` class for SDK init and let them decide whether to add one.
 4. **Language**: Is the existing Application class Kotlin or Java? Match it.
 5. **`minSdk`**: Note the value. The SDK supports API 26+; on lower API levels it no-ops but still builds. If the user's `minSdk < 26`, mention this once — do not raise their `minSdk` without permission.
 
@@ -260,7 +259,6 @@ Do not run the app on a device or emulator unless asked.
 - Do not add `identify()`, `clearUser()`, `updateUser()`, `recordEvent()`, or `Creative` calls.
 - Do not install Firebase or create a `google-services.json` — only detect what's already there.
 - Do not add `<service tools:node="remove">` for `AttentiveFirebaseMessagingService`. Use `pushEnabled(false)` instead.
-- Do not create an `Application` subclass for the user. If one doesn't exist, ask them to add it themselves.
 - Do not bump the user's `minSdk`, `targetSdk`, AGP version, or Kotlin version.
 - Do not introduce DI frameworks (Hilt/Dagger/Koin) to wire this — direct construction in `onCreate` is correct here.
 - Do not write tests for the integration unless asked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Before editing anything, determine:
 3. **Application class**: Does the app already have a custom `Application` subclass?
    - Look for `android:name=".SomeApp"` (or fully-qualified) on the `<application>` tag in `AndroidManifest.xml`.
    - If yes, edit that class.
-   - If no, create one (e.g. `MainApplication.kt` in the app's root package) and register it in the manifest.
+   - If no, **stop and ask the user**. Do not create an `Application` subclass on their behalf — adding one has app-wide implications (lifecycle, DI, ContentProvider init order) that the user should own. Tell them they need a custom `Application` class for SDK init and let them decide whether to add one.
 4. **Language**: Is the existing Application class Kotlin or Java? Match it.
 5. **`minSdk`**: Note the value. The SDK supports API 26+; on lower API levels it no-ops but still builds. If the user's `minSdk < 26`, mention this once — do not raise their `minSdk` without permission.
 
@@ -71,37 +71,11 @@ The SDK must be initialized as early as possible after process start so app-open
 
 ### If the client has no Application class
 
-Create `app/src/main/java/<their-package>/MainApplication.kt`:
+**Stop.** Do not create one. Tell the user:
 
-```kotlin
-package com.example.myapp
+> "The Attentive SDK needs to be initialized in `Application.onCreate()`, but this app doesn't have a custom `Application` subclass. Adding one has app-wide implications, so I'd like you to decide whether to add it. Once you've created an `Application` subclass and registered it in the manifest, I can wire up the Attentive init."
 
-import android.app.Application
-import com.attentive.androidsdk.AttentiveConfig
-import com.attentive.androidsdk.AttentiveSdk
-
-class MainApplication : Application() {
-    override fun onCreate() {
-        super.onCreate()
-
-        val attentiveConfig = AttentiveConfig.Builder()
-            .applicationContext(this)
-            .domain("YOUR_ATTENTIVE_DOMAIN")
-            .mode(AttentiveConfig.Mode.DEBUG)
-            .build()
-
-        AttentiveSdk.initialize(attentiveConfig)
-    }
-}
-```
-
-Then register it in `AndroidManifest.xml` on the `<application>` tag:
-
-```xml
-<application
-    android:name=".MainApplication"
-    ...>
-```
+Wait for the user to either add the class themselves or explicitly ask you to create one. Do not proceed.
 
 ### If the client already has an Application class
 
@@ -139,6 +113,7 @@ Do not run the app on a device or emulator unless asked.
 - Do not touch Firebase, push permissions, or `google-services.json`.
 - Do not remove or add the `AttentiveFirebaseMessagingService` manifest entry.
 - Do not add `notificationIconId(...)` to the builder.
+- Do not create an `Application` subclass for the user. If one doesn't exist, ask them to add it themselves.
 - Do not bump the user's `minSdk`, `targetSdk`, AGP version, or Kotlin version.
 - Do not introduce DI frameworks (Hilt/Dagger/Koin) to wire this — direct construction in `onCreate` is correct here.
 - Do not write tests for the integration unless asked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,19 +50,37 @@ Before editing anything, determine:
 
 ## Step 2 — Add the dependency
 
+### 2a. Look up the latest SDK version
+
+Do **not** hardcode a version from this guide — fetch the latest release from GitHub at integration time so the user gets the current SDK. Run one of the following and capture the `tag_name`, stripping the leading `v`:
+
+```bash
+curl -fsSL https://api.github.com/repos/attentive-mobile/attentive-android-sdk/releases/latest \
+  | grep -m1 '"tag_name"' \
+  | sed -E 's/.*"v?([^"]+)".*/\1/'
+```
+
+If `jq` is available: `curl -fsSL …/releases/latest | jq -r .tag_name | sed 's/^v//'`. If you have a web-fetch tool instead of shell access, fetch `https://github.com/attentive-mobile/attentive-android-sdk/releases/latest` (it redirects to `/releases/tag/v<version>`) and read the version out of the URL or page title.
+
+If the lookup fails (no network, rate-limited, etc.), tell the user and ask them for the version they want to use — do not guess.
+
+Use the resolved version (e.g. `2.1.7`) in place of `<VERSION>` below.
+
+### 2b. Add to the build file
+
 In the **app module's** `build.gradle` or `build.gradle.kts`, add to `dependencies`:
 
 **Groovy (`build.gradle`):**
 ```groovy
-implementation 'com.attentive:attentive-android-sdk:2.1.7'
+implementation 'com.attentive:attentive-android-sdk:<VERSION>'
 ```
 
 **Kotlin DSL (`build.gradle.kts`):**
 ```kotlin
-implementation("com.attentive:attentive-android-sdk:2.1.7")
+implementation("com.attentive:attentive-android-sdk:<VERSION>")
 ```
 
-> Use `2.1.7` as the default version. If the client uses a version catalog (`libs.versions.toml`), add an entry there instead and reference it via `libs.attentive.android.sdk`.
+> If the client uses a version catalog (`libs.versions.toml`), add an entry there instead (`attentive-android-sdk = "<VERSION>"` plus a library entry) and reference it via `libs.attentive.android.sdk`.
 
 Ensure `mavenCentral()` is in the authoritative repositories block. If `dependencyResolutionManagement` exists in `settings.gradle`(.kts), add it there; otherwise add to the root `build.gradle` `allprojects { repositories { ... } }`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,18 @@ Wait for the user to either add the class themselves or explicitly ask you to cr
 
 Add the same two blocks (`AttentiveConfig.Builder()...build()` and `AttentiveSdk.initialize(...)`) inside the existing `onCreate()`, **after** `super.onCreate()` and after any logging/crash-reporter initialization the client already has. Do not reorder existing initialization. Match the file's language (Kotlin or Java).
 
-**Java equivalent:**
+**Kotlin:**
+```kotlin
+val attentiveConfig = AttentiveConfig.Builder()
+    .applicationContext(this)
+    .domain("YOUR_ATTENTIVE_DOMAIN")
+    .mode(AttentiveConfig.Mode.DEBUG)
+    .build()
+
+AttentiveSdk.initialize(attentiveConfig)
+```
+
+**Java:**
 ```java
 AttentiveConfig attentiveConfig = new AttentiveConfig.Builder()
     .applicationContext(this)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,150 @@
+# CLAUDE.md
+
+## Project Overview
+
+Attentive Android SDK — provides identity, event tracking, creatives, push notifications, and inbox for Android apps. Supports Kotlin and Java consumers.
+
+## Internal API Documentation
+
+Internal Attentive API documentation and instructions live in the private [`attentive-mobile/claude-plugins`](https://github.com/attentive-mobile/claude-plugins) repo as the `mobile-sdk-internal` plugin. To load this context into Claude Code:
+
+```
+/plugin marketplace add attentive-mobile/claude-plugins
+/plugin install mobile-sdk-internal@attentive-mobile
+```
+
+This keeps internal details out of the public SDK repo while letting Claude Code pull them in at runtime.
+
+## Project Structure
+
+Multi-module Android Gradle project:
+- **attentive-android-sdk** — The SDK library, published to Maven Central as `com.attentive:attentive-android-sdk`
+- **bonni** — Internal demo/test app distributed via Firebase App Distribution
+- **attentive-lint** — Custom lint rules
+- **scripts/** — Gradle publish scripts (`publish-root.gradle`, `publish-module.gradle`)
+
+## Build & Test
+
+```bash
+# Unit tests
+./gradlew :attentive-android-sdk:testDebugUnitTest
+
+# Lint
+./gradlew lintDebug
+./gradlew ktlintCheck
+
+# Build SDK
+./gradlew :attentive-android-sdk:assembleRelease
+
+# Snapshot tests (bonni)
+./gradlew :bonni:verifyRoborazziDebug
+```
+
+SDK targets Java 11. Bonni requires Java 21. Kotlin 2.0.0 with Compose.
+
+## Versioning
+
+SDK version lives in `attentive-android-sdk/gradle.properties` as `VERSION_NAME=x.y.z`. Beta versions use format `x.y.z.beta.N`.
+
+## Publishing
+
+Published to Maven Central via Sonatype:
+```bash
+./gradlew clean publishToSonatype closeAndReleaseSonatypeStagingRepository
+```
+- **Local**: Uses credentials from `local.properties`
+- **CI**: GitHub Action triggers CircleCI pipeline with signing and Sonatype credentials provided as env vars.
+
+## CI
+
+- **GitHub Actions** (`ci.yml`) — Runs unit tests and checkstyle on push/PR to main and feature branches
+- **CircleCI** (`.circleci/config.yml`) — Lint, unit tests, instrumented tests, snapshot tests, build, bonni distribution, and release pipeline
+- **Release workflow** — GitHub Action (`release.yml`) triggers CircleCI which publishes to Maven Central, creates GitHub Release, and opens version bump PR. Beta versions skip release/bump.
+
+## Git Push Policy
+
+- **Feature/bugfix branches**: You may push freely without asking.
+- **main and develop**: Never push without explicit user confirmation. If the user's original message says "push it" or similar, that counts. Otherwise, stop and ask before pushing. Do not push in the same turn as asking the question — wait for the user's reply.
+
+## Branching
+
+- `main` — stable release branch
+- `develop` — integration branch (cutting-edge changes)
+- Feature branches: `feature/MSDK-###-description`
+- Bugfix branches: `bugfix/MSDK-###-description`
+- Release branches: `release/x.y.z`
+- Merge branches (reconciling `develop` → `main` or similar): `merge/<from>-to-<to>-MMDDYYYY`, e.g. `merge/develop-to-main-05112026`. The date is the date the merge branch is created.
+- **Do not create branches with new prefix directories** (e.g. `docs/`, `chore/`) without asking first. Stick to the established prefixes above.
+
+### Keeping main and develop in sync
+
+- **Features** go into `develop` first. When ready, merge `develop` into `main` using a **regular merge commit** (not squash merge). Squash merges create new commit hashes that prevent git from recognizing shared history, causing conflicts on future merges.
+- **Hotfixes** land on `main` first (for urgent shipping), then get **cherry-picked into `develop` immediately** — same day, before more work lands on either branch.
+- When merging `develop` → `main`, always use `git merge` (not squash) so both branches maintain shared commit history.
+
+## Key Conventions
+
+- **Singleton + object pattern** for SDK entry points (`AttentiveSdk`, `AttentivePush`)
+- **Builder pattern** for all public-facing models (config, events, identifiers)
+- **Coroutine-first async design** with callback wrappers for Java interop
+- **Public API** lives in top-level packages; internal implementation details stay in `internal` subpackages
+- **Persistence** goes through `PersistentStorage` (SharedPreferences wrapper) — never access SharedPreferences directly
+- Use the SDK logger — never `println()` or `Log.d()` directly
+- Domain validation rejects URLs containing scheme/path separators — pass bare hostnames
+
+## Architecture
+
+### Initialization
+- `AttentiveSdk` (Kotlin object) is the main public API — singleton facade
+- `AttentiveConfig.Builder` constructs config with validation, wires up all dependencies
+- `ClassFactory` builds internal components: `PersistentStorage`, `VisitorService`, `SettingsService`, `OkHttpClient`, `AttentiveApi`
+
+### Event Pipeline
+- Public event types: `PurchaseEvent`, `AddToCartEvent`, `ProductViewEvent`, `CustomEvent`
+- One event can produce multiple API requests (e.g., Purchase with 3 items = 3 Purchase + 1 OrderConfirmed)
+- Flow: `AttentiveSdk.recordEvent()` → `AttentiveEventTracker` → mapper → `AttentiveApi` → network
+- Events enriched with user identifiers (email/phone Base64-encoded)
+- Kotlin serialization with polymorphic metadata (`className` discriminator)
+
+### Networking
+- OkHttp with interceptor chain: `UserAgentInterceptor` → `HttpLoggingInterceptor`
+- Domain passed directly by the developer — no geo-domain resolution
+
+### Creatives
+- WebView-based display system
+- Communication via `WebMessageListener` JSON messages (OPEN/CLOSE/RESIZE_FRAME)
+- Touch filtering: only touches within creative bounds pass to WebView
+- Lifecycle-aware: auto-destroys via `CreativeActivityCallbacks` on API 30+
+
+### User Identification
+- `UserIdentifiers` with builder pattern — holds visitorId, clientUserId, email, phone, shopifyId, klaviyoId, customIdentifiers
+- Visitor ID: auto-generated UUID, persisted in SharedPreferences, regenerated on `clearUser()`
+- `identify()` merges new identifiers with existing (second overwrites first)
+- `clearUser()` resets all identifiers and generates new visitor ID
+
+### Push Notifications
+- `AttentivePush` singleton handles token management and notification display
+- `TokenProvider` wraps Firebase token retrieval with caching
+- `AppLaunchTracker` observes `ProcessLifecycleOwner` to detect notification-driven launches
+
+### Inbox
+- Compose-based UI (`AttentiveInbox`) driven by `StateFlow<InboxState>`
+- Swipe gestures: right to delete, left to mark unread
+- Offset-based pagination with debouncing and Mutex for thread safety
+- Image loading via Coil3
+
+## Testing
+
+- **Framework**: JUnit 4 with Mockito
+- **Test doubles**: Use the `FactoryMocks` helper for mocking SDK internals
+- **Pattern**: Constructor-inject dependencies, then pass mocks in tests
+- **Snapshot testing**: Roborazzi for Compose UI (`bonni` module)
+
+## Do Not
+
+- **Use `!!` (force unwrap)** without clear justification — prefer safe-call (`?.`) or `requireNotNull` with a message
+- **Access SharedPreferences directly** — go through `PersistentStorage`
+- **Use `Log.d`/`println`** — use the SDK logger
+- **Add dependencies** without team discussion — the SDK must stay lightweight
+- **Expose internal types** in the public API surface
+- **Hardcode URLs or domains** — accept them via config

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ for a sample of how the Attentive Android SDK is used.
 
 __*** NOTE: Please refrain from using any private or undocumented classes or methods as they may change between releases. ***__
 
+### Setup with an AI coding agent
+
+If you use Claude Code, Cursor, Copilot, Codex, or another AI coding agent, you can have the agent walk you through setup. Point it at [`AGENTS.md`](./AGENTS.md) in this repo — it's a step-by-step integration guide written for agents that handles dependency wiring, `Application` initialization, and an interactive push-setup flow (Firebase detection, `FirebaseMessagingService` forwarding, notification icon, and permission prompt).
+
+**What the agent flow intentionally does not do:**
+
+- **Identify / clearUser / updateUser wiring.** These hook into your login, logout, and account-switch flows, which are sensitive auth-adjacent code paths. You should decide where they go.
+- **Event recording (`PurchaseEvent`, `AddToCartEvent`, `ProductViewEvent`, `CustomEvent`).** Where and how you fire these is highly domain-specific (your checkout, cart, and PDP code is yours), so the agent leaves them to you.
+- **Showing Creatives.** Creatives are optional functionality, so the agent doesn't wire them up by default.
+
+For all of these, follow the relevant sections of this README.
+
 ## Step 1 - SDK initialization
 
 __*** NOTE: To function properly, the SDK must be initialized as soon as possible after application startup. This is required for us to properly track metrics (app open events, etc) ***__

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ __*** NOTE: Please refrain from using any private or undocumented classes or met
 
 If you use Claude Code, Cursor, Copilot, Codex, or another AI coding agent, you can have the agent walk you through setup. Point it at [`AGENTS.md`](./AGENTS.md) in this repo — it's a step-by-step integration guide written for agents that handles dependency wiring, `Application` initialization, and an interactive push-setup flow (Firebase detection, `FirebaseMessagingService` forwarding, notification icon, and permission prompt).
 
+**To trigger the flow**, open your project in your agent of choice and paste a prompt like:
+
+> Integrate the Attentive Android SDK into this app. Follow the guide at https://github.com/attentive-mobile/attentive-android-sdk/blob/main/AGENTS.md top-to-bottom and ask me any questions it tells you to ask before writing code.
+
+The agent will collect your Attentive domain, inspect the build setup, add the dependency, sync Gradle, wire up `AttentiveSdk.initialize` in your `Application` class, and then ask whether you want push notifications enabled before going further.
+
 **What the agent flow intentionally does not do:**
 
 - **Identify / clearUser / updateUser wiring.** These hook into your login, logout, and account-switch flows, which are sensitive auth-adjacent code paths. You should decide where they go.


### PR DESCRIPTION
## Ticket
[MSDK-349](https://attentivemobile.atlassian.net/browse/MSDK-349)

## Summary
- Adds `AGENTS.md` at the repo root as a tightly-scoped integration guide for AI coding agents (Claude Code, Cursor, Copilot, Codex, etc.)
- Functions as an alternative to reading the full `README.md` — focused on agent execution, not human reading
- Scope is intentionally limited to the minimum viable integration: Maven Central dependency, host `Application` class, `AttentiveConfig` + `AttentiveSdk.initialize` in `onCreate`
- Explicitly forbids the agent from wiring identify/clearUser/updateUser, recording events, rendering creatives, or doing anything related to push/Firebase, so client agents don't over-implement on the first pass
- Pinned to SDK version `2.1.7`

## Typical client usage

A client developer integrating Attentive into their Android app points their AI agent at this repo (or copies `AGENTS.md` into their own repo) and gives a one-line prompt:

> "Set up the Attentive Android SDK in this app."

The agent then:

1. **Inspects the client codebase** — detects Groovy vs Kotlin DSL, whether repositories are declared in root `build.gradle` or `settings.gradle` `dependencyResolutionManagement`, whether a custom `Application` subclass already exists (via `android:name` on `<application>`), the language of that class, and the project's `minSdk`.
2. **Asks the user for their Attentive domain** (and defaults `Mode` to `DEBUG` for first-time integration, with a note to switch to `PRODUCTION` for release).
3. **Adds the dependency** (`com.attentive:attentive-android-sdk:2.1.7`) to the app module, ensuring `mavenCentral()` is in the authoritative repositories block.
4. **Wires init in `Application.onCreate`** — either editing the existing class or creating `MainApplication.kt`/`.java` and registering it in `AndroidManifest.xml`. Matches the host project's language.
5. **Stops.** Runs a Gradle sync / `assembleDebug` to verify, then tells the user to replace the domain placeholder if needed and points them to `README.md` for identify, events, creatives, or push.

The "Things NOT to do" section keeps the agent from drifting into Firebase setup, manifest mutations for the messaging service, DI wiring, `minSdk` bumps, or speculative event recording.

## Test plan
- [ ] Verify `AGENTS.md` renders correctly on GitHub
- [x] Dry-run the guide against a sample Android app (with a custom `Application` class) and confirm the agent produces a working integration
- [x] Dry-run against an app with no `Application` class and confirm `MainApplication` is created and registered in the manifest
- [x] Confirm the agent does not touch push/Firebase/identify/events when given the base prompt

Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-349]: https://attentivemobile.atlassian.net/browse/MSDK-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ