### PR TITLE
MSDK-466: Expose API version override in AttentiveConfig.Builder

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveConfig.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveConfig.kt
@@ -235,7 +235,7 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
             _notificationIconBackgroundColorResource = colorResourceId
         }
 
-        private val allowApiVersionOverride = false
+        private val allowApiVersionOverride = true
 
         /**
          * Currently a no-op for integrators — gated behind a private flag.


### PR DESCRIPTION
## Ticket
[MSDK-466](https://attentivemobile.atlassian.net/browse/MSDK-466)

## Summary
- Flip `AttentiveConfig.Builder.allowApiVersionOverride` from `false` to `true` so `apiVersion(...)` on the builder actually applies the caller's choice instead of being a silent no-op.

## Example

```kotlin
val config = AttentiveConfig.Builder()
    .applicationContext(application)
    .domain("your-domain")
    .apiVersion(ApiVersion.NEW)
    .build()
```

## Test plan
- [x] `./gradlew :attentive-android-sdk:compileDebugKotlin :attentive-android-sdk:testDebugUnitTest` — clean.
- [x] Manual: build bonni against this SDK, call the snippet above, confirm the config picks up `ApiVersion.NEW` (previously ignored).

Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-466]: https://attentivemobile.atlassian.net/browse/MSDK-466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ