### PR TITLE
MSDK-446: Gate push token fetch on pushEnabled

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -58,6 +58,16 @@ object AttentiveSdk {
                     "Please call AttentiveSdk.initialize() in your Application.onCreate() method.",
             )
 
+    private const val PUSH_DISABLED_MESSAGE =
+        "Push is disabled via AttentiveConfig.Builder.pushEnabled(false)"
+
+    /**
+     * True only when a config is present and has push turned off. An uninitialized SDK is
+     * not treated as disabled — those calls keep failing the way they always have rather
+     * than being silently swallowed by this gate.
+     */
+    private fun isPushDisabled(): Boolean = _config?.pushEnabled == false
+
     // Inbox state management
     private val _inboxState = MutableStateFlow(InboxState())
 
@@ -579,6 +589,9 @@ object AttentiveSdk {
      * Fetches the current FCM push token, optionally prompting the user for notification
      * permission first.
      *
+     * Returns a failed [Result] without fetching or prompting if push is disabled via
+     * [AttentiveConfig.Builder.pushEnabled].
+     *
      * @param application Application context, used to request permission if needed.
      * @param requestPermission If `true`, prompts for `POST_NOTIFICATIONS` on Android 13+
      *   before fetching.
@@ -587,11 +600,18 @@ object AttentiveSdk {
         application: Application,
         requestPermission: Boolean,
     ): Result<TokenFetchResult> {
+        if (isPushDisabled()) {
+            Timber.d("$PUSH_DISABLED_MESSAGE; skipping push token fetch")
+            return Result.failure(IllegalStateException(PUSH_DISABLED_MESSAGE))
+        }
         return AttentivePush.getInstance().fetchPushToken(application, requestPermission)
     }
 
     /**
      * Callback-based variant of [getPushToken] for Java interop.
+     *
+     * Invokes [PushTokenCallback.onFailure] without fetching or prompting if push is
+     * disabled via [AttentiveConfig.Builder.pushEnabled].
      */
     @JvmStatic
     fun getPushTokenWithCallback(
@@ -599,6 +619,11 @@ object AttentiveSdk {
         requestPermission: Boolean,
         callback: PushTokenCallback,
     ) {
+        if (isPushDisabled()) {
+            Timber.d("$PUSH_DISABLED_MESSAGE; skipping push token fetch")
+            callback.onFailure(IllegalStateException(PUSH_DISABLED_MESSAGE))
+            return
+        }
         Timber.d("Synchronously fetching push token with requestPermission: $requestPermission")
         CoroutineScope(Dispatchers.IO).launch {
             try {

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveSdkTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveSdkTest.kt
@@ -20,6 +20,8 @@ import com.attentive.androidsdk.internal.network.UnreadCountResponse
 import kotlinx.coroutines.flow.MutableStateFlow
 import retrofit2.Response
 import com.attentive.androidsdk.internal.util.Constants
+import com.attentive.androidsdk.push.AttentivePush
+import com.attentive.androidsdk.push.TokenFetchResult
 import com.attentive.androidsdk.push.TokenProvider
 import com.google.firebase.messaging.RemoteMessage
 import kotlinx.coroutines.runBlocking
@@ -48,6 +50,7 @@ class AttentiveSdkTest {
     private lateinit var callback: AttentiveSdk.PushTokenCallback
     private lateinit var factoryMocks: FactoryMocks
     private var mockedAppInfo: MockedStatic<AppInfo>? = null
+    private var mockedAttentivePush: Boolean = false
     @Before
     fun setUp() {
         remoteMessage = mock(RemoteMessage::class.java)
@@ -79,6 +82,7 @@ class AttentiveSdkTest {
 
     @After
     fun tearDown() {
+        restoreAttentivePushInstance()
         factoryMocks.close()
         mockedAppInfo?.close()
         TokenProvider.getInstance().token = null
@@ -110,6 +114,63 @@ class AttentiveSdkTest {
     fun isAttentiveFirebaseMessage_returnsFalse_whenNoAttentiveKey() {
         whenever(remoteMessage.data).thenReturn(mapOf("other_key" to "Test"))
         assertFalse(AttentiveSdk.isAttentiveFirebaseMessage(remoteMessage))
+    }
+
+    @Test
+    fun getPushToken_whenPushDisabled_doesNotFetchToken() {
+        setConfig(pushEnabled = false)
+        val push = mockAttentivePushInstance()
+
+        val result = runBlocking { AttentiveSdk.getPushToken(application, requestPermission = true) }
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalStateException)
+        runBlocking { verify(push, never()).fetchPushToken(any(), any()) }
+    }
+
+    @Test
+    fun getPushToken_whenPushEnabled_fetchesToken() {
+        setConfig(pushEnabled = true)
+        val push = mockAttentivePushInstance()
+        val expected = TokenFetchResult(PUSH_TOKEN, permissionGranted = true)
+        runBlocking {
+            whenever(push.fetchPushToken(any(), any())).thenReturn(Result.success(expected))
+        }
+
+        val result = runBlocking { AttentiveSdk.getPushToken(application, requestPermission = true) }
+
+        assertEquals(expected, result.getOrNull())
+    }
+
+    @Test
+    fun getPushTokenWithCallback_whenPushDisabled_invokesOnFailureWithoutFetching() {
+        setConfig(pushEnabled = false)
+        val push = mockAttentivePushInstance()
+
+        AttentiveSdk.getPushTokenWithCallback(application, requestPermission = true, callback)
+
+        // The gate returns synchronously, before the Dispatchers.IO launch.
+        verify(callback).onFailure(any())
+        verify(callback, never()).onSuccess(any())
+        runBlocking { verify(push, never()).fetchPushToken(any(), any()) }
+    }
+
+    @Test
+    fun getPushTokenWithCallback_whenPushEnabled_fetchesTokenAndInvokesOnSuccess() {
+        setConfig(pushEnabled = true)
+        val push = mockAttentivePushInstance()
+        val expected = TokenFetchResult(PUSH_TOKEN, permissionGranted = true)
+        runBlocking {
+            whenever(push.fetchPushToken(any(), any())).thenReturn(Result.success(expected))
+        }
+
+        AttentiveSdk.getPushTokenWithCallback(application, requestPermission = true, callback)
+
+        // The fetch is launched on Dispatchers.IO; give it time to execute.
+        Thread.sleep(100)
+
+        verify(callback).onSuccess(eq(expected))
+        verify(callback, never()).onFailure(any())
     }
 
     @Test
@@ -513,6 +574,44 @@ class AttentiveSdkTest {
         val state = AttentiveSdk.inboxState.value
         assertEquals(0, state.messages.size)
         assertNull(readNextPageToken())
+    }
+
+    /**
+     * Replaces the config on [AttentiveSdk] with one built at the given [pushEnabled] setting.
+     * Set directly by reflection for the same reason as [setUp] — AttentiveEventTracker.initialize
+     * requires the main looper.
+     */
+    private fun setConfig(pushEnabled: Boolean) {
+        val config = AttentiveConfig.Builder()
+            .domain(DOMAIN)
+            .mode(AttentiveConfig.Mode.DEBUG)
+            .applicationContext(mock(Application::class.java))
+            .pushEnabled(pushEnabled)
+            .build()
+        val field = AttentiveSdk::class.java.getDeclaredField("_config")
+        field.isAccessible = true
+        field.set(AttentiveSdk, config)
+    }
+
+    /**
+     * Swaps the [AttentivePush] singleton for a mock so the gate can be asserted on without
+     * touching FCM. Restored in [tearDown] via [restoreAttentivePushInstance].
+     */
+    private fun mockAttentivePushInstance(): AttentivePush {
+        val mockPush = mock(AttentivePush::class.java)
+        val field = AttentivePush::class.java.getDeclaredField("INSTANCE")
+        field.isAccessible = true
+        field.set(null, mockPush)
+        mockedAttentivePush = true
+        return mockPush
+    }
+
+    private fun restoreAttentivePushInstance() {
+        if (!mockedAttentivePush) return
+        val field = AttentivePush::class.java.getDeclaredField("INSTANCE")
+        field.isAccessible = true
+        field.set(null, AttentivePush())
+        mockedAttentivePush = false
     }
 
     private fun setNextPageToken(token: String?) {


### PR DESCRIPTION
## Ticket
[MSDK-446](https://attentivemobile.atlassian.net/browse/MSDK-446)

## Summary
`pushEnabled(false)` gated the automatic push paths — `AttentiveEventTracker.registerPushToken`, the app-launch event, and `AttentiveSdk.sendNotification` — but not the public token-fetch entry points. `AttentiveSdk.getPushToken` (`AttentiveSdk.kt:598` pre-change) and `getPushTokenWithCallback` (`:609`) called `AttentivePush.fetchPushToken` unconditionally, so with push disabled the SDK still minted an FCM token and, with `requestPermission = true`, could show the OS notification-permission prompt.

Both entry points now short-circuit before reaching `AttentivePush`: the suspend variant returns `Result.failure(IllegalStateException(...))`, the callback variant invokes `onFailure(...)` synchronously. This mirrors the iOS `guard pushEnabled else { ... }` in `registerForPushNotifications` / `registerDeviceToken`.

Audited the other public push entry points — no further changes needed:
- `updatePushPermissionStatus` delegates to the already-gated `registerPushToken`
- `isPushPermissionGranted` is a read-only permission check, no fetch
- `clearUser` / `updateUser` read the cached token; the ticket specifies opt-in/opt-out must keep working with `pushEnabled = false`

## Confidence
Two things worth a second opinion:

1. **`Result.failure` vs. success-with-no-token.** The three existing gates are all void functions that just `return`, so there's no precedent for what a *gated* return value should be. `Result.failure` is a behaviour change for callers doing `getOrNull()?.token` — they go from receiving a real token to `null`. That seems correct (a caller asking for a token while push is off should learn it isn't getting one), but if the RN bridge treats `onFailure` as an error to surface to JS, a silent success-with-empty-token may be preferable. Easy to flip.

2. **Scope.** The ticket names only `getPushTokenWithCallback`; I gated the suspend `getPushToken` too, since it's the same defect reachable from Kotlin and the ticket asks to "audit any other public push entry points."

The gate reads `_config` directly rather than the throwing `config` getter, so an uninitialized SDK keeps throwing its existing "must be initialized" error rather than being converted into a push-disabled failure.

Verified from source; the reproduction in the ticket (RN Bonni host app) was not re-run on a device.

## Test plan
- [ ] `getPushToken_whenPushDisabled_doesNotFetchToken` and `getPushTokenWithCallback_whenPushDisabled_invokesOnFailureWithoutFetching` — confirmed both fail on `develop` without the fix (`WantedButNotInvoked: pushTokenCallback.onFailure` / `AssertionError` on `isFailure`) and pass with it
- [ ] `getPushToken_whenPushEnabled_fetchesToken` and `getPushTokenWithCallback_whenPushEnabled_fetchesTokenAndInvokesOnSuccess` — guard against the gate over-firing; these pass both before and after
- [ ] `./gradlew :attentive-android-sdk:testDebugUnitTest` passes
- [ ] `./gradlew :attentive-android-sdk:lintDebug ktlintCheck` passes; no new warnings in the changed files
- [ ] Manual: RN Bonni with `.pushEnabled(false)`, call `registerForPushNotifications()` — confirm no permission prompt and no "Push token fetched successfully" log

🤖 Automated fix attempt by Claude Code. Review before merging.

[MSDK-446]: https://attentivemobile.atlassian.net/browse/MSDK-446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ