### PR TITLE
MSDK-424: Prefix push token with fcm: in inbox requests

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -147,10 +147,13 @@ object AttentiveSdk {
         }
     }
 
+    private fun fcmPushToken(): String? =
+        TokenProvider.getInstance().token?.takeIf { it.isNotBlank() }?.let { "fcm:$it" }
+
     private fun buildGetMessagesRequest(pageToken: String?): GetMessagesRequest? {
         val identifiers = config.userIdentifiers
         val visitorId = identifiers.visitorId ?: return null
-        val pushToken = TokenProvider.getInstance().token?.takeIf { it.isNotBlank() }
+        val pushToken = fcmPushToken()
         return GetMessagesRequest(
             domain = config.domain,
             visitorId = visitorId,
@@ -776,14 +779,14 @@ object AttentiveSdk {
             Timber.w("Skipping refreshInboxUnreadCount — visitor id is null")
             return
         }
-        val pushToken = TokenProvider.getInstance().token
+        val pushToken = fcmPushToken()
         try {
             val response = inboxApi.getUnreadCount(
                 url = inboxUnreadCountUrl,
                 body = UnreadCountRequest(
                     domain = config.domain,
                     visitorId = visitorId,
-                    pushToken = pushToken?.takeIf { it.isNotBlank() },
+                    pushToken = pushToken,
                     email = identifiers.email?.trim()?.takeIf { it.isNotBlank() },
                     phone = identifiers.phone?.trim()?.takeIf { it.isNotBlank() },
                 ),
@@ -838,7 +841,7 @@ object AttentiveSdk {
                 Timber.w("Skipping markRead network call — visitor id is null")
                 return@also
             }
-            val pushToken = TokenProvider.getInstance().token?.takeIf { it.isNotBlank() }
+            val pushToken = fcmPushToken()
             CoroutineScope(Dispatchers.IO).launch {
                 try {
                     val response = api.markMessagesRead(
@@ -887,7 +890,7 @@ object AttentiveSdk {
                 Timber.w("Skipping markUnread network call — visitor id is null")
                 return@also
             }
-            val pushToken = TokenProvider.getInstance().token?.takeIf { it.isNotBlank() }
+            val pushToken = fcmPushToken()
             CoroutineScope(Dispatchers.IO).launch {
                 try {
                     val response = api.markMessagesUnread(
@@ -931,7 +934,7 @@ object AttentiveSdk {
             Timber.w("Skipping deleteMessage network call — visitor id is null")
             return
         }
-        val pushToken = TokenProvider.getInstance().token?.takeIf { it.isNotBlank() }
+        val pushToken = fcmPushToken()
         CoroutineScope(Dispatchers.IO).launch {
             try {
                 inboxApi.deleteMessage(
@@ -954,7 +957,7 @@ object AttentiveSdk {
             Timber.w("Skipping trackInboxClick — visitor id is null")
             return
         }
-        val pushToken = TokenProvider.getInstance().token?.takeIf { it.isNotBlank() }
+        val pushToken = fcmPushToken()
         CoroutineScope(Dispatchers.IO).launch {
             try {
                 inboxApi.trackClick(

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveSdkTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveSdkTest.kt
@@ -4,11 +4,15 @@ import android.app.Application
 import android.content.Context
 import com.attentive.androidsdk.internal.util.AppInfo
 import com.attentive.androidsdk.internal.util.AppInfo.isDebuggable
+import com.attentive.androidsdk.internal.network.RetrofitInboxApiService
+import com.attentive.androidsdk.internal.network.UnreadCountRequest
+import com.attentive.androidsdk.internal.network.UnreadCountResponse
 import com.attentive.androidsdk.internal.util.Constants
 import com.attentive.androidsdk.push.TokenProvider
 import com.google.firebase.messaging.RemoteMessage
 import kotlinx.coroutines.runBlocking
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -19,6 +23,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.whenever
@@ -64,6 +69,9 @@ class AttentiveSdkTest {
         factoryMocks.close()
         mockedAppInfo?.close()
         TokenProvider.getInstance().token = null
+        val inboxApiField = AttentiveSdk::class.java.getDeclaredField("inboxApi")
+        inboxApiField.isAccessible = true
+        inboxApiField.set(AttentiveSdk, null)
     }
 
     @Test
@@ -115,6 +123,23 @@ class AttentiveSdkTest {
         runBlocking {
             verify(factoryMocks.attentiveApi, never()).sendUserUpdate(any(), any(), any(), any(), any(), any())
         }
+    }
+
+    @Test
+    fun refreshInboxUnreadCount_prefixesPushTokenWithFcm() {
+        val inboxApi = mock(RetrofitInboxApiService::class.java)
+        runBlocking {
+            whenever(inboxApi.getUnreadCount(any(), any())).thenReturn(UnreadCountResponse(0))
+        }
+        val inboxApiField = AttentiveSdk::class.java.getDeclaredField("inboxApi")
+        inboxApiField.isAccessible = true
+        inboxApiField.set(AttentiveSdk, inboxApi)
+
+        runBlocking { AttentiveSdk.refreshInboxUnreadCount() }
+
+        val bodyCaptor = argumentCaptor<UnreadCountRequest>()
+        runBlocking { verify(inboxApi).getUnreadCount(any(), bodyCaptor.capture()) }
+        assertEquals("fcm:$PUSH_TOKEN", bodyCaptor.firstValue.pushToken)
     }
 
     companion object {


### PR DESCRIPTION
## Summary
- Inbox endpoints (`/inbox/messages`, `/inbox/messages/unread/count`, mark read/unread, delete, click) were returning 401 in prod. Backend expects a scheme-qualified push token (e.g. `fcm:<token>`), and the SDK was sending the raw FCM token.
- Adds a single `fcmPushToken()` helper on `AttentiveSdk` and swaps every inbox request site over to it. The two non-inbox `sendUserUpdate` sites are unchanged.

[MSDK-424](https://attentivemobile.atlassian.net/browse/MSDK-424)

## Test plan
- [x] Launch bonni on a device with FCM enabled, open the inbox, and confirm `/inbox/messages` and `/inbox/messages/unread/count` return 200.
- [x] Verify the outgoing `push_token` field in the request body is prefixed with `fcm:` via logcat / OkHttp logging.
- [ ] Confirm mark-read, mark-unread, delete, and inbox click tracking also succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-424]: https://attentivemobile.atlassian.net/browse/MSDK-424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ