### PR TITLE
MSDK-408: Include domain in all inbox request payloads

### DIFF
--- a/attentive-android-sdk/build.gradle
+++ b/attentive-android-sdk/build.gradle
@@ -131,6 +131,7 @@ dependencies {
     implementation(libs.okhttp.logging)
     implementation(libs.retrofit)
     implementation(libs.retrofit.gson)
+    implementation(libs.retrofit.kotlinx.serialization)
     implementation(libs.gson)
 
     // Serialization

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -33,8 +33,10 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import okhttp3.OkHttpClient
 import org.jetbrains.annotations.VisibleForTesting
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
 import retrofit2.Retrofit
-import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import timber.log.Timber
 
 object AttentiveSdk {
@@ -88,10 +90,11 @@ object AttentiveSdk {
         )
         val inboxBaseUrl = appInfo.metaData?.getString(INBOX_BASE_URL_META_KEY)
         if (inboxBaseUrl != null) {
+            val json = Json { ignoreUnknownKeys = true }
             inboxApi = Retrofit.Builder()
                 .baseUrl(inboxBaseUrl)
                 .client(OkHttpClient())
-                .addConverterFactory(GsonConverterFactory.create())
+                .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
                 .build()
                 .create(RetrofitInboxApiService::class.java)
             Timber.d("Inbox API configured with base URL: $inboxBaseUrl")

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -13,6 +13,7 @@ import com.attentive.androidsdk.inbox.InboxState
 import com.attentive.androidsdk.inbox.Message
 import com.attentive.androidsdk.inbox.Style
 import com.attentive.androidsdk.internal.network.RetrofitInboxApiService
+import com.attentive.androidsdk.internal.network.UpdateMessageRequest
 import com.attentive.androidsdk.internal.network.buffer.FlushWorker
 import com.attentive.androidsdk.internal.util.Constants
 import com.attentive.androidsdk.internal.util.isEmail
@@ -100,7 +101,7 @@ object AttentiveSdk {
         if (inboxApi != null) {
             CoroutineScope(Dispatchers.IO).launch {
                 try {
-                    val response = inboxApi.getMessages(0, INBOX_PAGE_SIZE)
+                    val response = inboxApi.getMessages(config.domain, 0, INBOX_PAGE_SIZE)
                     _inboxState.value = InboxState(
                         messages = response.messages,
                         unreadCount = response.unreadCount,
@@ -219,7 +220,7 @@ object AttentiveSdk {
                 val inboxApi = inboxApi
 
                 if (inboxApi != null) {
-                    val response = inboxApi.getMessages(offsetToFetch, INBOX_PAGE_SIZE)
+                    val response = inboxApi.getMessages(config.domain, offsetToFetch, INBOX_PAGE_SIZE)
                     val latestState = _inboxState.value
                     val updatedMessages = latestState.messages + response.messages
 
@@ -727,7 +728,7 @@ object AttentiveSdk {
         Timber.d("Message $messageId marked as read")
         inboxApi?.also { api ->
             CoroutineScope(Dispatchers.IO).launch {
-                try { api.updateMessage(messageId, mapOf("isRead" to true)) }
+                try { api.updateMessage(messageId, UpdateMessageRequest(c = config.domain, isRead = true)) }
                 catch (e: Exception) { Timber.e(e, "Failed to sync markRead to server") }
             }
         }
@@ -763,7 +764,7 @@ object AttentiveSdk {
         Timber.d("Message $messageId marked as unread")
         inboxApi?.also { api ->
             CoroutineScope(Dispatchers.IO).launch {
-                try { api.updateMessage(messageId, mapOf("isRead" to false)) }
+                try { api.updateMessage(messageId, UpdateMessageRequest(c = config.domain, isRead = false)) }
                 catch (e: Exception) { Timber.e(e, "Failed to sync markUnread to server") }
             }
         }
@@ -796,7 +797,7 @@ object AttentiveSdk {
         val inboxApi = inboxApi
         if (inboxApi != null) {
             CoroutineScope(Dispatchers.IO).launch {
-                try { inboxApi.deleteMessage(messageId) }
+                try { inboxApi.deleteMessage(messageId, config.domain) }
                 catch (e: Exception) { Timber.e(e, "Failed to sync deleteMessage to server") }
             }
         }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -728,7 +728,7 @@ object AttentiveSdk {
         Timber.d("Message $messageId marked as read")
         inboxApi?.also { api ->
             CoroutineScope(Dispatchers.IO).launch {
-                try { api.updateMessage(messageId, UpdateMessageRequest(c = config.domain, isRead = true)) }
+                try { api.updateMessage(messageId, UpdateMessageRequest(domain = config.domain, isRead = true)) }
                 catch (e: Exception) { Timber.e(e, "Failed to sync markRead to server") }
             }
         }
@@ -764,7 +764,7 @@ object AttentiveSdk {
         Timber.d("Message $messageId marked as unread")
         inboxApi?.also { api ->
             CoroutineScope(Dispatchers.IO).launch {
-                try { api.updateMessage(messageId, UpdateMessageRequest(c = config.domain, isRead = false)) }
+                try { api.updateMessage(messageId, UpdateMessageRequest(domain = config.domain, isRead = false)) }
                 catch (e: Exception) { Timber.e(e, "Failed to sync markUnread to server") }
             }
         }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/InboxResponse.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/InboxResponse.kt
@@ -1,10 +1,12 @@
 package com.attentive.androidsdk.internal.network
 
 import com.attentive.androidsdk.inbox.Message
+import kotlinx.serialization.Serializable
 
+@Serializable
 internal data class InboxResponse(
     val messages: List<Message>,
     val unreadCount: Int,
     val hasMoreMessages: Boolean,
-    val nextOffset: Int?,
+    val nextOffset: Int? = null,
 )

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/RetrofitInboxApiService.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/RetrofitInboxApiService.kt
@@ -1,5 +1,6 @@
 package com.attentive.androidsdk.internal.network
 
+import com.google.gson.annotations.SerializedName
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -30,6 +31,6 @@ internal interface RetrofitInboxApiService {
 }
 
 internal data class UpdateMessageRequest(
-    val c: String,
+    @SerializedName("c") val domain: String,
     val isRead: Boolean,
 )

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/RetrofitInboxApiService.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/RetrofitInboxApiService.kt
@@ -1,6 +1,7 @@
 package com.attentive.androidsdk.internal.network
 
-import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -30,7 +31,8 @@ internal interface RetrofitInboxApiService {
     ): Response<Unit>
 }
 
+@Serializable
 internal data class UpdateMessageRequest(
-    @SerializedName("c") val domain: String,
+    @SerialName("c") val domain: String,
     val isRead: Boolean,
 )

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/RetrofitInboxApiService.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/RetrofitInboxApiService.kt
@@ -11,6 +11,7 @@ import retrofit2.http.Query
 internal interface RetrofitInboxApiService {
     @GET("inbox/messages")
     suspend fun getMessages(
+        @Query("c") domain: String,
         @Query("offset") offset: Int,
         @Query("limit") limit: Int,
     ): InboxResponse
@@ -18,11 +19,17 @@ internal interface RetrofitInboxApiService {
     @PATCH("inbox/messages/{id}")
     suspend fun updateMessage(
         @Path("id") id: String,
-        @Body body: Map<String, Boolean>,
+        @Body body: UpdateMessageRequest,
     ): Response<Unit>
 
     @DELETE("inbox/messages/{id}")
     suspend fun deleteMessage(
         @Path("id") id: String,
+        @Query("c") domain: String,
     ): Response<Unit>
 }
+
+internal data class UpdateMessageRequest(
+    val c: String,
+    val isRead: Boolean,
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -117,6 +117,7 @@ okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhtt
 okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
+retrofit-kotlinx-serialization = { group = "com.squareup.retrofit2", name = "converter-kotlinx-serialization", version.ref = "retrofit" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 
 # Image loading


### PR DESCRIPTION
## Summary
- Add `c` (domain) to every inbox API request to match the iOS SDK convention ([MSDK-408](https://attentivemobile.atlassian.net/browse/MSDK-408))
- `GET /inbox/messages` and `DELETE /inbox/messages/{id}` carry `c` as a query parameter
- `PATCH /inbox/messages/{id}` carries `c` in the JSON body via a new typed `UpdateMessageRequest` (replacing the ad-hoc `Map<String, Boolean>`)
- All call sites in `AttentiveSdk` pass `config.domain`

## Test plan
- [ ] Unit tests / build pass on CI
- [ ] Verify inbox requests in a network trace include `c=<domain>` on GET/DELETE and `"c": "<domain>"` in the PATCH body

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-408]: https://attentivemobile.atlassian.net/browse/MSDK-408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ