### PR TITLE
MSDK-366: Run release pipeline via PR instead of pushing to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,18 +311,33 @@ jobs:
               echo "gradle.properties already at $RELEASE_VERSION; skipping release branch + PR. Publishing from current commit."
             else
               git commit -m "Set version to $RELEASE_VERSION"
-              git push origin "$BRANCH"
+              git push --force origin "$BRANCH"
 
-              curl -sf -X POST \
+              GH_API_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+              if [ -z "$GH_API_TOKEN" ]; then
+                echo "Neither GITHUB_TOKEN nor GH_TOKEN is set in this CircleCI context; cannot open PR." >&2
+                exit 1
+              fi
+
+              HTTP_STATUS=$(curl -s -o /tmp/pr-response.json -w "%{http_code}" \
+                -X POST \
                 "https://api.github.com/repos/attentive-mobile/attentive-android-sdk/pulls" \
-                -H "Authorization: token $GITHUB_TOKEN" \
+                -H "Authorization: token $GH_API_TOKEN" \
                 -H "Content-Type: application/json" \
                 -d "{
                   \"title\": \"Release v$RELEASE_VERSION\",
                   \"body\": \"Automated release PR. Maven Central publish and GitHub Release are performed from this branch by CircleCI. Merge into main once verified.\",
                   \"head\": \"$BRANCH\",
                   \"base\": \"main\"
-                }"
+                }")
+
+              echo "GitHub PR API status: $HTTP_STATUS"
+              cat /tmp/pr-response.json
+              echo
+
+              if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
+                exit 1
+              fi
             fi
       - run:
           name: Clean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,6 @@ parameters:
   release_version:
     type: string
     default: ""
-  next_version:
-    type: string
-    default: ""
 
 # Reusable environment variables
 environment: &default_environment
@@ -291,40 +288,37 @@ jobs:
             fi
             echo "export RELEASE_VERSION=$VERSION" >> "$BASH_ENV"
 
-            # Detect beta versions
             if echo "$VERSION" | grep -qi "beta"; then
               echo "export IS_BETA=true" >> "$BASH_ENV"
-              echo "Beta release detected — skipping GitHub Release and version bump"
+              echo "Beta release detected — skipping GitHub Release"
             else
               echo "export IS_BETA=false" >> "$BASH_ENV"
-
-              if [ -n "<< pipeline.parameters.next_version >>" ]; then
-                NEXT="<< pipeline.parameters.next_version >>"
-              else
-                MAJOR=$(echo "$VERSION" | cut -d. -f1)
-                MINOR=$(echo "$VERSION" | cut -d. -f2)
-                PATCH=$(echo "$VERSION" | cut -d. -f3)
-                NEXT="$MAJOR.$MINOR.$((PATCH + 1))"
-              fi
-              echo "export NEXT_VERSION=$NEXT" >> "$BASH_ENV"
-              echo "Next dev version: $NEXT"
             fi
 
             echo "Releasing: $VERSION"
       - run:
-          name: Set release version
-          command: |
-            sed -i "s/^VERSION_NAME=.*/VERSION_NAME=$RELEASE_VERSION/" attentive-android-sdk/gradle.properties
-      - run:
-          name: Commit release version
+          name: Push release branch and open PR
           command: |
             git config user.name "circleci[bot]"
             git config user.email "circleci[bot]@users.noreply.github.com"
+
+            BRANCH="release/$RELEASE_VERSION"
+            git checkout -b "$BRANCH"
+            sed -i "s/^VERSION_NAME=.*/VERSION_NAME=$RELEASE_VERSION/" attentive-android-sdk/gradle.properties
             git add attentive-android-sdk/gradle.properties
-            if ! git diff --cached --quiet; then
-              git commit -m "Set version to $RELEASE_VERSION"
-              git push origin HEAD:main
-            fi
+            git commit -m "Set version to $RELEASE_VERSION"
+            git push origin "$BRANCH"
+
+            curl -sf -X POST \
+              "https://api.github.com/repos/attentive-mobile/attentive-android-sdk/pulls" \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "{
+                \"title\": \"Release v$RELEASE_VERSION\",
+                \"body\": \"Automated release PR. Maven Central publish and GitHub Release are performed from this branch by CircleCI. Merge into main once verified.\",
+                \"head\": \"$BRANCH\",
+                \"base\": \"main\"
+              }"
       - run:
           name: Clean
           command: ./gradlew clean
@@ -338,43 +332,16 @@ jobs:
               echo "Skipping GitHub Release for beta version"
               exit 0
             fi
-            git tag "v$RELEASE_VERSION"
-            git push origin "v$RELEASE_VERSION"
+            git tag "$RELEASE_VERSION"
+            git push origin "$RELEASE_VERSION"
             curl -sf -X POST \
               "https://api.github.com/repos/attentive-mobile/attentive-android-sdk/releases" \
               -H "Authorization: token $GITHUB_TOKEN" \
               -H "Content-Type: application/json" \
               -d "{
-                \"tag_name\": \"v$RELEASE_VERSION\",
-                \"name\": \"v$RELEASE_VERSION\",
+                \"tag_name\": \"$RELEASE_VERSION\",
+                \"name\": \"$RELEASE_VERSION\",
                 \"generate_release_notes\": true
-              }"
-      - run:
-          name: Create version bump PR
-          command: |
-            if [ "$IS_BETA" = "true" ]; then
-              echo "Skipping version bump for beta version"
-              exit 0
-            fi
-            git config user.name "circleci[bot]"
-            git config user.email "circleci[bot]@users.noreply.github.com"
-
-            BRANCH="chore/bump-version-to-$NEXT_VERSION"
-            git checkout -b "$BRANCH"
-            sed -i "s/^VERSION_NAME=.*/VERSION_NAME=$NEXT_VERSION/" attentive-android-sdk/gradle.properties
-            git add attentive-android-sdk/gradle.properties
-            git commit -m "Bump version to $NEXT_VERSION"
-            git push origin "$BRANCH"
-
-            curl -sf -X POST \
-              "https://api.github.com/repos/attentive-mobile/attentive-android-sdk/pulls" \
-              -H "Authorization: token $GITHUB_TOKEN" \
-              -H "Content-Type: application/json" \
-              -d "{
-                \"title\": \"Bump version to $NEXT_VERSION\",
-                \"body\": \"Automated version bump after releasing v$RELEASE_VERSION to Maven Central.\",
-                \"head\": \"$BRANCH\",
-                \"base\": \"main\"
               }"
       - notify-slack-on-failure
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ version: 2.1
 orbs:
   android: circleci/android@2.5.0
   slack: circleci/slack@6.1.3
+  attentive: attentive-mobile/circleci-orb@0.0.11
 
 # ========================
 # Constants
@@ -274,6 +275,17 @@ jobs:
     executor: android-executor
     steps:
       - checkout
+      - attentive/app-based-github-token:
+          github_app_client_id: ${GITHUB_APP_CLIENT_ID}
+          github_app_private_key_base64: ${GITHUB_APP_PRIVATE_KEY_BASE64}
+          github_app_installation_id: ${GITHUB_APP_INSTALLATION_ID}
+      - run:
+          name: Switch git remote to HTTPS with App token
+          command: |
+            git remote set-url origin "https://github.com/attentive-mobile/attentive-android-sdk.git"
+            git config --local --replace-all \
+              "http.https://github.com/.extraheader" \
+              "Authorization: basic $(printf 'x-access-token:%s' "${GITHUB_TOKEN}" | base64 -w 0)"
       - restore_cache:
           keys:
             - gradle-v2-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "attentive-android-sdk/build.gradle" }}
@@ -313,32 +325,10 @@ jobs:
               git commit -m "Set version to $RELEASE_VERSION"
               git push --force origin "$BRANCH"
 
-              GH_API_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
-              if [ -n "$GITHUB_TOKEN" ]; then
-                echo "Token source: GITHUB_TOKEN"
-              elif [ -n "$GH_TOKEN" ]; then
-                echo "Token source: GH_TOKEN"
-              else
-                echo "Neither GITHUB_TOKEN nor GH_TOKEN is set in this CircleCI context; cannot open PR." >&2
-                exit 1
-              fi
-
-              echo "--- Authenticated user ---"
-              GH_USER=$(curl -s -H "Authorization: token $GH_API_TOKEN" https://api.github.com/user)
-              echo "$GH_USER" | jq '{login, type, name}'
-              GH_LOGIN=$(echo "$GH_USER" | jq -r '.login // empty')
-
-              if [ -n "$GH_LOGIN" ]; then
-                echo "--- Permission on attentive-android-sdk for $GH_LOGIN ---"
-                curl -s -H "Authorization: token $GH_API_TOKEN" \
-                  "https://api.github.com/repos/attentive-mobile/attentive-android-sdk/collaborators/$GH_LOGIN/permission" \
-                  | jq '{permission, role_name, message}'
-              fi
-
               HTTP_STATUS=$(curl -s -o /tmp/pr-response.json -w "%{http_code}" \
                 -X POST \
                 "https://api.github.com/repos/attentive-mobile/attentive-android-sdk/pulls" \
-                -H "Authorization: token $GH_API_TOKEN" \
+                -H "Authorization: token $GITHUB_TOKEN" \
                 -H "Content-Type: application/json" \
                 -d "{
                   \"title\": \"Release v$RELEASE_VERSION\",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,9 +314,25 @@ jobs:
               git push --force origin "$BRANCH"
 
               GH_API_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
-              if [ -z "$GH_API_TOKEN" ]; then
+              if [ -n "$GITHUB_TOKEN" ]; then
+                echo "Token source: GITHUB_TOKEN"
+              elif [ -n "$GH_TOKEN" ]; then
+                echo "Token source: GH_TOKEN"
+              else
                 echo "Neither GITHUB_TOKEN nor GH_TOKEN is set in this CircleCI context; cannot open PR." >&2
                 exit 1
+              fi
+
+              echo "--- Authenticated user ---"
+              GH_USER=$(curl -s -H "Authorization: token $GH_API_TOKEN" https://api.github.com/user)
+              echo "$GH_USER" | jq '{login, type, name}'
+              GH_LOGIN=$(echo "$GH_USER" | jq -r '.login // empty')
+
+              if [ -n "$GH_LOGIN" ]; then
+                echo "--- Permission on attentive-android-sdk for $GH_LOGIN ---"
+                curl -s -H "Authorization: token $GH_API_TOKEN" \
+                  "https://api.github.com/repos/attentive-mobile/attentive-android-sdk/collaborators/$GH_LOGIN/permission" \
+                  | jq '{permission, role_name, message}'
               fi
 
               HTTP_STATUS=$(curl -s -o /tmp/pr-response.json -w "%{http_code}" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,19 +306,24 @@ jobs:
             git checkout -b "$BRANCH"
             sed -i "s/^VERSION_NAME=.*/VERSION_NAME=$RELEASE_VERSION/" attentive-android-sdk/gradle.properties
             git add attentive-android-sdk/gradle.properties
-            git commit -m "Set version to $RELEASE_VERSION"
-            git push origin "$BRANCH"
 
-            curl -sf -X POST \
-              "https://api.github.com/repos/attentive-mobile/attentive-android-sdk/pulls" \
-              -H "Authorization: token $GITHUB_TOKEN" \
-              -H "Content-Type: application/json" \
-              -d "{
-                \"title\": \"Release v$RELEASE_VERSION\",
-                \"body\": \"Automated release PR. Maven Central publish and GitHub Release are performed from this branch by CircleCI. Merge into main once verified.\",
-                \"head\": \"$BRANCH\",
-                \"base\": \"main\"
-              }"
+            if git diff --cached --quiet; then
+              echo "gradle.properties already at $RELEASE_VERSION; skipping release branch + PR. Publishing from current commit."
+            else
+              git commit -m "Set version to $RELEASE_VERSION"
+              git push origin "$BRANCH"
+
+              curl -sf -X POST \
+                "https://api.github.com/repos/attentive-mobile/attentive-android-sdk/pulls" \
+                -H "Authorization: token $GITHUB_TOKEN" \
+                -H "Content-Type: application/json" \
+                -d "{
+                  \"title\": \"Release v$RELEASE_VERSION\",
+                  \"body\": \"Automated release PR. Maven Central publish and GitHub Release are performed from this branch by CircleCI. Merge into main once verified.\",
+                  \"head\": \"$BRANCH\",
+                  \"base\": \"main\"
+                }"
+            fi
       - run:
           name: Clean
           command: ./gradlew clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
         description: 'Version to release (e.g. 2.1.3). Leave empty to use the version in gradle.properties.'
         required: false
         type: string
+      branch:
+        description: 'Branch to run the release pipeline against. Defaults to main.'
+        required: false
+        type: string
+        default: 'main'
 
 jobs:
   trigger-release:
@@ -21,7 +26,7 @@ jobs:
             -H "Circle-Token: ${{ secrets.CIRCLECI_TOKEN }}" \
             -H "Content-Type: application/json" \
             -d '{
-              "branch": "main",
+              "branch": "${{ inputs.branch }}",
               "parameters": {
                 "run_release": true,
                 "release_version": "${{ inputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,6 @@ on:
         description: 'Version to release (e.g. 2.1.3). Leave empty to use the version in gradle.properties.'
         required: false
         type: string
-      next_version:
-        description: 'Next development version (e.g. 2.1.4). Leave empty to auto-increment patch.'
-        required: false
-        type: string
 
 jobs:
   trigger-release:
@@ -28,7 +24,6 @@ jobs:
               "branch": "main",
               "parameters": {
                 "run_release": true,
-                "release_version": "${{ inputs.version }}",
-                "next_version": "${{ inputs.next_version }}"
+                "release_version": "${{ inputs.version }}"
               }
             }'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ Published to Maven Central via Sonatype:
 
 - **GitHub Actions** (`ci.yml`) — Runs unit tests and checkstyle on push/PR to main and feature branches
 - **CircleCI** (`.circleci/config.yml`) — Lint, unit tests, instrumented tests, snapshot tests, build, bonni distribution, and release pipeline
-- **Release workflow** — GitHub Action (`release.yml`) triggers CircleCI which publishes to Maven Central, creates GitHub Release, and opens version bump PR. Beta versions skip release/bump.
+- **Release workflow** — GitHub Action (`release.yml`) triggers CircleCI which pushes a `release/x.y.z` branch, opens a PR into `main`, then publishes to Maven Central and creates a GitHub Release tagged off the release branch. The PR is merged into `main` manually after the release is verified. Beta versions skip the GitHub Release.
 
 ## Git Push Policy
 


### PR DESCRIPTION
## Summary
- Release job now creates a `release/x.y.z` branch and opens a PR into `main` instead of pushing directly (which was rejected by the Trufflehog required status check rule).
- Maven Central publish, tagging, and GitHub Release all run from the release branch. The PR is merged into `main` manually after the release is verified.
- Removed the next-version bump PR and the `next_version` workflow input — not needed.
- Tag name is now bare (`x.y.z`) instead of `vx.y.z`.

[MSDK-366](https://attentivemobile.atlassian.net/browse/MSDK-366)

## Test plan
- [ ] Merge this PR into `main`.
- [ ] Trigger the **Release** GitHub Action with `version=2.1.8`.
- [ ] Verify CircleCI pipeline runs to completion: pushes `release/2.1.8`, opens PR, publishes to Maven Central, creates `2.1.8` tag and GitHub Release.
- [ ] Verify the release PR can be merged manually into `main` afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-366]: https://attentivemobile.atlassian.net/browse/MSDK-366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ