### PR TITLE
MSDK-443: Propagate cartTotal and cartDiscount on v2 /mobile events

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
@@ -612,12 +612,13 @@ private fun mapPurchaseEvent(
     val visitorId = userIdentifiers.visitorId!! // Safe because we validate it's not null in recordEvent
 
     val products = event.items.map { item -> itemToProduct(item) }
-    val cart = event.cart?.let { cartToCartModel(it) }
+    val computedCartTotal = calculateCartTotal(event.items)
+    val cart = event.cart?.let { cartToCartModel(it, computedCartTotal) }
 
     val purchaseMetadata = PurchaseMetadata(
         orderId = event.order.orderId,
         currency = event.items.firstOrNull()?.price?.currency?.currencyCode,
-        orderTotal = calculateCartTotal(event.items),
+        orderTotal = computedCartTotal,
         cart = cart,
         products = products
     )
@@ -1161,11 +1162,14 @@ internal fun itemToProduct(item: Item): Product {
 }
 
 @VisibleForTesting
-internal fun cartToCartModel(cart: com.attentive.androidsdk.events.Cart): Cart {
+internal fun cartToCartModel(
+    cart: com.attentive.androidsdk.events.Cart,
+    computedCartTotal: String? = null,
+): Cart {
     return Cart(
-        cartTotal = null,
+        cartTotal = cart.cartTotal ?: computedCartTotal,
         cartCoupon = cart.cartCoupon,
-        cartDiscount = null,
+        cartDiscount = cart.cartDiscount,
         cartId = cart.cartId
     )
 }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
@@ -505,11 +505,12 @@ private fun getEventRequestsFromEvent(event: Event): List<EventRequest> {
             purchaseMetadataDto.orderId =
                 purchaseEvent.order.orderId // Assuming orderId is non-nullable
             purchaseMetadataDto.cartTotal =
-                cartTotalString // Assuming cartTotalString is non-nullable
+                purchaseEvent.cart?.cartTotal ?: cartTotalString
 
             if (purchaseEvent.cart != null) {
                 purchaseMetadataDto.cartId = purchaseEvent.cart.cartId
                 purchaseMetadataDto.cartCoupon = purchaseEvent.cart.cartCoupon
+                purchaseMetadataDto.cartDiscount = purchaseEvent.cart.cartDiscount
             }
             eventRequests.add(EventRequest(purchaseMetadataDto, EventRequest.Type.PURCHASE))
         }
@@ -518,7 +519,8 @@ private fun getEventRequestsFromEvent(event: Event): List<EventRequest> {
         val ocMetadata = OrderConfirmedMetadataDto()
         ocMetadata.orderId = purchaseEvent.order.orderId
         ocMetadata.currency = purchaseEvent.items[0]?.price?.currency?.currencyCode
-        ocMetadata.cartTotal = cartTotalString
+        ocMetadata.cartTotal = purchaseEvent.cart?.cartTotal ?: cartTotalString
+        ocMetadata.cartDiscount = purchaseEvent.cart?.cartDiscount
         val products: MutableList<ProductDto> = ArrayList()
         for (item in purchaseEvent.items) {
             val product = ProductDto()
@@ -613,7 +615,7 @@ private fun mapPurchaseEvent(
 
     val products = event.items.map { item -> itemToProduct(item) }
     val computedCartTotal = calculateCartTotal(event.items)
-    val cart = event.cart?.let { cartToCartModel(it, computedCartTotal) }
+    val cart = cartToCartModel(event.cart, computedCartTotal)
 
     val purchaseMetadata = PurchaseMetadata(
         orderId = event.order.orderId,
@@ -1163,14 +1165,14 @@ internal fun itemToProduct(item: Item): Product {
 
 @VisibleForTesting
 internal fun cartToCartModel(
-    cart: com.attentive.androidsdk.events.Cart,
+    cart: com.attentive.androidsdk.events.Cart?,
     computedCartTotal: String? = null,
 ): Cart {
     return Cart(
-        cartTotal = cart.cartTotal ?: computedCartTotal,
-        cartCoupon = cart.cartCoupon,
-        cartDiscount = cart.cartDiscount,
-        cartId = cart.cartId
+        cartTotal = cart?.cartTotal ?: computedCartTotal,
+        cartCoupon = cart?.cartCoupon,
+        cartDiscount = cart?.cartDiscount,
+        cartId = cart?.cartId
     )
 }
 

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Cart.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Cart.kt
@@ -8,11 +8,16 @@ import kotlinx.serialization.Serializable
  *
  * @property cartId Your canonical cart identifier. Required, non-empty.
  * @property cartCoupon A promotion code applied to the cart, if any.
+ * @property cartTotal The cart total as a string (e.g. "42.00"). When null on v2 events,
+ * the SDK computes a fallback from the item prices.
+ * @property cartDiscount The cart discount amount as a string, if any.
  */
 @Serializable
 data class Cart(
     val cartId: String,
     val cartCoupon: String? = null,
+    val cartTotal: String? = null,
+    val cartDiscount: String? = null,
 ) {
     init {
         ParameterValidation.verifyNotEmpty(cartId, "cartId")
@@ -22,6 +27,8 @@ data class Cart(
     class Builder {
         lateinit var cartId: String
         private var cartCoupon: String? = null
+        private var cartTotal: String? = null
+        private var cartDiscount: String? = null
 
         fun cartId(id: String): Builder {
             cartId = id
@@ -33,6 +40,16 @@ data class Cart(
             return this
         }
 
+        fun cartTotal(total: String?): Builder {
+            cartTotal = total
+            return this
+        }
+
+        fun cartDiscount(discount: String?): Builder {
+            cartDiscount = discount
+            return this
+        }
+
         /**
          * @throws UninitializedPropertyAccessException if [cartId] was not set.
          */
@@ -40,6 +57,8 @@ data class Cart(
             return Cart(
                 cartId = cartId,
                 cartCoupon = cartCoupon,
+                cartTotal = cartTotal,
+                cartDiscount = cartDiscount,
             )
         }
     }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/OrderConfirmedMetadataDto.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/OrderConfirmedMetadataDto.kt
@@ -45,6 +45,7 @@ object ProductListSerializer : KSerializer<List<ProductDto>?> {
 class OrderConfirmedMetadataDto : Metadata() {
     var orderId: String? = null
     var cartTotal: String? = null
+    var cartDiscount: String? = null
     var currency: String? = null
 
     /**

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/PurchaseMetadataDto.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/PurchaseMetadataDto.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.Serializable
 class PurchaseMetadataDto : ProductMetadata() {
     var quantity: String? = null
     var cartTotal: String? = null
+    var cartDiscount: String? = null
     var cartId: String? = null
     var cartCoupon: String? = null
 }

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/BaseEventRequestMapperTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/BaseEventRequestMapperTest.kt
@@ -534,6 +534,55 @@ class BaseEventRequestMapperTest {
         assertEquals(metadata.orderTotal, metadata.cart?.cartTotal)
     }
 
+    @Test
+    fun mapPurchaseEvent_hostCartTotalAndDiscount_roundTripToWireCart() {
+        // Arrange
+        val purchaseEvent =
+            PurchaseEvent.Builder(
+                listOf(buildItemWithAllFields()),
+                Order.Builder().orderId("ORDER123").build(),
+            ).cart(
+                Cart.Builder()
+                    .cartId("CART123")
+                    .cartTotal("999.99")
+                    .cartDiscount("5.00")
+                    .build(),
+            ).build()
+        val userIdentifiers = buildAllUserIdentifiers()
+
+        // Act
+        val result = invokeGetBaseEventRequestsFromEvent(purchaseEvent, userIdentifiers, "test")
+
+        // Assert - host-provided cartTotal wins over item-sum; discount rides along
+        val metadata = result[0].eventMetadata as PurchaseMetadata
+        assertNotNull(metadata.cart)
+        assertEquals("999.99", metadata.cart?.cartTotal)
+        assertEquals("5.00", metadata.cart?.cartDiscount)
+        // orderTotal stays as the SDK-computed item sum (15.99), independent of host cartTotal
+        assertEquals("15.99", metadata.orderTotal)
+    }
+
+    @Test
+    fun mapPurchaseEvent_withNoCart_stillSynthesizesWireCartWithComputedTotal() {
+        // Arrange - PurchaseEvent with no Cart at all
+        val purchaseEvent =
+            PurchaseEvent.Builder(
+                listOf(buildItemWithAllFields()),
+                Order.Builder().orderId("ORDER123").build(),
+            ).build()
+        val userIdentifiers = buildAllUserIdentifiers()
+
+        // Act
+        val result = invokeGetBaseEventRequestsFromEvent(purchaseEvent, userIdentifiers, "test")
+
+        // Assert - parity with iOS: even without a host cart, wire cart carries computed total
+        val metadata = result[0].eventMetadata as PurchaseMetadata
+        assertNotNull(metadata.cart)
+        assertEquals("15.99", metadata.cart?.cartTotal)
+        assertNull(metadata.cart?.cartId)
+        assertNull(metadata.cart?.cartDiscount)
+    }
+
     // Test calculateCartTotal
     @Test
     fun calculateCartTotal_withMultipleItems_calculatesCorrectSum() {

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/BaseEventRequestMapperTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/BaseEventRequestMapperTest.kt
@@ -474,6 +474,8 @@ class BaseEventRequestMapperTest {
             Cart.Builder()
                 .cartId("CART123")
                 .cartCoupon("SUMMER20")
+                .cartTotal("42.00")
+                .cartDiscount("5.00")
                 .build()
 
         // Act
@@ -482,8 +484,54 @@ class BaseEventRequestMapperTest {
         // Assert
         assertEquals("CART123", result.cartId)
         assertEquals("SUMMER20", result.cartCoupon)
-        assertNull(result.cartTotal)
+        assertEquals("42.00", result.cartTotal)
+        assertEquals("5.00", result.cartDiscount)
+    }
+
+    @Test
+    fun cartToCartModel_withoutCartTotal_fallsBackToComputedValue() {
+        // Arrange
+        val cart = Cart.Builder().cartId("CART123").build()
+
+        // Act
+        val result = attentiveApi.cartToCartModel(cart, computedCartTotal = "12.34")
+
+        // Assert
+        assertEquals("12.34", result.cartTotal)
         assertNull(result.cartDiscount)
+    }
+
+    @Test
+    fun cartToCartModel_hostProvidedCartTotal_overridesComputedValue() {
+        // Arrange
+        val cart =
+            Cart.Builder()
+                .cartId("CART123")
+                .cartTotal("99.99")
+                .build()
+
+        // Act
+        val result = attentiveApi.cartToCartModel(cart, computedCartTotal = "12.34")
+
+        // Assert - host-provided value wins over SDK-computed fallback
+        assertEquals("99.99", result.cartTotal)
+    }
+
+    @Test
+    fun mapPurchaseEvent_withoutHostCartTotal_populatesFromComputedTotal() {
+        // Arrange
+        val purchaseEvent = buildPurchaseEventWithAllFields()
+        val userIdentifiers = buildAllUserIdentifiers()
+
+        // Act
+        val result = invokeGetBaseEventRequestsFromEvent(purchaseEvent, userIdentifiers, "test")
+
+        // Assert
+        val metadata = result[0].eventMetadata as PurchaseMetadata
+        assertNotNull(metadata.cart)
+        // buildPurchaseEventWithAllFields uses a single item at 15.99
+        assertEquals("15.99", metadata.cart?.cartTotal)
+        assertEquals(metadata.orderTotal, metadata.cart?.cartTotal)
     }
 
     // Test calculateCartTotal


### PR DESCRIPTION
## Summary

- Adds `cartTotal` and `cartDiscount` to the public `Cart` model + builder so hosts can pass a cart total on v2 `/mobile` events.
- Threads both fields through `cartToCartModel` so they no longer get hardcoded to `null` on the wire.
- When the host doesn't provide a `cartTotal`, falls back to the SDK-computed `sum(item.price.price)` — matching the legacy `/e` path, so v1 and v2 produce the same numbers.

No formula change (Android v1 and v2 remain quantity-agnostic `sum(price)`). No change to `Product.name` — already optional.

Companion to [MSDK-442](https://attentivemobile.atlassian.net/browse/MSDK-442) (iOS). See [MSDK-443](https://attentivemobile.atlassian.net/browse/MSDK-443) for the full analysis and rollout notes.

## Test plan

- [x] `cartToCartModel_withAllFields_mapsCorrectly` — round-trips `cartTotal` / `cartDiscount` through the wire model
- [x] `cartToCartModel_withoutCartTotal_fallsBackToComputedValue` — SDK computes fallback when host omits `cartTotal`
- [x] `cartToCartModel_hostProvidedCartTotal_overridesComputedValue` — host value wins over fallback
- [x] `mapPurchaseEvent_withoutHostCartTotal_populatesFromComputedTotal` — end-to-end mapper populates `cart.cartTotal` on v2 payloads
- [x] Existing `calculateCartTotal_*` tests still assert `sum(price)` behavior (regression guard against multiply-by-quantity drift)
- [ ] Manual: fire a `PurchaseEvent` with `ApiVersion.NEW` and confirm `/mobile` payload has non-null `cartTotal` matching legacy `/e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-442]: https://attentivemobile.atlassian.net/browse/MSDK-442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MSDK-443]: https://attentivemobile.atlassian.net/browse/MSDK-443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ