### PR TITLE
MSDK-470: Guard updateUser/clearUser against no-op regenerations

### DIFF
--- a/attentive-android-sdk/src/androidTest/java/com/attentive/androidsdk/IdentitySyncScenariosIT.kt
+++ b/attentive-android-sdk/src/androidTest/java/com/attentive/androidsdk/IdentitySyncScenariosIT.kt
@@ -1,0 +1,344 @@
+package com.attentive.androidsdk
+
+import android.app.Application
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.attentive.androidsdk.push.TokenProvider
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import timber.log.Timber
+import java.util.Collections
+
+/**
+ * Drives the MSDK-470 identity guards on a real device against real SharedPreferences, with the
+ * network stubbed at the OkHttp layer so no `/user-update` reaches production.
+ *
+ * Each scenario logs `IDENTITY-SCENARIO` markers so the behaviour can be read straight out of
+ * logcat alongside the SDK's own Timber output.
+ */
+@RunWith(AndroidJUnit4::class)
+class IdentitySyncScenariosIT {
+    private lateinit var application: Application
+    private val userUpdates = Collections.synchronizedList(mutableListOf<String>())
+
+    private val client =
+        OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val request = chain.request()
+                if (request.url.encodedPath.endsWith("user-update")) {
+                    val body = okio.Buffer().also { request.body?.writeTo(it) }.readUtf8()
+                    userUpdates.add(body)
+                    Timber.i("IDENTITY-SCENARIO fake backend received /user-update: $body")
+                }
+                Response.Builder()
+                    .request(request)
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .body("".toResponseBody())
+                    .build()
+            }.build()
+
+    @Before
+    fun setUp() {
+        application =
+            InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as Application
+        TokenProvider.getInstance().token = PUSH_TOKEN
+    }
+
+    @After
+    fun tearDown() {
+        TokenProvider.getInstance().token = null
+    }
+
+    /**
+     * Wipes everything the SDK persists — the fresh-install state.
+     */
+    private fun wipeStorage() {
+        PersistentStorage(application).deleteAll()
+        userUpdates.clear()
+    }
+
+    /**
+     * Builds a brand new [AttentiveConfig] over the same on-disk storage and installs it, which is
+     * exactly what a process recreation does: identifiers rebuilt from the persisted visitor ID
+     * alone, with no email or phone in memory.
+     */
+    private fun launch(domain: String = DOMAIN): AttentiveConfig {
+        Timber.uprootAll()
+        val config =
+            AttentiveConfig.Builder()
+                .applicationContext(application)
+                .mode(AttentiveConfig.Mode.DEBUG)
+                .domain(domain)
+                .logLevel(AttentiveLogLevel.VERBOSE)
+                .okHttpClient(client)
+                .build()
+        AttentiveEventTracker.instance.config = config
+        val field = AttentiveSdk::class.java.getDeclaredField("_config")
+        field.isAccessible = true
+        field.set(AttentiveSdk, config)
+        return config
+    }
+
+    private fun scenario(name: String) {
+        Timber.i("IDENTITY-SCENARIO ===== $name =====")
+    }
+
+    private fun step(description: String) {
+        Timber.i("IDENTITY-SCENARIO   -> $description")
+    }
+
+    private fun updateUser(
+        email: String?,
+        phone: String?,
+    ): Int {
+        val before = userUpdates.size
+        val result = runBlocking { AttentiveSdk.updateUserSuspend(email = email, phoneNumber = phone) }
+        assertTrue("updateUser failed: ${result.exceptionOrNull()?.message}", result.isSuccess)
+        return userUpdates.size - before
+    }
+
+    private fun clearUser(): Int {
+        val before = userUpdates.size
+        AttentiveSdk.clearUser()
+        Thread.sleep(500)
+        return userUpdates.size - before
+    }
+
+    private fun report(
+        requestsSent: Int,
+        visitorBefore: String?,
+        visitorAfter: String?,
+    ) {
+        step(
+            "requests sent = $requestsSent, visitor ${if (visitorBefore == visitorAfter) {
+                "unchanged ($visitorAfter)"
+            } else {
+                "ROTATED ($visitorBefore -> $visitorAfter)"
+            }}",
+        )
+    }
+
+    @Test
+    fun scenario1_firstUpdateUser_sendsAndRotates() {
+        wipeStorage()
+        scenario("1. first ever updateUser (fresh install)")
+        var config = launch()
+        val before = config.userIdentifiers.visitorId
+
+        val sent = updateUser(EMAIL, PHONE)
+        val after = config.userIdentifiers.visitorId
+        report(sent, before, after)
+
+        assertEquals("expected the first update to be sent", 1, sent)
+        assertNotEquals("expected a genuine identity change to rotate the visitor", before, after)
+    }
+
+    @Test
+    fun scenario2_repeatUpdateUser_sameProcess_isNoOp() {
+        wipeStorage()
+        scenario("2. identical updateUser repeated in the same process")
+        val config = launch()
+        updateUser(EMAIL, PHONE)
+        val before = config.userIdentifiers.visitorId
+
+        step("calling updateUser again with the same identifiers")
+        val sent = updateUser(EMAIL, PHONE)
+        val after = config.userIdentifiers.visitorId
+        report(sent, before, after)
+
+        assertEquals("the repeat call should send nothing", 0, sent)
+        assertEquals("the repeat call should not rotate the visitor", before, after)
+    }
+
+    /** The fix for the process-recreation P1. */
+    @Test
+    fun scenario3_repeatUpdateUser_afterColdLaunch_isNoOp() {
+        wipeStorage()
+        scenario("3. identical updateUser after a cold launch (process recreation)")
+        launch()
+        updateUser(EMAIL, PHONE)
+
+        step("simulating process death: rebuilding AttentiveConfig from disk")
+        val relaunched = launch()
+        val before = relaunched.userIdentifiers.visitorId
+        step("after relaunch, in-memory email=${relaunched.userIdentifiers.email} phone=${relaunched.userIdentifiers.phone}")
+
+        val sent = updateUser(EMAIL, PHONE)
+        val after = relaunched.userIdentifiers.visitorId
+        report(sent, before, after)
+        step("identifiers now email=${relaunched.userIdentifiers.email} phone=${relaunched.userIdentifiers.phone}")
+
+        assertEquals("a relaunch with identical identifiers should send nothing", 0, sent)
+        assertEquals("a relaunch should not rotate the visitor", before, after)
+        assertEquals("the confirmed email should be restored locally", EMAIL, relaunched.userIdentifiers.email)
+        assertEquals("the confirmed phone should be restored locally", PHONE, relaunched.userIdentifiers.phone)
+    }
+
+    @Test
+    fun scenario4_differentUser_afterColdLaunch_stillRotates() {
+        wipeStorage()
+        scenario("4. cold launch, then updateUser for a DIFFERENT user")
+        launch()
+        updateUser(EMAIL, PHONE)
+
+        step("simulating process death, then identifying someone else")
+        val relaunched = launch()
+        val before = relaunched.userIdentifiers.visitorId
+
+        val sent = updateUser(OTHER_EMAIL, PHONE)
+        val after = relaunched.userIdentifiers.visitorId
+        report(sent, before, after)
+
+        assertEquals("a genuine new user must be sent", 1, sent)
+        assertNotEquals("a genuine new user must rotate the visitor", before, after)
+    }
+
+    /** The fix for the domain-scoping P1. */
+    @Test
+    fun scenario5_afterDomainChange_resendsWithoutRotating() {
+        wipeStorage()
+        scenario("5. changeDomain, then the identical updateUser")
+        val config = launch()
+        updateUser(EMAIL, PHONE)
+        val before = config.userIdentifiers.visitorId
+
+        step("changing domain to $OTHER_DOMAIN")
+        config.changeDomain(OTHER_DOMAIN)
+
+        val sent = updateUser(EMAIL, PHONE)
+        val after = config.userIdentifiers.visitorId
+        report(sent, before, after)
+
+        assertEquals("the new domain has never heard of this user, so it must be sent", 1, sent)
+        assertEquals("re-associating the same user must not rotate the visitor", before, after)
+        assertTrue(
+            "the request should carry the new domain",
+            userUpdates.last().contains(OTHER_DOMAIN),
+        )
+    }
+
+    @Test
+    fun scenario6_afterLocalOnlyClear_rotatedVisitor_resends() {
+        wipeStorage()
+        scenario("6. deprecated AttentiveConfig.clearUser() rotates the visitor, then updateUser")
+        val config = launch()
+        updateUser(EMAIL, PHONE)
+
+        step("calling the deprecated local-only clearUser (rotates the visitor, tells nobody)")
+        @Suppress("DEPRECATION")
+        config.clearUser()
+        val before = config.userIdentifiers.visitorId
+
+        val sent = updateUser(EMAIL, PHONE)
+        val after = config.userIdentifiers.visitorId
+        report(sent, before, after)
+
+        assertEquals("the new visitor was never associated, so it must be sent", 1, sent)
+    }
+
+    @Test
+    fun scenario7_clearUser_repeated_isNoOp() {
+        wipeStorage()
+        scenario("7. clearUser twice")
+        val config = launch()
+        updateUser(EMAIL, PHONE)
+
+        step("first clearUser")
+        val firstSent = clearUser()
+        val before = config.userIdentifiers.visitorId
+        step("requests sent = $firstSent, visitor now $before")
+
+        step("second clearUser")
+        val sent = clearUser()
+        val after = config.userIdentifiers.visitorId
+        report(sent, before, after)
+
+        assertEquals("the first clear must reach the backend", 1, firstSent)
+        assertEquals("the repeat clear should send nothing", 0, sent)
+        assertEquals("the repeat clear should not rotate the visitor", before, after)
+    }
+
+    @Test
+    fun scenario8_clearUser_afterColdLaunch_isNoOp() {
+        wipeStorage()
+        scenario("8. clearUser, cold launch, clearUser again")
+        launch()
+        updateUser(EMAIL, PHONE)
+        clearUser()
+
+        step("simulating process death")
+        val relaunched = launch()
+        val before = relaunched.userIdentifiers.visitorId
+
+        val sent = clearUser()
+        val after = relaunched.userIdentifiers.visitorId
+        report(sent, before, after)
+
+        assertEquals("a relaunch with nothing to clear should send nothing", 0, sent)
+        assertEquals("a relaunch should not rotate the visitor", before, after)
+    }
+
+    @Test
+    fun scenario9_clearUser_afterDomainChange_resends() {
+        wipeStorage()
+        scenario("9. clearUser, changeDomain, clearUser again")
+        val config = launch()
+        updateUser(EMAIL, PHONE)
+        clearUser()
+        val before = config.userIdentifiers.visitorId
+
+        step("changing domain to $OTHER_DOMAIN")
+        config.changeDomain(OTHER_DOMAIN)
+
+        val sent = clearUser()
+        val after = config.userIdentifiers.visitorId
+        report(sent, before, after)
+
+        assertEquals("the detach must be repeated for the new domain", 1, sent)
+        assertEquals("re-detaching must not rotate the visitor", before, after)
+    }
+
+    @Test
+    fun scenario10_rotatedPushToken_resendsWithoutRotating() {
+        wipeStorage()
+        scenario("10. push token rotates, then the identical updateUser")
+        val config = launch()
+        updateUser(EMAIL, PHONE)
+        val before = config.userIdentifiers.visitorId
+
+        step("rotating the FCM token")
+        TokenProvider.getInstance().token = "rotatedPushToken"
+
+        val sent = updateUser(EMAIL, PHONE)
+        val after = config.userIdentifiers.visitorId
+        report(sent, before, after)
+
+        assertEquals("the new token must be attached", 1, sent)
+        assertEquals("attaching a new token must not rotate the visitor", before, after)
+        assertTrue(
+            "the request should carry the rotated token",
+            userUpdates.last().contains("rotatedPushToken"),
+        )
+    }
+
+    private companion object {
+        const val DOMAIN = "someDomain"
+        const val OTHER_DOMAIN = "someOtherDomain"
+        const val EMAIL = "identity.scenarios@example.com"
+        const val OTHER_EMAIL = "someone.else@example.com"
+        const val PHONE = "+15556667777"
+        const val PUSH_TOKEN = "instrumentedPushToken"
+    }
+}

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -639,6 +639,9 @@ object AttentiveSdk {
      * available, the network call is skipped (see
      * [MSDK-345](https://attentivemobile.atlassian.net/browse/MSDK-345)).
      *
+     * No-op when the given identifiers already match the current user — see
+     * [updateUserSuspend].
+     *
      * Errors are logged but not surfaced. Use [updateUserSuspend] for coroutine-aware
      * error handling.
      */
@@ -657,6 +660,12 @@ object AttentiveSdk {
     /**
      * Suspend variant of [updateUser]. Returns success or wrapped failure once the network
      * call completes.
+     *
+     * Host apps commonly call this on every launch "to be safe". When the incoming
+     * identifiers already match the current user the call is a no-op — the visitor ID is
+     * left alone and no `/user-update` is sent — so repeat calls no longer grow the
+     * identity graph server-side. Returns success in that case, since the requested state
+     * already holds.
      */
     suspend fun updateUserSuspend(
         email: String? = null,
@@ -699,6 +708,11 @@ object AttentiveSdk {
             return Result.failure(IllegalArgumentException(msg))
         }
 
+        if (config.userIdentifiers.matchesUser(validatedEmail, validatedNumber)) {
+            Timber.i("Skipping user update: identifiers already match the current user")
+            return Result.success(Unit)
+        }
+
         config.resetIdentifiers()
         resetInboxForIdentityChange()
         val domain = config.domain
@@ -708,7 +722,14 @@ object AttentiveSdk {
             Timber.w("Skipping user update network call: visitorId=$visitorId, pushToken=$pushToken")
             return Result.failure(IllegalArgumentException("Visitor id $visitorId and pushToken $pushToken must not be null"))
         }
-        return config.attentiveApi.sendUserUpdate(domain, validatedEmail, validatedNumber, visitorId, pushToken)
+        val result = config.attentiveApi.sendUserUpdate(domain, validatedEmail, validatedNumber, visitorId, pushToken)
+        if (result.isFailure) {
+            // sendUserUpdate stores the identifiers before the request completes, so a failed
+            // update leaves them looking current. Drop them again or an identical retry would
+            // be swallowed by the guard above.
+            config.userIdentifiers = config.userIdentifiers.copy(email = null, phone = null)
+        }
+        return result
     }
 
     /**
@@ -735,8 +756,18 @@ object AttentiveSdk {
      *
      * Prefer this over the deprecated `AttentiveConfig.clearUser()`, which only clears local
      * state.
+     *
+     * No-op when there is no user to clear — that is, when the only identifier held is the
+     * visitor ID. Host apps that call this on every launch "to be safe" would otherwise mint
+     * a fresh visitor ID and POST `/user-update` each time, growing the identity graph
+     * server-side for no benefit.
      */
     fun clearUser() {
+        if (config.userIdentifiers.hasNoUserScopedIdentifiers()) {
+            Timber.i("Skipping clear user: no user-scoped identifiers to clear")
+            return
+        }
+
         config.resetIdentifiers()
         resetInboxForIdentityChange()
         val domain = config.domain
@@ -768,6 +799,35 @@ object AttentiveSdk {
 
         fun onFailure(exception: Exception)
     }
+
+    /**
+     * True when this set holds nothing but a visitor ID — nothing identifying a person.
+     * Push-token presence is deliberately not considered; the token is tracked separately.
+     */
+    private fun UserIdentifiers.hasNoUserScopedIdentifiers(): Boolean =
+        email == null &&
+            phone == null &&
+            clientUserId == null &&
+            shopifyId == null &&
+            klaviyoId == null &&
+            customIdentifiers.isEmpty()
+
+    /**
+     * True when [email] and [phone] are byte-for-byte what this set already holds and no other
+     * user-scoped identifier is present. Comparison is exact — no case folding, no phone
+     * normalization — so any difference falls through to a regular update.
+     *
+     * The "no other identifier" condition matters because a real update resets the whole set:
+     * if a client user ID or custom identifier is attached, skipping would not be equivalent
+     * to proceeding.
+     */
+    private fun UserIdentifiers.matchesUser(email: String?, phone: String?): Boolean =
+        this.email == email &&
+            this.phone == phone &&
+            clientUserId == null &&
+            shopifyId == null &&
+            klaviyoId == null &&
+            customIdentifiers.isEmpty()
 
     private fun dispatchResult(result: Result<Unit>, callback: AttentiveCallback) {
         result.fold(

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -14,6 +14,8 @@ import com.attentive.androidsdk.events.Event
 import com.attentive.androidsdk.inbox.InboxState
 import com.attentive.androidsdk.inbox.Message
 import com.attentive.androidsdk.inbox.Style
+import com.attentive.androidsdk.internal.identity.IdentitySyncDecision
+import com.attentive.androidsdk.internal.identity.IdentitySyncStore
 import com.attentive.androidsdk.internal.network.DeleteMessageRequest
 import com.attentive.androidsdk.internal.network.GetMessagesRequest
 import com.attentive.androidsdk.internal.network.InboxMessageDto
@@ -43,7 +45,6 @@ import org.jetbrains.annotations.VisibleForTesting
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import timber.log.Timber
-import kotlin.coroutines.cancellation.CancellationException
 
 object AttentiveSdk {
     private var _config: AttentiveConfig? = null
@@ -87,6 +88,10 @@ object AttentiveSdk {
     private val inboxMessagesReadUrl get() = "${inboxHost.trimEnd('/')}/inbox/messages/read"
     private val inboxMessagesUnreadUrl get() = "${inboxHost.trimEnd('/')}/inbox/messages/unread"
     private val inboxEventsClickedUrl get() = "${inboxHost.trimEnd('/')}/inbox/events/clicked"
+
+    // Guards identity decisions and the visitor-ID rotation that follows them. A plain monitor
+    // rather than a Mutex because clearUser() is not a suspend function.
+    private val identityLock = Any()
 
     // Pagination management
     private val paginationLock = Mutex()
@@ -662,11 +667,15 @@ object AttentiveSdk {
      * Suspend variant of [updateUser]. Returns success or wrapped failure once the network
      * call completes.
      *
-     * Host apps commonly call this on every launch "to be safe". When the incoming
-     * identifiers already match the current user the call is a no-op — the visitor ID is
-     * left alone and no `/user-update` is sent — so repeat calls no longer grow the
-     * identity graph server-side. Returns success in that case, since the requested state
-     * already holds.
+     * Host apps commonly call this on every launch "to be safe". When the incoming identifiers
+     * already match the current user *and* the last `/user-update` the backend confirmed carried
+     * exactly those identifiers and this push token, the call is a no-op — the visitor ID is left
+     * alone and nothing is sent — so repeat calls no longer grow the identity graph server-side.
+     * Returns success in that case, since the requested state already holds.
+     *
+     * When the identifiers match but the sync was never confirmed — a fresh launch, a failed
+     * request, or a rotated push token — the request is sent on the *existing* visitor ID rather
+     * than a new one, so a relaunch still reaches the backend without churning identity.
      */
     suspend fun updateUserSuspend(
         email: String? = null,
@@ -709,52 +718,76 @@ object AttentiveSdk {
             return Result.failure(IllegalArgumentException(msg))
         }
 
-        if (config.userIdentifiers.matchesUser(validatedEmail, validatedNumber)) {
-            Timber.i("Skipping user update: identifiers already match the current user")
-            return Result.success(Unit)
+        val pushToken = TokenProvider.getInstance().token
+        when (planUpdateUser(validatedEmail, validatedNumber, pushToken)) {
+            IdentitySyncDecision.SKIP -> {
+                Timber.i("Skipping user update: identifiers already match the last confirmed sync")
+                return Result.success(Unit)
+            }
+
+            IdentitySyncDecision.RETRY_WITHOUT_ROTATION ->
+                Timber.i("Resending user update without rotating the visitor ID: sync not yet confirmed")
+
+            IdentitySyncDecision.ROTATED_AND_REPLACED -> resetInboxForIdentityChange()
         }
 
-        config.resetIdentifiers()
-        resetInboxForIdentityChange()
         val domain = config.domain
         val visitorId = config.userIdentifiers.visitorId
-        val pushToken = TokenProvider.getInstance().token
         if (visitorId == null || pushToken == null) {
             Timber.w("Skipping user update network call: visitorId=$visitorId, pushToken=$pushToken")
             return Result.failure(IllegalArgumentException("Visitor id $visitorId and pushToken $pushToken must not be null"))
         }
-        val result =
-            try {
-                config.attentiveApi.sendUserUpdate(domain, validatedEmail, validatedNumber, visitorId, pushToken)
-            } catch (e: CancellationException) {
-                // sendUserUpdate stores the identifiers before it rethrows, so cancellation
-                // exits without reaching the rollback below.
-                rollBackStoredContactInfo(visitorId)
-                throw e
-            }
-        if (result.isFailure) {
-            rollBackStoredContactInfo(visitorId)
+        val result = config.attentiveApi.sendUserUpdate(domain, validatedEmail, validatedNumber, visitorId, pushToken)
+        if (result.isSuccess) {
+            identitySyncStore().recordSuccessfulSync(validatedEmail, validatedNumber, pushToken)
         }
         return result
     }
 
     /**
-     * Undoes the email/phone that [AttentiveApi.sendUserUpdate] stores before its request
-     * completes. Without this, a failed or cancelled update leaves the identifiers looking
-     * current and an identical retry would be swallowed by the no-op guard in
-     * [updateUserSuspend].
+     * Decides what [updateUserSuspend] should do, rotating the visitor ID and installing the new
+     * identifiers when the change is genuine.
      *
-     * Only rolls back while [visitorId] is still the current one, so an update that lost a race
-     * to a newer one can't strip contact info off the newer user.
+     * Deciding and mutating happen under one lock so two concurrent callers passing the same
+     * identifiers can't each mint a visitor ID — the loser sees the winner's state and falls
+     * through to [IdentitySyncDecision.RETRY_WITHOUT_ROTATION] at worst.
      */
-    private fun rollBackStoredContactInfo(visitorId: String) {
-        val current = config.userIdentifiers
-        if (current.visitorId != visitorId) {
-            Timber.i("Not rolling back user update: a newer identity change has since landed")
-            return
+    private fun planUpdateUser(
+        email: String?,
+        phone: String?,
+        pushToken: String?,
+    ): IdentitySyncDecision =
+        synchronized(identityLock) {
+            if (!config.userIdentifiers.matchesUser(email, phone)) {
+                config.resetIdentifiers()
+                config.userIdentifiers = config.userIdentifiers.copy(email = email, phone = phone)
+                return IdentitySyncDecision.ROTATED_AND_REPLACED
+            }
+            if (identitySyncStore().matchesLastSync(email, phone, pushToken)) {
+                IdentitySyncDecision.SKIP
+            } else {
+                IdentitySyncDecision.RETRY_WITHOUT_ROTATION
+            }
         }
-        config.userIdentifiers = current.copy(email = null, phone = null)
-    }
+
+    /**
+     * Decides what [clearUser] should do. Same locking rationale as [planUpdateUser].
+     */
+    private fun planClearUser(pushToken: String?): IdentitySyncDecision =
+        synchronized(identityLock) {
+            if (!config.userIdentifiers.hasNoUserScopedIdentifiers()) {
+                config.resetIdentifiers()
+                return IdentitySyncDecision.ROTATED_AND_REPLACED
+            }
+            if (identitySyncStore().matchesLastSync(null, null, pushToken)) {
+                IdentitySyncDecision.SKIP
+            } else {
+                IdentitySyncDecision.RETRY_WITHOUT_ROTATION
+            }
+        }
+
+    private fun identitySyncStore(): IdentitySyncStore =
+        IdentitySyncStore(ClassFactory.buildPersistentStorage(config.applicationContext))
 
     /**
      * Callback-based variant of [updateUserSuspend] for Java interop.
@@ -781,28 +814,42 @@ object AttentiveSdk {
      * Prefer this over the deprecated `AttentiveConfig.clearUser()`, which only clears local
      * state.
      *
-     * No-op when there is no user to clear — that is, when the only identifier held is the
-     * visitor ID. Host apps that call this on every launch "to be safe" would otherwise mint
-     * a fresh visitor ID and POST `/user-update` each time, growing the identity graph
-     * server-side for no benefit.
+     * No-op when there is no user to clear *and* the backend already knows it — that is, when
+     * the only identifier held is the visitor ID and the last confirmed `/user-update` already
+     * detached this push token. Host apps that call this on every launch "to be safe" would
+     * otherwise mint a fresh visitor ID and POST `/user-update` each time, growing the identity
+     * graph server-side for no benefit.
+     *
+     * When there is nothing to clear but the detach was never confirmed — a fresh install, a
+     * failed request, or a rotated push token — the request is sent again on the *existing*
+     * visitor ID rather than a new one.
      */
     fun clearUser() {
-        if (config.userIdentifiers.hasNoUserScopedIdentifiers()) {
-            Timber.i("Skipping clear user: no user-scoped identifiers to clear")
-            return
+        val pushToken = TokenProvider.getInstance().token
+        when (planClearUser(pushToken)) {
+            IdentitySyncDecision.SKIP -> {
+                Timber.i("Skipping clear user: nothing to clear and the detach is already confirmed")
+                return
+            }
+
+            IdentitySyncDecision.RETRY_WITHOUT_ROTATION ->
+                Timber.i("Resending clear user without rotating the visitor ID: detach not yet confirmed")
+
+            IdentitySyncDecision.ROTATED_AND_REPLACED -> resetInboxForIdentityChange()
         }
 
-        config.resetIdentifiers()
-        resetInboxForIdentityChange()
         val domain = config.domain
         val visitorId = config.userIdentifiers.visitorId
-        val pushToken = TokenProvider.getInstance().token
         if (visitorId == null || pushToken == null) {
             Timber.w("Skipping clear user: visitorId=$visitorId, pushToken=$pushToken")
             return
         }
+        val syncStore = identitySyncStore()
         CoroutineScope(Dispatchers.IO).launch {
-            config.attentiveApi.sendUserUpdate(domain, null, null, visitorId, pushToken, logLabel = "clear user")
+            val result = config.attentiveApi.sendUserUpdate(domain, null, null, visitorId, pushToken, logLabel = "clear user")
+            if (result.isSuccess) {
+                syncStore.recordSuccessfulSync(null, null, pushToken)
+            }
         }
     }
 

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -15,6 +15,7 @@ import com.attentive.androidsdk.inbox.InboxState
 import com.attentive.androidsdk.inbox.Message
 import com.attentive.androidsdk.inbox.Style
 import com.attentive.androidsdk.internal.identity.IdentitySyncDecision
+import com.attentive.androidsdk.internal.identity.IdentitySyncRecord
 import com.attentive.androidsdk.internal.identity.IdentitySyncStore
 import com.attentive.androidsdk.internal.network.DeleteMessageRequest
 import com.attentive.androidsdk.internal.network.GetMessagesRequest
@@ -673,9 +674,13 @@ object AttentiveSdk {
      * alone and nothing is sent — so repeat calls no longer grow the identity graph server-side.
      * Returns success in that case, since the requested state already holds.
      *
-     * When the identifiers match but the sync was never confirmed — a fresh launch, a failed
-     * request, or a rotated push token — the request is sent on the *existing* visitor ID rather
-     * than a new one, so a relaunch still reaches the backend without churning identity.
+     * This holds across process restarts, which is when host apps most often re-issue the call:
+     * the confirmed record is persisted, and a cold launch — where the in-memory email and phone
+     * are necessarily null — is recognised as the no-op it is rather than as a new user.
+     *
+     * When the identifiers match but the sync was never confirmed — a failed request, a rotated
+     * push token, or a [AttentiveConfig.changeDomain] since — the request is sent on the *existing*
+     * visitor ID rather than a new one, so it reaches the backend without churning identity.
      */
     suspend fun updateUserSuspend(
         email: String? = null,
@@ -739,7 +744,9 @@ object AttentiveSdk {
         }
         val result = config.attentiveApi.sendUserUpdate(domain, validatedEmail, validatedNumber, visitorId, pushToken)
         if (result.isSuccess) {
-            identitySyncStore().recordSuccessfulSync(validatedEmail, validatedNumber, pushToken)
+            identitySyncStore().recordSuccessfulSync(
+                IdentitySyncRecord(domain, visitorId, pushToken, validatedEmail, validatedNumber),
+            )
         }
         return result
     }
@@ -758,12 +765,26 @@ object AttentiveSdk {
         pushToken: String?,
     ): IdentitySyncDecision =
         synchronized(identityLock) {
+            val syncStore = identitySyncStore()
+            // A cold launch rebuilds userIdentifiers from the persisted visitor ID alone
+            // (AttentiveConfig), so the in-memory email and phone are *always* null no matter what
+            // the previous process sent. Without this check, a host that re-issues the same
+            // updateUser on every launch would look like a genuine identity change every time and
+            // rotate the visitor ID — the exact churn this guard exists to stop. The confirmed
+            // record says the backend already holds these identifiers on this visitor, in this
+            // domain, for this token, so adopt them locally instead of treating the gap as news.
+            if (config.userIdentifiers.hasNoUserScopedIdentifiers() &&
+                syncStore.matches(syncRecord(email, phone, pushToken))
+            ) {
+                config.userIdentifiers = config.userIdentifiers.copy(email = email, phone = phone)
+                return IdentitySyncDecision.SKIP
+            }
             if (!config.userIdentifiers.matchesUser(email, phone)) {
                 config.resetIdentifiers()
                 config.userIdentifiers = config.userIdentifiers.copy(email = email, phone = phone)
                 return IdentitySyncDecision.ROTATED_AND_REPLACED
             }
-            if (identitySyncStore().matchesLastSync(email, phone, pushToken)) {
+            if (syncStore.matches(syncRecord(email, phone, pushToken))) {
                 IdentitySyncDecision.SKIP
             } else {
                 IdentitySyncDecision.RETRY_WITHOUT_ROTATION
@@ -772,6 +793,10 @@ object AttentiveSdk {
 
     /**
      * Decides what [clearUser] should do. Same locking rationale as [planUpdateUser].
+     *
+     * No cold-launch special case is needed here: a relaunch rebuilds the identifiers with nothing
+     * user-scoped attached, which is already the state [clearUser] is asking for, so the confirmed
+     * record decides on its own.
      */
     private fun planClearUser(pushToken: String?): IdentitySyncDecision =
         synchronized(identityLock) {
@@ -779,12 +804,32 @@ object AttentiveSdk {
                 config.resetIdentifiers()
                 return IdentitySyncDecision.ROTATED_AND_REPLACED
             }
-            if (identitySyncStore().matchesLastSync(null, null, pushToken)) {
+            if (identitySyncStore().matches(syncRecord(null, null, pushToken))) {
                 IdentitySyncDecision.SKIP
             } else {
                 IdentitySyncDecision.RETRY_WITHOUT_ROTATION
             }
         }
+
+    /**
+     * The sync [email] and [phone] would produce if sent right now, or null when the SDK can't
+     * assemble a complete one — no push token or no visitor ID yet — in which case there is
+     * nothing meaningful to compare against the confirmed record.
+     */
+    private fun syncRecord(
+        email: String?,
+        phone: String?,
+        pushToken: String?,
+    ): IdentitySyncRecord? {
+        val visitorId = config.userIdentifiers.visitorId ?: return null
+        return IdentitySyncRecord(
+            domain = config.domain,
+            visitorId = visitorId,
+            pushToken = pushToken ?: return null,
+            email = email,
+            phone = phone,
+        )
+    }
 
     private fun identitySyncStore(): IdentitySyncStore =
         IdentitySyncStore(ClassFactory.buildPersistentStorage(config.applicationContext))
@@ -848,7 +893,7 @@ object AttentiveSdk {
         CoroutineScope(Dispatchers.IO).launch {
             val result = config.attentiveApi.sendUserUpdate(domain, null, null, visitorId, pushToken, logLabel = "clear user")
             if (result.isSuccess) {
-                syncStore.recordSuccessfulSync(null, null, pushToken)
+                syncStore.recordSuccessfulSync(IdentitySyncRecord(domain, visitorId, pushToken, null, null))
             }
         }
     }

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveSdk.kt
@@ -43,6 +43,7 @@ import org.jetbrains.annotations.VisibleForTesting
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import timber.log.Timber
+import kotlin.coroutines.cancellation.CancellationException
 
 object AttentiveSdk {
     private var _config: AttentiveConfig? = null
@@ -722,14 +723,37 @@ object AttentiveSdk {
             Timber.w("Skipping user update network call: visitorId=$visitorId, pushToken=$pushToken")
             return Result.failure(IllegalArgumentException("Visitor id $visitorId and pushToken $pushToken must not be null"))
         }
-        val result = config.attentiveApi.sendUserUpdate(domain, validatedEmail, validatedNumber, visitorId, pushToken)
+        val result =
+            try {
+                config.attentiveApi.sendUserUpdate(domain, validatedEmail, validatedNumber, visitorId, pushToken)
+            } catch (e: CancellationException) {
+                // sendUserUpdate stores the identifiers before it rethrows, so cancellation
+                // exits without reaching the rollback below.
+                rollBackStoredContactInfo(visitorId)
+                throw e
+            }
         if (result.isFailure) {
-            // sendUserUpdate stores the identifiers before the request completes, so a failed
-            // update leaves them looking current. Drop them again or an identical retry would
-            // be swallowed by the guard above.
-            config.userIdentifiers = config.userIdentifiers.copy(email = null, phone = null)
+            rollBackStoredContactInfo(visitorId)
         }
         return result
+    }
+
+    /**
+     * Undoes the email/phone that [AttentiveApi.sendUserUpdate] stores before its request
+     * completes. Without this, a failed or cancelled update leaves the identifiers looking
+     * current and an identical retry would be swallowed by the no-op guard in
+     * [updateUserSuspend].
+     *
+     * Only rolls back while [visitorId] is still the current one, so an update that lost a race
+     * to a newer one can't strip contact info off the newer user.
+     */
+    private fun rollBackStoredContactInfo(visitorId: String) {
+        val current = config.userIdentifiers
+        if (current.visitorId != visitorId) {
+            Timber.i("Not rolling back user update: a newer identity change has since landed")
+            return
+        }
+        config.userIdentifiers = current.copy(email = null, phone = null)
     }
 
     /**

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/identity/IdentitySyncStore.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/identity/IdentitySyncStore.kt
@@ -1,0 +1,75 @@
+package com.attentive.androidsdk.internal.identity
+
+import com.attentive.androidsdk.PersistentStorage
+
+/**
+ * What the SDK last successfully told the backend about this device: the push token it was
+ * carrying and the contact info attached to it.
+ *
+ * Local identifiers alone can't answer "does the backend already know this?" — they're rebuilt
+ * from nothing on every launch and they're set optimistically, before the request completes. This
+ * record is written only after a `/user-update` succeeds, so an unconfirmed or failed sync is
+ * retried on the next call instead of being mistaken for a no-op.
+ *
+ * Persisted so the guard survives a process restart, which is exactly when host apps re-issue
+ * the calls this is meant to absorb.
+ */
+internal class IdentitySyncStore(private val persistentStorage: PersistentStorage) {
+    /**
+     * True when the last confirmed sync carried exactly this push token and contact info, meaning
+     * another `/user-update` would tell the backend nothing new.
+     *
+     * A null [pushToken] never matches: without a token there is nothing to compare the record
+     * against, so the caller should proceed rather than guess.
+     */
+    fun matchesLastSync(email: String?, phone: String?, pushToken: String?): Boolean {
+        if (pushToken == null) {
+            return false
+        }
+        return persistentStorage.read(PUSH_TOKEN_KEY) == pushToken &&
+            persistentStorage.read(EMAIL_KEY) == email &&
+            persistentStorage.read(PHONE_KEY) == phone
+    }
+
+    /**
+     * Records a `/user-update` the backend accepted. Call only on success.
+     */
+    fun recordSuccessfulSync(email: String?, phone: String?, pushToken: String) {
+        persistentStorage.save(PUSH_TOKEN_KEY, pushToken)
+        write(EMAIL_KEY, email)
+        write(PHONE_KEY, phone)
+    }
+
+    private fun write(key: String, value: String?) {
+        if (value == null) {
+            persistentStorage.delete(key)
+        } else {
+            persistentStorage.save(key, value)
+        }
+    }
+
+    companion object {
+        internal const val PUSH_TOKEN_KEY = "com.attentive.androidsdk.LAST_SYNCED_PUSH_TOKEN"
+        internal const val EMAIL_KEY = "com.attentive.androidsdk.LAST_SYNCED_EMAIL"
+        internal const val PHONE_KEY = "com.attentive.androidsdk.LAST_SYNCED_PHONE"
+    }
+}
+
+/**
+ * What [com.attentive.androidsdk.AttentiveSdk] should do with an identity call, decided in one
+ * locked step so concurrent callers can't each rotate the visitor ID.
+ */
+internal enum class IdentitySyncDecision {
+    /** Local state and the backend already agree — do nothing. */
+    SKIP,
+
+    /**
+     * Local state is already correct but the backend never confirmed it, so send the
+     * `/user-update` again *without* minting a new visitor ID. This is the relaunch and
+     * failed-request path: the identity is unchanged, only the sync is outstanding.
+     */
+    RETRY_WITHOUT_ROTATION,
+
+    /** A genuine identity change — the visitor ID was rotated and the new identifiers installed. */
+    ROTATED_AND_REPLACED,
+}

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/identity/IdentitySyncStore.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/identity/IdentitySyncStore.kt
@@ -3,8 +3,27 @@ package com.attentive.androidsdk.internal.identity
 import com.attentive.androidsdk.PersistentStorage
 
 /**
- * What the SDK last successfully told the backend about this device: the push token it was
- * carrying and the contact info attached to it.
+ * One `/user-update` the backend accepted, in full: the domain and visitor it was sent for, the
+ * push token it carried, and the contact info attached to that token.
+ *
+ * Every field is part of the identity of the sync, because changing any one of them means the
+ * backend has *not* been told the resulting state:
+ * - [domain] — a different Attentive account entirely. The same user must be re-associated after
+ *   [com.attentive.androidsdk.AttentiveConfig.changeDomain].
+ * - [visitorId] — the association hangs off the visitor. Once the visitor rotates, the backend
+ *   has never seen this contact info on the new one.
+ * - [pushToken] — a rotated token has to be re-attached or push goes to the old token.
+ */
+internal data class IdentitySyncRecord(
+    val domain: String,
+    val visitorId: String,
+    val pushToken: String,
+    val email: String?,
+    val phone: String?,
+)
+
+/**
+ * What the SDK last successfully told the backend about this device.
  *
  * Local identifiers alone can't answer "does the backend already know this?" — they're rebuilt
  * from nothing on every launch and they're set optimistically, before the request completes. This
@@ -16,28 +35,40 @@ import com.attentive.androidsdk.PersistentStorage
  */
 internal class IdentitySyncStore(private val persistentStorage: PersistentStorage) {
     /**
-     * True when the last confirmed sync carried exactly this push token and contact info, meaning
-     * another `/user-update` would tell the backend nothing new.
+     * True when the last confirmed sync was exactly [candidate], meaning another `/user-update`
+     * would tell the backend nothing new.
      *
-     * A null [pushToken] never matches: without a token there is nothing to compare the record
-     * against, so the caller should proceed rather than guess.
+     * A null [candidate] never matches: the caller couldn't assemble a complete record (no push
+     * token or no visitor ID yet), so there is nothing to compare and it should proceed rather
+     * than guess.
      */
-    fun matchesLastSync(email: String?, phone: String?, pushToken: String?): Boolean {
-        if (pushToken == null) {
-            return false
-        }
-        return persistentStorage.read(PUSH_TOKEN_KEY) == pushToken &&
-            persistentStorage.read(EMAIL_KEY) == email &&
-            persistentStorage.read(PHONE_KEY) == phone
+    fun matches(candidate: IdentitySyncRecord?): Boolean = candidate != null && read() == candidate
+
+    /**
+     * The last confirmed sync, or null if none was ever recorded or the record is incomplete.
+     */
+    fun read(): IdentitySyncRecord? {
+        val domain = persistentStorage.read(DOMAIN_KEY) ?: return null
+        val visitorId = persistentStorage.read(VISITOR_ID_KEY) ?: return null
+        val pushToken = persistentStorage.read(PUSH_TOKEN_KEY) ?: return null
+        return IdentitySyncRecord(
+            domain = domain,
+            visitorId = visitorId,
+            pushToken = pushToken,
+            email = persistentStorage.read(EMAIL_KEY),
+            phone = persistentStorage.read(PHONE_KEY),
+        )
     }
 
     /**
      * Records a `/user-update` the backend accepted. Call only on success.
      */
-    fun recordSuccessfulSync(email: String?, phone: String?, pushToken: String) {
-        persistentStorage.save(PUSH_TOKEN_KEY, pushToken)
-        write(EMAIL_KEY, email)
-        write(PHONE_KEY, phone)
+    fun recordSuccessfulSync(sync: IdentitySyncRecord) {
+        persistentStorage.save(DOMAIN_KEY, sync.domain)
+        persistentStorage.save(VISITOR_ID_KEY, sync.visitorId)
+        persistentStorage.save(PUSH_TOKEN_KEY, sync.pushToken)
+        write(EMAIL_KEY, sync.email)
+        write(PHONE_KEY, sync.phone)
     }
 
     private fun write(key: String, value: String?) {
@@ -49,6 +80,8 @@ internal class IdentitySyncStore(private val persistentStorage: PersistentStorag
     }
 
     companion object {
+        internal const val DOMAIN_KEY = "com.attentive.androidsdk.LAST_SYNCED_DOMAIN"
+        internal const val VISITOR_ID_KEY = "com.attentive.androidsdk.LAST_SYNCED_VISITOR_ID"
         internal const val PUSH_TOKEN_KEY = "com.attentive.androidsdk.LAST_SYNCED_PUSH_TOKEN"
         internal const val EMAIL_KEY = "com.attentive.androidsdk.LAST_SYNCED_EMAIL"
         internal const val PHONE_KEY = "com.attentive.androidsdk.LAST_SYNCED_PHONE"

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveSdkTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveSdkTest.kt
@@ -274,6 +274,123 @@ class AttentiveSdkTest {
         assertEquals(VISITOR_ID, sdkConfig().userIdentifiers.visitorId)
     }
 
+    /**
+     * The cold-launch case. [setUp] leaves the SDK in exactly the state a recreated process is in:
+     * identifiers rebuilt from the persisted visitor ID alone, with no email or phone in memory —
+     * deliberately *without* [seedUserIdentifiers], since a relaunch cannot produce that state.
+     *
+     * A host that re-issues the same updateUser on every launch must not rotate the visitor ID
+     * here, or every cold start grows the identity graph — the churn this guard exists to stop.
+     */
+    @Test
+    fun updateUser_afterProcessRecreation_withConfirmedSync_isNoOp() {
+        seedLastSync(email = EMAIL, phone = PHONE)
+
+        val result = runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL, phoneNumber = PHONE) }
+
+        assertTrue(result.isSuccess)
+        verify(factoryMocks.visitorService, never()).createNewVisitorId()
+        runBlocking {
+            verify(factoryMocks.attentiveApi, never()).sendUserUpdate(any(), any(), any(), any(), any(), any())
+        }
+        assertEquals(VISITOR_ID, sdkConfig().userIdentifiers.visitorId)
+    }
+
+    /**
+     * Same cold launch, but the confirmed identifiers are adopted in memory rather than left null,
+     * so events recorded after the skipped update still carry the user's contact info.
+     */
+    @Test
+    fun updateUser_afterProcessRecreation_restoresTheConfirmedIdentifiersLocally() {
+        seedLastSync(email = EMAIL, phone = PHONE)
+
+        runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL, phoneNumber = PHONE) }
+
+        assertEquals(EMAIL, sdkConfig().userIdentifiers.email)
+        assertEquals(PHONE, sdkConfig().userIdentifiers.phone)
+    }
+
+    /**
+     * A cold launch for a *different* user is a genuine identity change and still rotates — the
+     * confirmed record doesn't match, so the missing in-memory state isn't excused.
+     */
+    @Test
+    fun updateUser_afterProcessRecreation_withDifferentUser_regenerates() {
+        seedLastSync(email = "someoneelse@email.com", phone = PHONE)
+        stubSendUserUpdate(Result.success(Unit))
+
+        val result = runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL, phoneNumber = PHONE) }
+
+        assertTrue(result.isSuccess)
+        verify(factoryMocks.visitorService).createNewVisitorId()
+        runBlocking {
+            verify(factoryMocks.attentiveApi).sendUserUpdate(
+                eq(DOMAIN), eq(EMAIL), eq(PHONE), eq(NEW_VISITOR_ID), any(), any()
+            )
+        }
+    }
+
+    /**
+     * A confirmed sync belongs to the domain it was sent for. After [AttentiveConfig.changeDomain]
+     * the new Attentive account has never heard of this user, so an identical updateUser has to
+     * reach the backend — on the existing visitor ID, since the identity itself didn't change.
+     */
+    @Test
+    fun updateUser_afterDomainChange_resendsForTheNewDomain() {
+        seedUserIdentifiers(email = EMAIL, phone = PHONE)
+        seedLastSync(email = EMAIL, phone = PHONE, domain = "previousDomain")
+        stubSendUserUpdate(Result.success(Unit))
+
+        val result = runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL, phoneNumber = PHONE) }
+
+        assertTrue(result.isSuccess)
+        verify(factoryMocks.visitorService, never()).createNewVisitorId()
+        runBlocking {
+            verify(factoryMocks.attentiveApi).sendUserUpdate(
+                eq(DOMAIN), eq(EMAIL), eq(PHONE), eq(VISITOR_ID), any(), any()
+            )
+        }
+    }
+
+    /**
+     * The association hangs off the visitor, so a record from a rotated-away visitor ID says
+     * nothing about the current one.
+     */
+    @Test
+    fun updateUser_withSyncConfirmedForAnotherVisitorId_resendsWithoutRotating() {
+        seedUserIdentifiers(email = EMAIL, phone = PHONE)
+        seedLastSync(email = EMAIL, phone = PHONE, visitorId = "rotatedAwayVisitorId")
+        stubSendUserUpdate(Result.success(Unit))
+
+        val result = runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL, phoneNumber = PHONE) }
+
+        assertTrue(result.isSuccess)
+        verify(factoryMocks.visitorService, never()).createNewVisitorId()
+        runBlocking {
+            verify(factoryMocks.attentiveApi).sendUserUpdate(
+                eq(DOMAIN), eq(EMAIL), eq(PHONE), eq(VISITOR_ID), any(), any()
+            )
+        }
+    }
+
+    /** Same domain scoping for the logout path. */
+    @Test
+    fun clearUser_afterDomainChange_resendsForTheNewDomain() {
+        seedLastSync(domain = "previousDomain")
+        stubSendUserUpdate(Result.success(Unit))
+
+        AttentiveSdk.clearUser()
+
+        Thread.sleep(100)
+
+        verify(factoryMocks.visitorService, never()).createNewVisitorId()
+        runBlocking {
+            verify(factoryMocks.attentiveApi).sendUserUpdate(
+                eq(DOMAIN), isNull(), isNull(), eq(VISITOR_ID), any(), any()
+            )
+        }
+    }
+
     @Test
     fun updateUser_withDifferentEmail_regeneratesAndEmits() {
         seedUserIdentifiers(email = EMAIL, phone = PHONE)
@@ -327,8 +444,10 @@ class AttentiveSdkTest {
 
     @Test
     fun updateUser_withIdenticalIdentifiers_butNoConfirmedSync_resendsWithoutRotating() {
-        // The relaunch case: local identifiers were restored by the host app, but nothing on disk
-        // says the backend ever heard about them. Resend on the existing visitor ID.
+        // Same process, identifiers already installed, but nothing on disk says the backend ever
+        // heard about them — a failed or in-flight earlier attempt. Resend on the existing visitor
+        // ID. (The cold-launch variant, where the identifiers are *not* installed, is covered by
+        // updateUser_afterProcessRecreation_* below.)
         seedUserIdentifiers(email = EMAIL, phone = PHONE)
         stubSendUserUpdate(Result.success(Unit))
 
@@ -846,7 +965,11 @@ class AttentiveSdkTest {
         email: String? = null,
         phone: String? = null,
         pushToken: String = PUSH_TOKEN,
+        domain: String = DOMAIN,
+        visitorId: String = VISITOR_ID,
     ) {
+        storedValues[IdentitySyncStore.DOMAIN_KEY] = domain
+        storedValues[IdentitySyncStore.VISITOR_ID_KEY] = visitorId
         storedValues[IdentitySyncStore.PUSH_TOKEN_KEY] = pushToken
         email?.let { storedValues[IdentitySyncStore.EMAIL_KEY] = it }
         phone?.let { storedValues[IdentitySyncStore.PHONE_KEY] = it }

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveSdkTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveSdkTest.kt
@@ -6,6 +6,7 @@ import com.attentive.androidsdk.internal.util.AppInfo
 import com.attentive.androidsdk.internal.util.AppInfo.isDebuggable
 import com.attentive.androidsdk.inbox.InboxState
 import com.attentive.androidsdk.inbox.Style
+import com.attentive.androidsdk.internal.identity.IdentitySyncStore
 import com.attentive.androidsdk.internal.network.DeleteMessageRequest
 import com.attentive.androidsdk.internal.network.DeleteMessageResponse
 import com.attentive.androidsdk.internal.network.InboxMessageDto
@@ -52,6 +53,8 @@ class AttentiveSdkTest {
     private lateinit var callback: AttentiveSdk.PushTokenCallback
     private lateinit var factoryMocks: FactoryMocks
     private var mockedAppInfo: MockedStatic<AppInfo>? = null
+    private val storedValues = mutableMapOf<String, String>()
+
     @Before
     fun setUp() {
         remoteMessage = mock(RemoteMessage::class.java)
@@ -62,6 +65,7 @@ class AttentiveSdkTest {
         factoryMocks = FactoryMocks.mockFactoryObjects()
         Mockito.doReturn(VISITOR_ID).`when`(factoryMocks.visitorService).visitorId
         Mockito.doReturn(NEW_VISITOR_ID).`when`(factoryMocks.visitorService).createNewVisitorId()
+        backPersistentStorageWithMap()
 
         mockedAppInfo = Mockito.mockStatic(AppInfo::class.java)
         Mockito.`when`(isDebuggable(any())).thenReturn(false)
@@ -81,8 +85,29 @@ class AttentiveSdkTest {
         field.set(AttentiveSdk, config)
     }
 
+    /**
+     * Makes the mocked [PersistentStorage] behave like a real one so the identity-sync record
+     * written after a successful `/user-update` is visible to the next read.
+     */
+    private fun backPersistentStorageWithMap() {
+        storedValues.clear()
+        Mockito.doAnswer { storedValues[it.getArgument<String>(0)] }
+            .`when`(factoryMocks.persistentStorage).read(anyOrNull())
+        Mockito.doAnswer { invocation ->
+            val key = invocation.getArgument<String?>(0)
+            val value = invocation.getArgument<String?>(1)
+            if (key != null && value != null) {
+                storedValues[key] = value
+            }
+            null
+        }.`when`(factoryMocks.persistentStorage).save(anyOrNull<String>(), anyOrNull<String>())
+        Mockito.doAnswer { storedValues.remove(it.getArgument<String>(0)) }
+            .`when`(factoryMocks.persistentStorage).delete(anyOrNull())
+    }
+
     @After
     fun tearDown() {
+        storedValues.clear()
         factoryMocks.close()
         mockedAppInfo?.close()
         TokenProvider.getInstance().token = null
@@ -142,8 +167,11 @@ class AttentiveSdkTest {
     }
 
     @Test
-    fun clearUser_withOnlyVisitorId_isNoOp() {
-        // Fresh config from @Before holds nothing but a visitor ID — there is no user to clear.
+    fun clearUser_withOnlyVisitorId_andConfirmedDetach_isNoOp() {
+        // Fresh config from @Before holds nothing but a visitor ID — there is no user to clear —
+        // and the backend already confirmed this token carries no contact info.
+        seedLastSync()
+
         AttentiveSdk.clearUser()
 
         Thread.sleep(100)
@@ -153,6 +181,63 @@ class AttentiveSdkTest {
             verify(factoryMocks.attentiveApi, never()).sendUserUpdate(any(), any(), any(), any(), any(), any())
         }
         assertEquals(VISITOR_ID, sdkConfig().userIdentifiers.visitorId)
+    }
+
+    @Test
+    fun clearUser_withOnlyVisitorId_andNoConfirmedDetach_sendsWithoutRotating() {
+        // Nothing to clear locally, but the backend never confirmed the detach (fresh install, or
+        // a prior request that failed), so the request goes out on the existing visitor ID.
+        stubSendUserUpdate(Result.success(Unit))
+
+        AttentiveSdk.clearUser()
+
+        Thread.sleep(100)
+
+        verify(factoryMocks.visitorService, never()).createNewVisitorId()
+        runBlocking {
+            verify(factoryMocks.attentiveApi).sendUserUpdate(
+                eq(DOMAIN), isNull(), isNull(), eq(VISITOR_ID), any(), any()
+            )
+        }
+    }
+
+    @Test
+    fun clearUser_withRotatedPushToken_sendsAgainWithoutRotating() {
+        // The record matches on contact info but not on the token, so the new token still needs
+        // detaching — without minting a visitor ID for it.
+        seedLastSync(pushToken = "staleToken")
+        stubSendUserUpdate(Result.success(Unit))
+
+        AttentiveSdk.clearUser()
+
+        Thread.sleep(100)
+
+        verify(factoryMocks.visitorService, never()).createNewVisitorId()
+        runBlocking {
+            verify(factoryMocks.attentiveApi).sendUserUpdate(
+                eq(DOMAIN), isNull(), isNull(), eq(VISITOR_ID), any(), any()
+            )
+        }
+    }
+
+    @Test
+    fun clearUser_afterSuccess_isNoOpOnTheSecondCall() {
+        seedUserIdentifiers(email = EMAIL)
+        stubSendUserUpdate(Result.success(Unit))
+
+        AttentiveSdk.clearUser()
+        Thread.sleep(100)
+        AttentiveSdk.clearUser()
+        Thread.sleep(100)
+
+        // The first call cleared a real user; the second had nothing to do and the detach was
+        // already confirmed, so it sent nothing.
+        runBlocking {
+            verify(factoryMocks.attentiveApi, Mockito.times(1)).sendUserUpdate(
+                any(), anyOrNull(), anyOrNull(), any(), any(), any()
+            )
+        }
+        verify(factoryMocks.visitorService, Mockito.times(1)).createNewVisitorId()
     }
 
     @Test
@@ -175,8 +260,9 @@ class AttentiveSdkTest {
     }
 
     @Test
-    fun updateUser_withIdenticalIdentifiers_isNoOp() {
+    fun updateUser_withIdenticalIdentifiers_andConfirmedSync_isNoOp() {
         seedUserIdentifiers(email = EMAIL, phone = PHONE)
+        seedLastSync(email = EMAIL, phone = PHONE)
 
         val result = runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL, phoneNumber = PHONE) }
 
@@ -240,24 +326,72 @@ class AttentiveSdkTest {
     }
 
     @Test
-    fun updateUser_afterFailedUpdate_retriesInsteadOfBeingGuarded() {
-        // The real AttentiveApi.sendUserUpdate stores the identifiers before the request
-        // completes, so reproduce that here to exercise the failure-path rollback.
-        answerSendUserUpdate {
-            sdkConfig().identify(UserIdentifiers.Builder().withEmail(EMAIL).build())
-            unboxed(Result.failure(RuntimeException("boom")))
+    fun updateUser_withIdenticalIdentifiers_butNoConfirmedSync_resendsWithoutRotating() {
+        // The relaunch case: local identifiers were restored by the host app, but nothing on disk
+        // says the backend ever heard about them. Resend on the existing visitor ID.
+        seedUserIdentifiers(email = EMAIL, phone = PHONE)
+        stubSendUserUpdate(Result.success(Unit))
+
+        val result = runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL, phoneNumber = PHONE) }
+
+        assertTrue(result.isSuccess)
+        verify(factoryMocks.visitorService, never()).createNewVisitorId()
+        runBlocking {
+            verify(factoryMocks.attentiveApi).sendUserUpdate(
+                eq(DOMAIN), eq(EMAIL), eq(PHONE), eq(VISITOR_ID), any(), any()
+            )
         }
+    }
+
+    @Test
+    fun updateUser_withRotatedPushToken_resendsWithoutRotatingVisitorId() {
+        seedUserIdentifiers(email = EMAIL, phone = PHONE)
+        seedLastSync(email = EMAIL, phone = PHONE, pushToken = "staleToken")
+        stubSendUserUpdate(Result.success(Unit))
+
+        runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL, phoneNumber = PHONE) }
+
+        verify(factoryMocks.visitorService, never()).createNewVisitorId()
+        runBlocking {
+            verify(factoryMocks.attentiveApi).sendUserUpdate(
+                eq(DOMAIN), eq(EMAIL), eq(PHONE), eq(VISITOR_ID), any(), any()
+            )
+        }
+    }
+
+    @Test
+    fun updateUser_afterSuccess_isNoOpOnTheSecondCall() {
+        stubSendUserUpdate(Result.success(Unit))
+
+        val first = runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL) }
+        val second = runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL) }
+
+        assertTrue(first.isSuccess)
+        assertTrue(second.isSuccess)
+        verify(factoryMocks.visitorService, Mockito.times(1)).createNewVisitorId()
+        runBlocking {
+            verify(factoryMocks.attentiveApi, Mockito.times(1)).sendUserUpdate(
+                any(), anyOrNull(), anyOrNull(), any(), any(), any()
+            )
+        }
+    }
+
+    @Test
+    fun updateUser_afterFailedUpdate_retriesWithoutRotatingAgain() {
+        // The real AttentiveApi.sendUserUpdate stores the identifiers before the request
+        // completes, so a failed update leaves local state looking current. Nothing was recorded
+        // as synced, so the retry still fires — on the same visitor ID.
+        answerSendUserUpdate { unboxed(Result.failure(RuntimeException("boom"))) }
 
         val first = runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL) }
         assertTrue(first.isFailure)
-        // The API stores identifiers before the request completes; the failure path must undo
-        // that so an identical retry isn't swallowed by the no-op guard.
-        assertNull(sdkConfig().userIdentifiers.email)
 
         stubSendUserUpdate(Result.success(Unit))
         val second = runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL) }
 
         assertTrue(second.isSuccess)
+        // Only the first call was a genuine identity change; the retry reused its visitor ID.
+        verify(factoryMocks.visitorService, Mockito.times(1)).createNewVisitorId()
         runBlocking {
             verify(factoryMocks.attentiveApi, Mockito.times(2)).sendUserUpdate(
                 eq(DOMAIN), eq(EMAIL), isNull(), eq(NEW_VISITOR_ID), any(), any()
@@ -266,13 +400,10 @@ class AttentiveSdkTest {
     }
 
     @Test
-    fun updateUser_afterCancelledUpdate_rollsBackStoredIdentifiers() {
-        // sendUserUpdate stores the identifiers and then rethrows CancellationException, so the
-        // cancellation path has to roll back too or an identical retry is guarded away.
-        answerSendUserUpdate {
-            sdkConfig().identify(UserIdentifiers.Builder().withEmail(EMAIL).build())
-            throw CancellationException("caller went away")
-        }
+    fun updateUser_afterCancelledUpdate_retriesWithoutRotatingAgain() {
+        // sendUserUpdate rethrows CancellationException without recording a sync, so the next
+        // identical call still reaches the backend rather than being treated as a no-op.
+        answerSendUserUpdate { throw CancellationException("caller went away") }
 
         try {
             runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL) }
@@ -281,13 +412,22 @@ class AttentiveSdkTest {
             // expected
         }
 
-        assertNull(sdkConfig().userIdentifiers.email)
+        stubSendUserUpdate(Result.success(Unit))
+        val retry = runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL) }
+
+        assertTrue(retry.isSuccess)
+        verify(factoryMocks.visitorService, Mockito.times(1)).createNewVisitorId()
+        runBlocking {
+            verify(factoryMocks.attentiveApi, Mockito.times(2)).sendUserUpdate(
+                eq(DOMAIN), eq(EMAIL), isNull(), eq(NEW_VISITOR_ID), any(), any()
+            )
+        }
     }
 
     @Test
-    fun updateUser_failureDoesNotRollBackANewerIdentity() {
+    fun updateUser_failureDoesNotClobberANewerIdentity() {
         // Simulate losing a race: while this update is in flight a newer one lands and installs
-        // its own visitor ID and contact info. The loser must not strip that back off.
+        // its own visitor ID and contact info. The loser must leave that alone.
         answerSendUserUpdate {
             sdkConfig().userIdentifiers =
                 UserIdentifiers(visitorId = "newerVisitorId", email = OTHER_EMAIL, phone = PHONE)
@@ -696,6 +836,20 @@ class AttentiveSdkTest {
     private fun seedUserIdentifiers(email: String? = null, phone: String? = null) {
         sdkConfig().userIdentifiers =
             UserIdentifiers(visitorId = VISITOR_ID, email = email, phone = phone)
+    }
+
+    /**
+     * Pretends the backend already confirmed a `/user-update` carrying these values, which is what
+     * makes an identical call a no-op rather than a resend.
+     */
+    private fun seedLastSync(
+        email: String? = null,
+        phone: String? = null,
+        pushToken: String = PUSH_TOKEN,
+    ) {
+        storedValues[IdentitySyncStore.PUSH_TOKEN_KEY] = pushToken
+        email?.let { storedValues[IdentitySyncStore.EMAIL_KEY] = it }
+        phone?.let { storedValues[IdentitySyncStore.PHONE_KEY] = it }
     }
 
     private fun stubSendUserUpdate(result: Result<Unit>) {

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveSdkTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveSdkTest.kt
@@ -28,6 +28,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import org.mockito.MockedStatic
@@ -42,6 +43,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.whenever
+import kotlin.coroutines.cancellation.CancellationException
 
 class AttentiveSdkTest {
     private lateinit var remoteMessage: RemoteMessage
@@ -261,6 +263,44 @@ class AttentiveSdkTest {
                 eq(DOMAIN), eq(EMAIL), isNull(), eq(NEW_VISITOR_ID), any(), any()
             )
         }
+    }
+
+    @Test
+    fun updateUser_afterCancelledUpdate_rollsBackStoredIdentifiers() {
+        // sendUserUpdate stores the identifiers and then rethrows CancellationException, so the
+        // cancellation path has to roll back too or an identical retry is guarded away.
+        answerSendUserUpdate {
+            sdkConfig().identify(UserIdentifiers.Builder().withEmail(EMAIL).build())
+            throw CancellationException("caller went away")
+        }
+
+        try {
+            runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL) }
+            fail("Expected CancellationException to propagate")
+        } catch (e: CancellationException) {
+            // expected
+        }
+
+        assertNull(sdkConfig().userIdentifiers.email)
+    }
+
+    @Test
+    fun updateUser_failureDoesNotRollBackANewerIdentity() {
+        // Simulate losing a race: while this update is in flight a newer one lands and installs
+        // its own visitor ID and contact info. The loser must not strip that back off.
+        answerSendUserUpdate {
+            sdkConfig().userIdentifiers =
+                UserIdentifiers(visitorId = "newerVisitorId", email = OTHER_EMAIL, phone = PHONE)
+            unboxed(Result.failure(RuntimeException("boom")))
+        }
+
+        val result = runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL) }
+
+        assertTrue(result.isFailure)
+        val identifiers = sdkConfig().userIdentifiers
+        assertEquals("newerVisitorId", identifiers.visitorId)
+        assertEquals(OTHER_EMAIL, identifiers.email)
+        assertEquals(PHONE, identifiers.phone)
     }
 
     @Test

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveSdkTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveSdkTest.kt
@@ -35,7 +35,9 @@ import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
+import org.mockito.stubbing.Answer
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
@@ -114,6 +116,8 @@ class AttentiveSdkTest {
 
     @Test
     fun clearUser_callsSendUserUpdateWithNullIdentifiers() {
+        seedUserIdentifiers(email = EMAIL)
+
         AttentiveSdk.clearUser()
 
         // sendUserUpdate is launched on Dispatchers.IO; give it time to execute
@@ -128,9 +132,135 @@ class AttentiveSdkTest {
 
     @Test
     fun clearUser_resetsIdentifiers() {
+        seedUserIdentifiers(email = EMAIL)
+
         AttentiveSdk.clearUser()
 
         verify(factoryMocks.visitorService).createNewVisitorId()
+    }
+
+    @Test
+    fun clearUser_withOnlyVisitorId_isNoOp() {
+        // Fresh config from @Before holds nothing but a visitor ID — there is no user to clear.
+        AttentiveSdk.clearUser()
+
+        Thread.sleep(100)
+
+        verify(factoryMocks.visitorService, never()).createNewVisitorId()
+        runBlocking {
+            verify(factoryMocks.attentiveApi, never()).sendUserUpdate(any(), any(), any(), any(), any(), any())
+        }
+        assertEquals(VISITOR_ID, sdkConfig().userIdentifiers.visitorId)
+    }
+
+    @Test
+    fun clearUser_withOnlyCustomIdentifiers_clearsAndEmits() {
+        sdkConfig().userIdentifiers = UserIdentifiers(
+            visitorId = VISITOR_ID,
+            customIdentifiers = mapOf("loyaltyId" to "abc123"),
+        )
+
+        AttentiveSdk.clearUser()
+
+        Thread.sleep(100)
+
+        verify(factoryMocks.visitorService).createNewVisitorId()
+        runBlocking {
+            verify(factoryMocks.attentiveApi).sendUserUpdate(
+                eq(DOMAIN), isNull(), isNull(), eq(NEW_VISITOR_ID), any(), any()
+            )
+        }
+    }
+
+    @Test
+    fun updateUser_withIdenticalIdentifiers_isNoOp() {
+        seedUserIdentifiers(email = EMAIL, phone = PHONE)
+
+        val result = runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL, phoneNumber = PHONE) }
+
+        assertTrue(result.isSuccess)
+        verify(factoryMocks.visitorService, never()).createNewVisitorId()
+        runBlocking {
+            verify(factoryMocks.attentiveApi, never()).sendUserUpdate(any(), any(), any(), any(), any(), any())
+        }
+        assertEquals(VISITOR_ID, sdkConfig().userIdentifiers.visitorId)
+    }
+
+    @Test
+    fun updateUser_withDifferentEmail_regeneratesAndEmits() {
+        seedUserIdentifiers(email = EMAIL, phone = PHONE)
+        stubSendUserUpdate(Result.success(Unit))
+
+        val result = runBlocking { AttentiveSdk.updateUserSuspend(email = OTHER_EMAIL, phoneNumber = PHONE) }
+
+        assertTrue(result.isSuccess)
+        verify(factoryMocks.visitorService).createNewVisitorId()
+        runBlocking {
+            verify(factoryMocks.attentiveApi).sendUserUpdate(
+                eq(DOMAIN), eq(OTHER_EMAIL), eq(PHONE), eq(NEW_VISITOR_ID), any(), any()
+            )
+        }
+    }
+
+    @Test
+    fun updateUser_withPhoneRemoved_regeneratesAndEmits() {
+        seedUserIdentifiers(email = EMAIL, phone = PHONE)
+        stubSendUserUpdate(Result.success(Unit))
+
+        runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL) }
+
+        verify(factoryMocks.visitorService).createNewVisitorId()
+        runBlocking {
+            verify(factoryMocks.attentiveApi).sendUserUpdate(
+                eq(DOMAIN), eq(EMAIL), isNull(), eq(NEW_VISITOR_ID), any(), any()
+            )
+        }
+    }
+
+    @Test
+    fun updateUser_withMatchingEmailButExtraStoredIdentifier_regeneratesAndEmits() {
+        // A client user ID would be dropped by a real update, so skipping isn't equivalent.
+        sdkConfig().userIdentifiers = UserIdentifiers(
+            visitorId = VISITOR_ID,
+            email = EMAIL,
+            clientUserId = "client-123",
+        )
+        stubSendUserUpdate(Result.success(Unit))
+
+        runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL) }
+
+        verify(factoryMocks.visitorService).createNewVisitorId()
+        runBlocking {
+            verify(factoryMocks.attentiveApi).sendUserUpdate(
+                eq(DOMAIN), eq(EMAIL), isNull(), eq(NEW_VISITOR_ID), any(), any()
+            )
+        }
+    }
+
+    @Test
+    fun updateUser_afterFailedUpdate_retriesInsteadOfBeingGuarded() {
+        // The real AttentiveApi.sendUserUpdate stores the identifiers before the request
+        // completes, so reproduce that here to exercise the failure-path rollback.
+        answerSendUserUpdate {
+            sdkConfig().identify(UserIdentifiers.Builder().withEmail(EMAIL).build())
+            unboxed(Result.failure(RuntimeException("boom")))
+        }
+
+        val first = runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL) }
+        assertTrue(first.isFailure)
+        // The API stores identifiers before the request completes; the failure path must undo
+        // that so an identical retry isn't swallowed by the no-op guard.
+        assertNull(sdkConfig().userIdentifiers.email)
+
+        stubSendUserUpdate(Result.success(Unit))
+        val second = runBlocking { AttentiveSdk.updateUserSuspend(email = EMAIL) }
+
+        assertTrue(second.isSuccess)
+        runBlocking {
+            verify(factoryMocks.attentiveApi, Mockito.times(2)).sendUserUpdate(
+                eq(DOMAIN), eq(EMAIL), isNull(), eq(NEW_VISITOR_ID), any(), any()
+            )
+        }
     }
 
     @Test
@@ -466,6 +596,7 @@ class AttentiveSdkTest {
 
     @Test
     fun clearUser_resetsInboxStateToEmpty() {
+        seedUserIdentifiers(email = EMAIL)
         setInboxState(
             InboxState(
                 messages = listOf(fakeMessage("m1", isRead = false), fakeMessage("m2", isRead = true)),
@@ -515,6 +646,48 @@ class AttentiveSdkTest {
         assertNull(readNextPageToken())
     }
 
+    private fun sdkConfig(): AttentiveConfig {
+        val field = AttentiveSdk::class.java.getDeclaredField("_config")
+        field.isAccessible = true
+        return field.get(AttentiveSdk) as AttentiveConfig
+    }
+
+    /** Puts the SDK into a "logged in" state without going through the network. */
+    private fun seedUserIdentifiers(email: String? = null, phone: String? = null) {
+        sdkConfig().userIdentifiers =
+            UserIdentifiers(visitorId = VISITOR_ID, email = email, phone = phone)
+    }
+
+    private fun stubSendUserUpdate(result: Result<Unit>) {
+        answerSendUserUpdate { unboxed(result) }
+    }
+
+    /**
+     * Stubs `sendUserUpdate` using the `doAnswer` form, which — unlike `whenever` — doesn't
+     * invoke the mock (and therefore any previously installed answer) while stubbing.
+     */
+    private fun answerSendUserUpdate(answer: () -> Any?) {
+        runBlocking {
+            Mockito.doAnswer(Answer<Any?> { answer() })
+                .`when`(factoryMocks.attentiveApi)
+                .sendUserUpdate(
+                    anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(),
+                )
+        }
+    }
+
+    /**
+     * A suspend function returning [Result] is erased to its *unboxed* underlying value, so a
+     * Mockito answer must hand back that value. Returning a boxed [Result] instead leaves the
+     * caller holding a Result wrapping a Result, which always looks like a success.
+     */
+    private fun unboxed(result: Result<Unit>): Any? {
+        val boxed: Any = result
+        return boxed.javaClass.getDeclaredField("value")
+            .apply { isAccessible = true }
+            .get(boxed)
+    }
+
     private fun setNextPageToken(token: String?) {
         val field = AttentiveSdk::class.java.getDeclaredField("nextPageToken")
         field.isAccessible = true
@@ -544,5 +717,8 @@ class AttentiveSdkTest {
         private const val VISITOR_ID = "visitorIdValue"
         private const val NEW_VISITOR_ID = "newVisitorIdValue"
         private const val PUSH_TOKEN = "testPushToken"
+        private const val EMAIL = "user@example.com"
+        private const val OTHER_EMAIL = "other@example.com"
+        private const val PHONE = "+15551234567"
     }
 }


### PR DESCRIPTION
[MSDK-470](https://attentivemobile.atlassian.net/browse/MSDK-470) · Android counterpart of [MSDK-469 / attentive-ios-sdk#298](https://github.com/attentive-mobile/attentive-ios-sdk/pull/298)

## Problem

Some host apps call `updateUser(...)` and `clearUser()` from their launch code defensively — not because the user changed, but "just to be safe."

The SDK never does this on its own. Every visitor-ID reset comes from a host-app call: `updateUserSuspend`, `clearUser`, or the deprecated `AttentiveConfig.clearUser()`. The only reset the SDK performs by itself is minting an ID when none exists on disk (`VisitorService.kt:10`) — first install only.

But those calls weren't cheap. Each one:

1. minted a brand-new visitor ID and **wrote it to disk**, replacing the persisted one (`VisitorService.kt:13-17`), then
2. POSTed `/user-update`, which drives `mobile-subscription-consumer` → `IdentityService.reIdentify` and appends a row to `identity_partition_<companyId>`.

So a per-launch call produced a per-launch row saying "this new ID is the same person as the old one," forever. Aeropostale (company_id 10687) shows the resulting step-change in `ReIdentifyDatapoint` traffic and per-push-token visitor fanout from ~2026-07-16.

Worse, step 1 ran *before* the push-token null check. A `clearUser()` early in `Application.onCreate()`, before Firebase returned a token, skipped the network call but still churned the device's persisted visitor ID — identity fragmentation with nothing sent at all.

## Solution

Guard on **what the backend last confirmed**, not on local state alone, and separate "send the request" from "rotate the visitor ID."

Local identifiers can't answer "does the backend already know this?" — email/phone/custom IDs are in-memory only (`PersistentStorage` holds just `visitorId`, `skipFatigue`, `logLevel`) and they're installed optimistically, before the request completes. So this adds one small persisted record, `IdentitySyncStore`: the push token and contact info from the last `/user-update` the backend accepted. Written only on success.

Every identity call then resolves to one of three decisions, taken under a single lock together with the mutation it implies:

| Decision | When | Effect |
| --- | --- | --- |
| `SKIP` | local state matches the request **and** the confirmed sync record matches it | nothing happens |
| `RETRY_WITHOUT_ROTATION` | local state already matches, but the sync was never confirmed — fresh launch, failed request, rotated push token | resend `/user-update` on the **existing** visitor ID |
| `ROTATED_AND_REPLACED` | a genuine identity change | rotate the visitor ID, install the new identifiers, reset the inbox, send |

That third state is what makes the guard safe. The pointless repeat calls stop, but a launch-time call that the backend genuinely never received still goes out — it just no longer mints a visitor ID to do it. Push token is part of the record, so an FCM token rotation re-syncs on its own.

Matching contact info is deliberately literal: no case folding, no phone normalization. `Bob@Example.com` ≠ `bob@example.com`. A missed update is worse than a redundant one, so anything that differs takes the full path.

Public API signatures are untouched. The legacy `AttentiveConfig.clearUser()` is left alone (already deprecated).

## Flow

```
FRESH LAUNCH after a prior logged-in session
(persisted state: visitorId=V1 — email/phone were never persisted)

  BEFORE                                  AFTER
  ──────                                  ─────
  app start                               app start
     │                                       │
     ├─ AttentiveConfig built                ├─ AttentiveConfig built
     │    userIdentifiers = {V1}             │    userIdentifiers = {V1}
     │                                       │
     ├─ onStart → /token (V1)                ├─ onStart → /token (V1)
     │                                       │
     └─ clearUser()  "just to be safe"       └─ clearUser()  "just to be safe"
          │                                       │
          ├─ resetIdentifiers() → V2 ★            ├─ nothing to clear locally —
          │    (persisted, always)                │  does the sync record already
          │                                       │  say this token is detached?
          └─ token resolved yet?                  │    │
               ├─ no  → skip POST                 │    ├─ yes → SKIP, no-op
               └─ yes → POST /user-update         │    │        (V1 kept)
                          (null, null, V2) ★      │    │
                             │                    │    └─ no  → POST (null, null, V1)
                             ▼                    │             then record the sync
                        reIdentify row            │
                        appended per launch       ✔ visitorId stays V1
                                                  ✔ at most one POST, ever


REPEAT updateUser(email=E, phone=P) — same values as last time

  BEFORE                                  AFTER
  ──────                                  ─────
  updateUser(E, P)                        updateUser(E, P)
     │                                       │
     ├─ validate E, P                        ├─ validate E, P
     │                                       │
     ├─ resetIdentifiers() → V2 ★            ├─ local == {V, E, P}, nothing else?
     │                                       │    │
     ├─ resetInbox()                         │    ├─ no  → ROTATED_AND_REPLACED
     │                                       │    │        V2, resetInbox, POST(E,P,V2)
     └─ POST /user-update(E, P, V2) ★        │    │
           │                                 │    └─ yes → sync record == (E, P, token)?
           ▼                                 │             ├─ yes → SKIP, success
      reIdentify row                         │             │        (V kept, inbox kept)
      appended per call                      │             └─ no  → POST(E, P, V) and
                                             │                      record it — no rotation

  ★ = the growth this ticket is chasing: new persisted visitorId + a row
      in identity_partition_<companyId> on every single call
```

## Why no rollback

The first cut of this PR guarded on local state only, which meant a failed or cancelled `/user-update` had to be undone: `AttentiveApi.sendUserUpdate` installs the identifiers *before* its request completes (`AttentiveApi.kt:124-128`), so a failure would leave them looking current and an identical retry would be guarded away.

Guarding on the confirmed sync record makes that unnecessary — an unconfirmed sync is retried by construction, whatever happened to the request. The rollback and its race-scoping check are gone, which also resolves the review comment about the relaunch case: that path is now `RETRY_WITHOUT_ROTATION`, not a skip. Same conclusion iOS reached in #298 (`dd089bd` → `d5e7fa6`).

## Concurrency

`planUpdateUser` / `planClearUser` decide *and* mutate under one `identityLock` acquisition, so two concurrent callers can't each mint a visitor ID for the same request — the loser sees the winner's state and falls through to `RETRY_WITHOUT_ROTATION` at worst. A plain monitor rather than a `Mutex` because `clearUser()` is not a suspend function. This matches the single-`NSLock` structure on iOS.

## Tests

| Case | Expectation |
| --- | --- |
| `updateUser`, identical identifiers, sync confirmed | no rotation, no POST, success |
| `updateUser`, identical identifiers, sync **not** confirmed | POST on the existing visitor ID, no rotation |
| `updateUser` after the push token rotated | POST on the existing visitor ID, no rotation |
| `updateUser` twice with the same values | exactly one POST, one rotation |
| `updateUser` with a different email | rotates and emits |
| `updateUser` with the phone removed | rotates and emits |
| `updateUser` matching email but a stored `clientUserId` | rotates and emits |
| `updateUser` retried after a failed request | second attempt emits, reusing the visitor ID |
| `updateUser` retried after a cancelled request | second attempt emits, reusing the visitor ID |
| `updateUser` failing after a newer identity landed | newer identity left intact |
| `clearUser`, visitor-ID-only, detach confirmed | no-op |
| `clearUser`, visitor-ID-only, detach **not** confirmed | POST on the existing visitor ID |
| `clearUser` after the push token rotated | POST on the existing visitor ID |
| `clearUser` twice | exactly one POST |
| `clearUser` from custom-identifiers-only state | clears and emits |

The mocked `PersistentStorage` is map-backed in `setUp`, so the record written after a success is visible to the next read and the two-call tests exercise the real sequence.

`./gradlew :attentive-android-sdk:testDebugUnitTest ktlintCheck` passes (35 tests in `AttentiveSdkTest`).

## Not in this PR

No flag to disable the guards, no telemetry counting guard hits, no `attentive-react-native-sdk` changes (pure pass-through), no backend changes. The patch version bump (AC g, candidate 2.1.10) is deferred to release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MSDK-470]: https://attentivemobile.atlassian.net/browse/MSDK-470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ