### PR TITLE
MSDK-453: Hide inbox APIs until GA

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -6,6 +6,7 @@ import android.annotation.SuppressLint
 import android.app.Application
 import android.content.Context
 import android.content.pm.PackageManager
+import androidx.annotation.RestrictTo
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.attentive.androidsdk.AttentiveSdk.getPushToken
@@ -64,6 +65,12 @@ object AttentiveSdk {
      * Subscribe to the inbox state stream to receive updates when messages change.
      * This StateFlow emits a new InboxState whenever messages are updated.
      */
+    @Suppress("DEPRECATION")
+    @Deprecated(
+        message = "Inbox is not yet available for public use.",
+        level = DeprecationLevel.WARNING,
+    )
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     val inboxState: StateFlow<InboxState> = _inboxState.asStateFlow()
 
     // Inbox server API (created from manifest meta-data if present)
@@ -295,6 +302,12 @@ object AttentiveSdk {
      * Call this when the user scrolls near the end of the message list.
      * Uses the server API when configured, otherwise falls back to mock data.
      */
+    @Suppress("DEPRECATION")
+    @Deprecated(
+        message = "Inbox is not yet available for public use.",
+        level = DeprecationLevel.WARNING,
+    )
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun loadMoreInboxMessages() {
         paginationLock.withLock {
             val currentState = _inboxState.value
@@ -791,6 +804,12 @@ object AttentiveSdk {
      *
      * @return List of all messages in the inbox
      */
+    @Suppress("DEPRECATION")
+    @Deprecated(
+        message = "Inbox is not yet available for public use.",
+        level = DeprecationLevel.WARNING,
+    )
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun getAllMessages(): List<Message> {
         return inboxState.value.messages
     }
@@ -839,6 +858,12 @@ object AttentiveSdk {
      *
      * @return The number of unread messages currently in state
      */
+    @Suppress("DEPRECATION")
+    @Deprecated(
+        message = "Inbox is not yet available for public use.",
+        level = DeprecationLevel.WARNING,
+    )
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun getUnreadCount(): Int {
         initializeInbox()
         return inboxState.value.unreadCount
@@ -848,6 +873,12 @@ object AttentiveSdk {
      * Marks a message as read and emits a new inbox state.*
      * @param messageId The ID of the message to mark as read
      */
+    @Suppress("DEPRECATION")
+    @Deprecated(
+        message = "Inbox is not yet available for public use.",
+        level = DeprecationLevel.WARNING,
+    )
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun markRead(messageId: String) {
         val currentState = _inboxState.value
         val updatedMessages =
@@ -897,6 +928,12 @@ object AttentiveSdk {
      * Marks a message as unread and emits a new inbox state.
      * @param messageId The ID of the message to mark as unread
      */
+    @Suppress("DEPRECATION")
+    @Deprecated(
+        message = "Inbox is not yet available for public use.",
+        level = DeprecationLevel.WARNING,
+    )
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun markUnread(messageId: String) {
         val currentState = _inboxState.value
         val updatedMessages =
@@ -945,6 +982,12 @@ object AttentiveSdk {
      * Deletes a message from the inbox and emits a new inbox state.*
      * @param messageId The ID of the message to delete
      */
+    @Suppress("DEPRECATION")
+    @Deprecated(
+        message = "Inbox is not yet available for public use.",
+        level = DeprecationLevel.WARNING,
+    )
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun deleteMessage(messageId: String) {
         val currentState = _inboxState.value
         val updatedMessages =
@@ -979,6 +1022,12 @@ object AttentiveSdk {
     /**
      * Reports a click on an inbox message link to the backend. Fire-and-forget.
      */
+    @Suppress("DEPRECATION")
+    @Deprecated(
+        message = "Inbox is not yet available for public use.",
+        level = DeprecationLevel.WARNING,
+    )
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun trackInboxClick(messageId: String, actionUrl: String? = null) {
         val inboxApi = inboxApi ?: return
         val visitorId = config.userIdentifiers.visitorId

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/inbox/AttentiveInbox.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/inbox/AttentiveInbox.kt
@@ -1,7 +1,10 @@
+@file:Suppress("DEPRECATION")
+
 package com.attentive.androidsdk.inbox
 
 import android.content.Intent
 import android.net.Uri
+import androidx.annotation.RestrictTo
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
@@ -172,6 +175,12 @@ private fun rememberTopLevelInboxImageLoader(): ImageLoader {
  * @param timestampFontFamily Font family for timestamps (null uses system default)
  * @param onMessageClick Callback invoked when a message is clicked (default marks as read)
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    message = "Inbox is not yet available for public use.",
+    level = DeprecationLevel.WARNING,
+)
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AttentiveInbox(

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/inbox/AttentiveInboxView.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/inbox/AttentiveInboxView.kt
@@ -1,7 +1,10 @@
+@file:Suppress("DEPRECATION")
+
 package com.attentive.androidsdk.inbox
 
 import android.content.Context
 import android.util.AttributeSet
+import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -46,6 +49,12 @@ import com.attentive.androidsdk.R
  * @param attrs Optional AttributeSet for XML attributes
  * @param defStyleAttr Optional default style attribute
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    message = "Inbox is not yet available for public use.",
+    level = DeprecationLevel.WARNING,
+)
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AttentiveInboxView
     @JvmOverloads
     constructor(

--- a/bonni/src/main/java/com/attentive/bonni/inbox/InboxScreen.kt
+++ b/bonni/src/main/java/com/attentive/bonni/inbox/InboxScreen.kt
@@ -1,5 +1,9 @@
+@file:Suppress("DEPRECATION")
+@file:SuppressLint("RestrictedApi")
+
 package com.attentive.bonni.inbox
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -14,6 +18,7 @@ import com.attentive.bonni.R
 import com.attentive.bonni.SimpleToolbar
 import com.attentive.bonni.ui.theme.BonniPink
 
+@Suppress("DEPRECATION")
 @Composable
 fun InboxScreen(navHostController: NavHostController) {
     Column(modifier = Modifier.fillMaxSize()) {

--- a/bonni/src/main/java/com/attentive/bonni/inbox/LegacyInboxScreen.kt
+++ b/bonni/src/main/java/com/attentive/bonni/inbox/LegacyInboxScreen.kt
@@ -1,5 +1,9 @@
+@file:Suppress("DEPRECATION")
+@file:SuppressLint("RestrictedApi")
+
 package com.attentive.bonni.inbox
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -18,6 +22,7 @@ import com.attentive.bonni.ui.theme.BonniPink
  *
  * This shows how the legacy View implementation works in a Compose context.
  */
+@Suppress("DEPRECATION")
 @Composable
 fun LegacyInboxScreen(navHostController: NavHostController) {
     Column(modifier = Modifier.fillMaxSize()) {

--- a/bonni/src/main/java/com/attentive/bonni/product/ProductScreen.kt
+++ b/bonni/src/main/java/com/attentive/bonni/product/ProductScreen.kt
@@ -1,5 +1,8 @@
+@file:SuppressLint("RestrictedApi")
+
 package com.attentive.bonni.product
 
+import android.annotation.SuppressLint
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.LocalActivity
@@ -66,6 +69,7 @@ fun ProductScreen(
     ProductScreenContent(navHostController, viewModel)
 }
 
+@Suppress("DEPRECATION")
 @Composable
 fun ProductScreenContent(
     navHostController: NavHostController,


### PR DESCRIPTION
## Summary
The inbox surface was promoted to public in MSDK-435 prematurely. Restore the beta gating on every public inbox member so external SDK consumers get a \`@Deprecated\` warning and a lint-level \`@RestrictTo\` error if they call it before GA.

**SDK members re-gated** (\`@Deprecated("Inbox is not yet available for public use.", WARNING)\` + \`@RestrictTo(LIBRARY_GROUP)\`):
- \`AttentiveSdk.inboxState\`
- \`AttentiveSdk.loadMoreInboxMessages\`
- \`AttentiveSdk.getAllMessages\`
- \`AttentiveSdk.getUnreadCount\`
- \`AttentiveSdk.markRead\`
- \`AttentiveSdk.markUnread\`
- \`AttentiveSdk.deleteMessage\`
- \`AttentiveSdk.trackInboxClick\`
- \`AttentiveInbox\` composable
- \`AttentiveInboxView\` class

Internal SDK members (\`initializeInbox\`, \`refreshInbox\`, \`refreshInboxUnreadCount\`, \`resetInboxForIdentityChange\`) remain internal — not part of the consumer surface.

**Bonni side:** reinstate \`@file:Suppress("DEPRECATION")\` / \`@file:SuppressLint("RestrictedApi")\` on \`InboxScreen\`, \`LegacyInboxScreen\`, and \`ProductScreen\` so the reference implementation still compiles.

[MSDK-453](https://attentivemobile.atlassian.net/browse/MSDK-453)

## Test plan
- [ ] \`./gradlew :attentive-android-sdk:testDebugUnitTest :attentive-android-sdk:ktlintCheck\` — clean.
- [ ] \`./gradlew :bonni:compileDebugKotlin :bonni:lintDebug\` — clean, no \`RestrictedApi\` errors.
- [ ] A hypothetical external consumer calling \`AttentiveSdk.inboxState\` sees the \`@Deprecated\` warning + a lint error pointing at \`RestrictedApi\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-453]: https://attentivemobile.atlassian.net/browse/MSDK-453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ