### PR TITLE
Install gh CLI in the release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,6 +283,11 @@ jobs:
           github_app_client_id: ${GITHUB_APP_CLIENT_ID}
           github_app_private_key_base64: ${GITHUB_APP_PRIVATE_KEY_BASE64}
           github_app_installation_id: ${GITHUB_APP_INSTALLATION_ID}
+      # cimg/android does not bundle the gh CLI, and `gh pr create` / `gh release create`
+      # below need it. Auth comes from GITHUB_TOKEN, already minted above, which gh reads
+      # from the environment — so `install` is enough and `setup` would re-auth needlessly.
+      - github-cli/install:
+          version: "2.97.0"
       - run:
           name: Switch git remote to HTTPS with App token
           command: |


### PR DESCRIPTION
## Problem

The `release` job failed on [pipeline 464 / job 1773](https://app.circleci.com/pipelines/gh/attentive-mobile/attentive-android-sdk/464/workflows/f12cb521-bc26-437f-a163-a9ef86ea3403/jobs/1773) while releasing `2.2.2-beta.1`:

```
/bin/bash: line 15: gh: command not found
Exited with code exit status 127
```

The `circleci/github-cli@3.0.0` orb is declared at `.circleci/config.yml:9` but none of its commands were ever invoked, and `cimg/android:2026.02.1` does not bundle the `gh` CLI. Both `gh pr create` and `gh release create` in the `release` job therefore could not run.

The release branch `release/2.2.2-beta.1` **was** pushed successfully before the failure. Everything after the push was skipped, including **Publish to Maven Central**, so `2.2.2-beta.1` was never published.

## Fix

Add `github-cli/install` to the `release` job, immediately after the App token is minted.

- **`install` rather than `setup`** — `attentive/app-based-github-token` already exports `GITHUB_TOKEN`, which `gh` reads from the environment. `setup` would run a redundant `gh auth login` on top of that.
- **Pinned to `2.97.0`** instead of the orb's `latest` default, so an upstream `gh` release cannot break the release pipeline without a deliberate bump here.

## Test plan

- [x] `circleci config validate` on an isolated config containing the new `github-cli/install` step + `cimg/android` executor — valid. (Full-config validation fails locally only because the private `attentive-mobile/circleci-orb` cannot be resolved without a token.)
- [ ] Re-trigger the `2.2.2-beta.1` release after this merges; confirm `gh --version` prints, the release PR is opened, and the Maven Central publish runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)