### PR TITLE
MSDK-375: expose AttentiveSdk.domain accessor

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -284,6 +284,10 @@ object AttentiveSdk {
         }
     }
 
+    @get:JvmStatic
+    val domain: String?
+        get() = _config?.domain
+
     /**
      * Records an analytics event with Attentive in a fire-and-forget manner. Errors are
      * logged but not surfaced to the caller. For coroutine-aware error handling, use

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -285,8 +285,8 @@ object AttentiveSdk {
     }
 
     @get:JvmStatic
-    val domain: String?
-        get() = _config?.domain
+    val domain: String
+        get() = config.domain
 
     /**
      * Records an analytics event with Attentive in a fire-and-forget manner. Errors are

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -284,6 +284,11 @@ object AttentiveSdk {
         }
     }
 
+    /**
+     * The Attentive domain the SDK is currently configured with, or `null` if [initialize]
+     * has not been called yet. Reflects [AttentiveConfig.domain] including any subsequent
+     * [AttentiveConfig.changeDomain] updates.
+     */
     @get:JvmStatic
     val domain: String?
         get() = _config?.domain

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -284,11 +284,6 @@ object AttentiveSdk {
         }
     }
 
-    /**
-     * The Attentive domain the SDK is currently configured with, or `null` if [initialize]
-     * has not been called yet. Reflects [AttentiveConfig.domain] including any subsequent
-     * [AttentiveConfig.changeDomain] updates.
-     */
     @get:JvmStatic
     val domain: String?
         get() = _config?.domain

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveSdkTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveSdkTest.kt
@@ -117,31 +117,6 @@ class AttentiveSdkTest {
         }
     }
 
-    @Test
-    fun domain_returnsConfiguredDomain_whenInitialized() {
-        assertTrue(AttentiveSdk.domain == DOMAIN)
-    }
-
-    @Test
-    fun domain_returnsNull_whenNotInitialized() {
-        val field = AttentiveSdk::class.java.getDeclaredField("_config")
-        field.isAccessible = true
-        field.set(AttentiveSdk, null)
-
-        assertTrue(AttentiveSdk.domain == null)
-    }
-
-    @Test
-    fun domain_reflectsChangeDomain() {
-        val newDomain = "newTestDomain"
-        val field = AttentiveSdk::class.java.getDeclaredField("_config")
-        field.isAccessible = true
-        val config = field.get(AttentiveSdk) as AttentiveConfig
-        config.changeDomain(newDomain)
-
-        assertTrue(AttentiveSdk.domain == newDomain)
-    }
-
     companion object {
         private const val DOMAIN = "testDomain"
         private const val VISITOR_ID = "visitorIdValue"

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveSdkTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveSdkTest.kt
@@ -117,6 +117,31 @@ class AttentiveSdkTest {
         }
     }
 
+    @Test
+    fun domain_returnsConfiguredDomain_whenInitialized() {
+        assertTrue(AttentiveSdk.domain == DOMAIN)
+    }
+
+    @Test
+    fun domain_returnsNull_whenNotInitialized() {
+        val field = AttentiveSdk::class.java.getDeclaredField("_config")
+        field.isAccessible = true
+        field.set(AttentiveSdk, null)
+
+        assertTrue(AttentiveSdk.domain == null)
+    }
+
+    @Test
+    fun domain_reflectsChangeDomain() {
+        val newDomain = "newTestDomain"
+        val field = AttentiveSdk::class.java.getDeclaredField("_config")
+        field.isAccessible = true
+        val config = field.get(AttentiveSdk) as AttentiveConfig
+        config.changeDomain(newDomain)
+
+        assertTrue(AttentiveSdk.domain == newDomain)
+    }
+
     companion object {
         private const val DOMAIN = "testDomain"
         private const val VISITOR_ID = "visitorIdValue"

--- a/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
+++ b/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
@@ -568,7 +568,7 @@ fun SwitchUserWithPhoneSetting(
 @Composable
 fun EditableDomainSetting(settingItem: SettingItem) {
     var isEditing by remember { mutableStateOf(false) }
-    var domain by remember { mutableStateOf(AttentiveSdk.domain ?: "") }
+    var domain by remember { mutableStateOf(AttentiveSdk.domain) }
 
     AnimatedContent(targetState = isEditing) { editing ->
         if (editing) {
@@ -580,7 +580,7 @@ fun EditableDomainSetting(settingItem: SettingItem) {
                     singleLine = true,
                     colors =
                         OutlinedTextFieldDefaults.colors(
-                            focusedBorderColor = BonniPink,
+                            focusedBorderColor = BonniPink,q
                             unfocusedBorderColor = Color.Gray,
                             focusedTextColor = Color.Black,
                         ),

--- a/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
+++ b/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
@@ -580,7 +580,7 @@ fun EditableDomainSetting(settingItem: SettingItem) {
                     singleLine = true,
                     colors =
                         OutlinedTextFieldDefaults.colors(
-                            focusedBorderColor = BonniPink,q
+                            focusedBorderColor = BonniPink,
                             unfocusedBorderColor = Color.Gray,
                             focusedTextColor = Color.Black,
                         ),

--- a/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
+++ b/bonni/src/main/java/com/attentive/bonni/settings/SettingsScreenComposables.kt
@@ -568,7 +568,7 @@ fun SwitchUserWithPhoneSetting(
 @Composable
 fun EditableDomainSetting(settingItem: SettingItem) {
     var isEditing by remember { mutableStateOf(false) }
-    var domain by remember { mutableStateOf(AttentiveEventTracker.instance.config.domain) }
+    var domain by remember { mutableStateOf(AttentiveSdk.domain ?: "") }
 
     AnimatedContent(targetState = isEditing) { editing ->
         if (editing) {


### PR DESCRIPTION
## Summary
- Add a public `@get:JvmStatic val domain: String?` accessor on the `AttentiveSdk` singleton that returns `_config?.domain` (or `null` when uninitialized).
- Add unit tests covering the initialized, uninitialized, and post-`changeDomain` paths.

## Why
The SDK currently exposes domain only on the per-instance `AttentiveConfig`. Consumers that don't hold their own config reference (notably the React Native bridge — see [MSDK-361](https://attentivemobile.atlassian.net/browse/MSDK-361)) have no public path to read the configured domain. This mirrors what iOS already exposes via `@objc public internal(set) var domain` on `ATTNSDK`.

## Test plan
- [x] `./gradlew :attentive-android-sdk:testDebugUnitTest --tests "com.attentive.androidsdk.AttentiveSdkTest"` — 9/9 pass, including the 3 new `domain_*` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-361]: https://attentivemobile.atlassian.net/browse/MSDK-361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ