### PR TITLE
MSDK-451: Clear inbox state on identity change (clearUser / updateUser)

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -86,6 +86,14 @@ object AttentiveSdk {
     private var nextPageToken: String? = null
 
     /**
+     * Monotonic counter bumped by [resetInboxForIdentityChange]. Long-running inbox
+     * fetches capture this value before the network call and check on return — a
+     * response from a superseded identity is discarded instead of being merged into
+     * the new user's blank state.
+     */
+    private var inboxGeneration: Long = 0L
+
+    /**
      * One-time inbox setup: builds the Retrofit client and kicks off the first-page
      * fetch. Subsequent calls are no-ops — use [refreshInbox] to reload.
      */
@@ -133,12 +141,17 @@ object AttentiveSdk {
                 Timber.d("Skipping refreshInbox — pagination fetch in flight")
                 return
             }
+            val generation = inboxGeneration
             try {
                 val request = buildGetMessagesRequest(pageToken = null) ?: run {
                     Timber.w("Skipping inbox refresh — no visitor id")
                     return
                 }
                 val response = inboxApi.getMessages(inboxMessagesUrl, request)
+                if (generation != inboxGeneration) {
+                    Timber.d("Discarding refreshInbox response — identity changed mid-flight")
+                    return
+                }
                 val messages = response.messages.map { it.toMessage() }
                 nextPageToken = response.nextPageToken
                 _inboxState.value = InboxState(
@@ -158,6 +171,20 @@ object AttentiveSdk {
             }
         }
         refreshInboxUnreadCount()
+    }
+
+    /**
+     * Clears inbox state so a logged-out user's messages don't leak into the next
+     * identity's session. Bumps [inboxGeneration] so any in-flight [refreshInbox]
+     * or [loadMoreInboxMessages] response returning after this call is discarded.
+     * Does NOT auto-refetch — callers should trigger a refresh once the new
+     * identity has been established server-side.
+     */
+    internal fun resetInboxForIdentityChange() {
+        inboxGeneration += 1
+        nextPageToken = null
+        _inboxState.value = InboxState()
+        Timber.d("Inbox state reset for identity change (generation=$inboxGeneration)")
     }
 
     private fun fcmPushToken(): String? =
@@ -285,6 +312,7 @@ object AttentiveSdk {
             try {
                 val offsetToFetch = currentState.currentOffset
                 val inboxApi = inboxApi
+                val generation = inboxGeneration
 
                 if (inboxApi != null) {
                     val request = buildGetMessagesRequest(pageToken = nextPageToken) ?: run {
@@ -292,6 +320,10 @@ object AttentiveSdk {
                         return@withLock
                     }
                     val response = inboxApi.getMessages(inboxMessagesUrl, request)
+                    if (generation != inboxGeneration) {
+                        Timber.d("Discarding loadMoreInboxMessages response — identity changed mid-flight")
+                        return@withLock
+                    }
                     val newMessages = response.messages.map { it.toMessage() }
                     nextPageToken = response.nextPageToken
                     val latestState = _inboxState.value
@@ -655,6 +687,7 @@ object AttentiveSdk {
         }
 
         config.resetIdentifiers()
+        resetInboxForIdentityChange()
         val domain = config.domain
         val visitorId = config.userIdentifiers.visitorId
         val pushToken = TokenProvider.getInstance().token
@@ -692,6 +725,7 @@ object AttentiveSdk {
      */
     fun clearUser() {
         config.resetIdentifiers()
+        resetInboxForIdentityChange()
         val domain = config.domain
         val visitorId = config.userIdentifiers.visitorId
         val pushToken = TokenProvider.getInstance().token

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveSdkTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveSdkTest.kt
@@ -84,6 +84,7 @@ class AttentiveSdkTest {
         TokenProvider.getInstance().token = null
         setInboxApi(null)
         setInboxState(InboxState())
+        setNextPageToken(null)
     }
 
     private fun setInboxApi(api: RetrofitInboxApiService?) {
@@ -461,6 +462,69 @@ class AttentiveSdkTest {
         runBlocking { verify(inboxApi).trackClick(any(), bodyCaptor.capture()) }
         assertEquals("m1", bodyCaptor.firstValue.messageId)
         assertEquals("https://example.com/action", bodyCaptor.firstValue.actionUrl)
+    }
+
+    @Test
+    fun clearUser_resetsInboxStateToEmpty() {
+        setInboxState(
+            InboxState(
+                messages = listOf(fakeMessage("m1", isRead = false), fakeMessage("m2", isRead = true)),
+                unreadCount = 1,
+                currentOffset = 2,
+                hasMoreMessages = true,
+            ),
+        )
+        // Seed a non-null nextPageToken so we can assert it's cleared too.
+        setNextPageToken("token-abc")
+
+        AttentiveSdk.clearUser()
+
+        val state = AttentiveSdk.inboxState.value
+        assertEquals(0, state.messages.size)
+        assertEquals(0, state.unreadCount)
+        assertEquals(0, state.currentOffset)
+        // Reset returns a fresh InboxState() — hasMoreMessages defaults to true
+        // (we don't know yet), which is fine; the empty messages list is what matters.
+        assertNull(readNextPageToken())
+    }
+
+    @Test
+    fun refreshInbox_discardsResponseWhenIdentityChangesMidFlight() {
+        val inboxApi = mock(RetrofitInboxApiService::class.java)
+        runBlocking {
+            whenever(inboxApi.getMessages(any(), any())).thenAnswer {
+                // Simulate an identity change occurring while the request is in flight.
+                AttentiveSdk.resetInboxForIdentityChange()
+                InboxResponse(
+                    messages = listOf(
+                        InboxMessageDto(inboxMessageId = "stale1", title = "stale", isRead = false),
+                    ),
+                    nextPageToken = "stale-token",
+                )
+            }
+            whenever(inboxApi.getUnreadCount(any(), any())).thenReturn(UnreadCountResponse(0))
+        }
+        setInboxApi(inboxApi)
+
+        runBlocking { AttentiveSdk.refreshInbox() }
+
+        // The stale response should NOT have populated state — resetInboxForIdentityChange
+        // ran mid-flight and bumped the generation, so refreshInbox discards the response.
+        val state = AttentiveSdk.inboxState.value
+        assertEquals(0, state.messages.size)
+        assertNull(readNextPageToken())
+    }
+
+    private fun setNextPageToken(token: String?) {
+        val field = AttentiveSdk::class.java.getDeclaredField("nextPageToken")
+        field.isAccessible = true
+        field.set(AttentiveSdk, token)
+    }
+
+    private fun readNextPageToken(): String? {
+        val field = AttentiveSdk::class.java.getDeclaredField("nextPageToken")
+        field.isAccessible = true
+        return field.get(AttentiveSdk) as String?
     }
 
     private fun fakeMessage(id: String, isRead: Boolean) =


### PR DESCRIPTION
## Summary
Brings Android inbox to parity with iOS's \`resetForIdentityChange\`. On logout / \`updateUser\`, the old user's cached messages and unread count were leaking into the next identity's session, and in-flight page loads or refreshes could merge their responses into the fresh state.

**Changes:**
- Added an \`inboxGeneration\` monotonic counter. \`refreshInbox()\` and \`loadMoreInboxMessages()\` capture it before the network call and discard the response if it advanced (identity changed mid-flight) — matches iOS's \`messagesGeneration\` guard.
- New internal \`resetInboxForIdentityChange()\` bumps the generation, clears \`_inboxState\` back to \`InboxState()\`, and resets \`nextPageToken\`.
- \`clearUser()\` and \`updateUserSuspend()\` invoke it right after \`resetIdentifiers()\` so subsequent inbox reads see a blank slate.
- Deliberately does NOT auto-refetch — caller re-fetches once the new identity is server-associated (mirrors iOS's stance so a fetch fired here doesn't run against an unlinked anonymous visitor).

[MSDK-451](https://attentivemobile.atlassian.net/browse/MSDK-451)

## Test plan
- [ ] \`./gradlew :attentive-android-sdk:testDebugUnitTest\` — new tests pass.
- [ ] Manual: log in as user A → open inbox → messages visible. Call \`clearUser()\` → inbox state clears immediately. Log in as user B → refresh → user B's messages appear (no leak from A).
- [ ] Manual: pull-to-refresh while calling \`clearUser()\` mid-flight — user A's messages don't appear in user B's state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-451]: https://attentivemobile.atlassian.net/browse/MSDK-451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ