### PR TITLE
MSDK-420: Mark agent-driven setup as experimental in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ __*** NOTE: Please refrain from using any private or undocumented classes or met
 
 ### Setup with an AI coding agent
 
+> **⚠️ Experimental:** Agent-driven setup is a new, experimental workflow. Behavior varies across agents and models, and the guide is still evolving. Review any changes an agent makes before committing them, and fall back to the manual steps below if something looks off.
+
 If you use Claude Code, Cursor, Copilot, Codex, or another AI coding agent, you can have the agent walk you through setup. Point it at [`AGENTS.md`](./AGENTS.md) in this repo — it's a step-by-step integration guide written for agents that handles dependency wiring, `Application` initialization, and an interactive push-setup flow (Firebase detection, `FirebaseMessagingService` forwarding, notification icon, and permission prompt).
 
 **To trigger the flow**, open your project in your agent of choice and paste a prompt like:


### PR DESCRIPTION
## Summary
- Adds an experimental callout above the "Setup with an AI coding agent" section so readers know the AGENTS.md-driven flow is new, still evolving, and can behave differently across agents/models.
- Encourages reviewing agent-produced changes and falling back to manual setup if something looks off.

Jira: [MSDK-420](https://attentivemobile.atlassian.net/browse/MSDK-420)

## Verification
- README-only change. Confirmed via `git diff` that the callout renders directly under the "Setup with an AI coding agent" heading and before the existing AGENTS.md pointer paragraph.
- No source code touched, so no API-level test coverage applies.

## Public API impact
None — documentation only.

## Host-app rollback
None required — no code or behavior changes ship with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-420]: https://attentivemobile.atlassian.net/browse/MSDK-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ