### PR TITLE
MSDK-473: v2-default readiness — payload parity + encoding audit

### DIFF
--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveApi.kt
@@ -69,7 +69,13 @@ class AttentiveApi(private var httpClient: OkHttpClient, private val domain: Str
 
     private val baseEventRequestJson = Json {
         ignoreUnknownKeys = true
-        encodeDefaults = true  // Must encode defaults to include eventType field
+        encodeDefaults = true // Must encode defaults so optional metadata fields are included
+        // EventMetadata is a sealed hierarchy, so kotlinx writes a polymorphic discriminator into
+        // every eventMetadata object. The events backend declares that discriminator as
+        // `eventType` (lib-analytics-event/schemas.yaml), so name it to match - otherwise we emit
+        // a stray `"type": "<Kotlin FQCN>"` that isn't in the schema, and `type` is unavailable
+        // for MobileCustomEventMetadata's host-supplied event name.
+        classDiscriminator = "eventType"
     }
 
     private val retrofitEventsEndpoint: HttpUrl.Builder
@@ -370,7 +376,7 @@ private fun internalSendUserIdentifiersCollectedEventAsync(
     }
 
     eventsApi.sendEvent(
-        version = "mobile-app",
+        version = TAG_VERSION_MOBILE_APP,
         externalVendorIds = externalVendorIdsJson,
         domain = domain,
         eventType = "idn",
@@ -620,7 +626,11 @@ private fun mapPurchaseEvent(
     val purchaseMetadata = PurchaseMetadata(
         orderId = event.order.orderId,
         currency = event.items.firstOrNull()?.price?.currency?.currencyCode,
-        orderTotal = computedCartTotal,
+        // A host-supplied cart total wins over the summed item prices, matching the `cartTotal` the
+        // legacy `/e` path puts on both its Purchase and OrderConfirmed requests. The backend turns
+        // this into the OrderConfirmed billing totals, so ignoring the override would understate
+        // orders whose total includes shipping or tax.
+        orderTotal = event.cart?.cartTotal ?: computedCartTotal,
         cart = cart,
         products = products
     )
@@ -628,7 +638,7 @@ private fun mapPurchaseEvent(
     return listOf(
         BaseEventRequest(
             visitorId = visitorId,
-            version = AppInfo.attentiveSDKVersion,
+            version = TAG_VERSION_MOBILE_APP,
             attentiveDomain = domain,
             eventType = EventType.Purchase,
             timestamp = timestamp,
@@ -663,14 +673,17 @@ private fun mapProductViewEvent(
 
         BaseEventRequest(
             visitorId = visitorId,
-            version = AppInfo.attentiveSDKVersion,
+            version = TAG_VERSION_MOBILE_APP,
             attentiveDomain = domain,
             eventType = EventType.ProductView,
             timestamp = timestamp,
             identifiers = identifiers,
             eventMetadata = productViewMetadata,
             sourceType = SourceType.mobile,
-            referrer = event.deeplink ?: "",
+            // The deeplink travels as `locationHref` only — that is the field the backend reads the
+            // legacy `pd` parameter into. The legacy path never sends a referrer (`r`) from mobile,
+            // so neither does this one; the backend derives the referrer from `locationHref` itself.
+            referrer = "",
             locationHref = event.deeplink
         )
     }
@@ -698,14 +711,16 @@ private fun mapAddToCartEvent(
 
         BaseEventRequest(
             visitorId = visitorId,
-            version = AppInfo.attentiveSDKVersion,
+            version = TAG_VERSION_MOBILE_APP,
             attentiveDomain = domain,
             eventType = EventType.AddToCart,
             timestamp = timestamp,
             identifiers = identifiers,
             eventMetadata = addToCartMetadata,
             sourceType = SourceType.mobile,
-            referrer = event.deeplink ?: "",
+            // See mapProductViewEvent: `locationHref` is the `pd` equivalent, referrer stays empty
+            // so the event's request referrer matches the legacy path's.
+            referrer = "",
             locationHref = event.deeplink
         )
     }
@@ -721,13 +736,14 @@ private fun mapCustomEvent(
     val visitorId = userIdentifiers.visitorId!! // Safe because we validate it's not null in recordEvent
 
     val customEventMetadata = MobileCustomEventMetadata(
+        type = event.type,
         customProperties = event.properties.ifEmpty { null }
     )
 
     return listOf(
         BaseEventRequest(
             visitorId = visitorId,
-            version = AppInfo.attentiveSDKVersion,
+            version = TAG_VERSION_MOBILE_APP,
             attentiveDomain = domain,
             eventType = EventType.MobileCustomEvent,
             timestamp = timestamp,
@@ -814,7 +830,7 @@ private fun sendEventInternalAsync(
     Timber.i("Send event type: %s, domain: %s", eventRequest.type.abbreviation, domain)
 
     eventsApi.sendEvent(
-        version = "mobile-app",
+        version = TAG_VERSION_MOBILE_APP,
         externalVendorIds = externalVendorIdsJson,
         domain = domain,
         eventType = eventRequest.type.abbreviation,
@@ -1188,6 +1204,15 @@ internal fun calculateCartTotal(items: List<Item>): String {
 companion object {
     const val ATTENTIVE_EVENTS_ENDPOINT_HOST: String = "events.attentivemobile.com"
     const val ATTENTIVE_MOBILE_ENDPOINT_HOST: String = "mobile.attentivemobile.com"
+
+    /**
+     * The tag version both event paths report: the legacy `/e` path sends it as `v`, the `/mobile`
+     * path as `BaseEventRequest.version`. It ends up on the event's `request.sdkVersion`, which
+     * several backend services compare against this exact literal to recognise mobile-app traffic
+     * (purchase-blocking exemption, app-specific cart links). Sending the SDK's semver here would
+     * silently reclassify `/mobile` events as web-tag traffic, so both paths send the same value.
+     */
+    internal const val TAG_VERSION_MOBILE_APP: String = "mobile-app"
 //        const val ATTENTIVE_DEV_MOBILE_ENDPOINT: String = "mobile.dev.attentivemobile.com"
 
     private fun getProductViewMetadataDto(item: Item): ProductViewMetadataDto {

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveConfig.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/AttentiveConfig.kt
@@ -116,7 +116,18 @@ class AttentiveConfig private constructor(builder: Builder) : AttentiveConfigInt
 
     /**
      * Changes the event-API version at runtime. Debug/testing use only.
+     *
+     * Kept for one more major version so existing debug tooling keeps compiling. The version is
+     * an implementation detail of the SDK, and both paths produce equivalent payloads, so there is
+     * no reason for a host app to switch at runtime — set it once via
+     * [Builder.apiVersion] if you need to pin it.
      */
+    @Deprecated(
+        "The event-API version is an SDK implementation detail and will stop being " +
+            "selectable in a future major version. Pin it at construction time with " +
+            "AttentiveConfig.Builder.apiVersion(...) if you still need to.",
+        ReplaceWith("AttentiveConfig.Builder().apiVersion(apiVersion)"),
+    )
     fun changeApiVersion(apiVersion: ApiVersion) {
         Timber.d("Changing API version from ${this@AttentiveConfig.apiVersion} to $apiVersion")
         this@AttentiveConfig.apiVersion = apiVersion

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Cart.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/events/Cart.kt
@@ -1,12 +1,15 @@
 package com.attentive.androidsdk.events
 
-import com.attentive.androidsdk.ParameterValidation
 import kotlinx.serialization.Serializable
 
 /**
  * Cart state associated with a [PurchaseEvent].
  *
- * @property cartId Your canonical cart identifier. Required, non-empty.
+ * Every field is optional, matching `ATTNCart` on iOS and the `Cart` schema the events backend
+ * accepts (which declares no required properties). A cart with no ID still carries useful
+ * coupon/total/discount context, so an omitted [cartId] is passed through rather than rejected.
+ *
+ * @property cartId Your canonical cart identifier, if you have one.
  * @property cartCoupon A promotion code applied to the cart, if any.
  * @property cartTotal The cart total as a string (e.g. "42.00"). When null on v2 events,
  * the SDK computes a fallback from the item prices.
@@ -14,23 +17,19 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class Cart(
-    val cartId: String,
+    val cartId: String? = null,
     val cartCoupon: String? = null,
     val cartTotal: String? = null,
     val cartDiscount: String? = null,
 ) {
-    init {
-        ParameterValidation.verifyNotEmpty(cartId, "cartId")
-    }
-
     @Serializable
     class Builder {
-        lateinit var cartId: String
+        var cartId: String? = null
         private var cartCoupon: String? = null
         private var cartTotal: String? = null
         private var cartDiscount: String? = null
 
-        fun cartId(id: String): Builder {
+        fun cartId(id: String?): Builder {
             cartId = id
             return this
         }
@@ -50,9 +49,6 @@ data class Cart(
             return this
         }
 
-        /**
-         * @throws UninitializedPropertyAccessException if [cartId] was not set.
-         */
         fun build(): Cart {
             return Cart(
                 cartId = cartId,

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/AddToCartMetadata.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/AddToCartMetadata.kt
@@ -1,10 +1,11 @@
 package com.attentive.androidsdk.internal.network.events
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@SerialName("AddToCart")
 data class AddToCartMetadata(
-    val eventType: String = "AddToCart",
     val product: Product? = null,
     val currency: String? = null,
 ) : EventMetadata()

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/CartUpdatedMetadata.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/CartUpdatedMetadata.kt
@@ -1,10 +1,11 @@
 package com.attentive.androidsdk.internal.network.events
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@SerialName("CartUpdated")
 data class CartUpdatedMetadata(
-    val eventType: String = "CartUpdated",
     val cart: Cart? = null,
     val products: List<Product>? = null,
     val currency: String? = null,

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/CartViewMetadata.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/CartViewMetadata.kt
@@ -1,10 +1,11 @@
 package com.attentive.androidsdk.internal.network.events
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@SerialName("CartView")
 data class CartViewMetadata(
-    val eventType: String = "CartView",
     val cart: Cart? = null,
     val products: List<Product>? = null,
     val currency: String? = null,

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/CheckoutStartedMetadata.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/CheckoutStartedMetadata.kt
@@ -1,10 +1,11 @@
 package com.attentive.androidsdk.internal.network.events
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@SerialName("CheckoutStarted")
 data class CheckoutStartedMetadata(
-    val eventType: String = "CheckoutStarted",
     val orderId: String? = null,
     val currency: String? = null,
     val orderTotal: String? = null,

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/CollectionViewMetadata.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/CollectionViewMetadata.kt
@@ -1,10 +1,11 @@
 package com.attentive.androidsdk.internal.network.events
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@SerialName("CollectionView")
 data class CollectionViewMetadata(
-    val eventType: String = "CollectionView",
     val collectionId: String? = null,
     val collectionTitle: String? = null,
     val products: List<Product>? = null,

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/MobileCustomEventMetadata.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/MobileCustomEventMetadata.kt
@@ -1,9 +1,18 @@
 package com.attentive.androidsdk.internal.network.events
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * The `eventType` discriminator this serializes with is always `MobileCustomEvent` - it identifies
+ * the metadata shape, *not* the host's event name.
+ *
+ * @property type The host-supplied custom event name (`CustomEvent.type`), which the legacy `/e`
+ * path sends as the `type` metadata entry. Matches `ATTNMobileCustomEventMetadata.type` on iOS.
+ */
 @Serializable
+@SerialName("MobileCustomEvent")
 data class MobileCustomEventMetadata(
-    val eventType: String = "MobileCustomEvent",
+    val type: String? = null,
     val customProperties: Map<String, String>? = null,
 ) : EventMetadata()

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/PageLeaveMetadata.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/PageLeaveMetadata.kt
@@ -1,10 +1,11 @@
 package com.attentive.androidsdk.internal.network.events
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@SerialName("PageLeave")
 data class PageLeaveMetadata(
-    val eventType: String = "PageLeave",
     val timeOnPage: Float? = null,
     val scrollDepth: Int? = null,
 ) : EventMetadata()

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/PageViewMetadata.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/PageViewMetadata.kt
@@ -1,8 +1,8 @@
 package com.attentive.androidsdk.internal.network.events
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class PageViewMetadata(
-    val eventType: String = "PageView",
-) : EventMetadata()
+@SerialName("PageView")
+data object PageViewMetadata : EventMetadata()

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/PaymentInfoSubmittedMetadata.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/PaymentInfoSubmittedMetadata.kt
@@ -1,10 +1,11 @@
 package com.attentive.androidsdk.internal.network.events
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@SerialName("PaymentInfoSubmitted")
 data class PaymentInfoSubmittedMetadata(
-    val eventType: String = "PaymentInfoSubmitted",
     val orderId: String? = null,
     val currency: String? = null,
     val orderTotal: String? = null,

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/ProductViewMetadata.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/ProductViewMetadata.kt
@@ -1,10 +1,11 @@
 package com.attentive.androidsdk.internal.network.events
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@SerialName("ProductView")
 data class ProductViewMetadata(
-    val eventType: String = "ProductView",
     val product: Product? = null,
     val currency: String? = null,
 ) : EventMetadata()

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/PurchaseMetadata.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/PurchaseMetadata.kt
@@ -1,10 +1,11 @@
 package com.attentive.androidsdk.internal.network.events
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@SerialName("Purchase")
 data class PurchaseMetadata(
-    val eventType: String = "Purchase",
     val orderId: String? = null,
     val currency: String? = null,
     val orderTotal: String? = null,

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/RemoveFromCartMetadata.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/RemoveFromCartMetadata.kt
@@ -1,9 +1,10 @@
 package com.attentive.androidsdk.internal.network.events
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@SerialName("RemoveFromCart")
 data class RemoveFromCartMetadata(
-    val eventType: String = "RemoveFromCart",
     val product: Product? = null,
 ) : EventMetadata()

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/SearchSubmitMetadata.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/SearchSubmitMetadata.kt
@@ -1,10 +1,11 @@
 package com.attentive.androidsdk.internal.network.events
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@SerialName("SearchSubmit")
 data class SearchSubmitMetadata(
-    val eventType: String = "SearchSubmit",
     val searchQuery: String? = null,
     val products: List<Product>? = null,
 ) : EventMetadata()

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/SortActionMetadata.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/SortActionMetadata.kt
@@ -1,10 +1,11 @@
 package com.attentive.androidsdk.internal.network.events
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@SerialName("SortAction")
 data class SortActionMetadata(
-    val eventType: String = "SortAction",
     val sortBy: String? = null,
     val direction: SortDirection? = null,
 ) : EventMetadata()

--- a/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/UserIdentifierCollectedMetadata.kt
+++ b/attentive-android-sdk/src/main/java/com/attentive/androidsdk/internal/network/events/UserIdentifierCollectedMetadata.kt
@@ -1,8 +1,8 @@
 package com.attentive.androidsdk.internal.network.events
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class UserIdentifierCollectedMetadata(
-    val eventType: String = "UserIdentifierCollected",
-) : EventMetadata()
+@SerialName("UserIdentifierCollected")
+data object UserIdentifierCollectedMetadata : EventMetadata()

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveApiPayloadParityTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/AttentiveApiPayloadParityTest.kt
@@ -1,0 +1,638 @@
+package com.attentive.androidsdk
+
+import com.attentive.androidsdk.events.AddToCartEvent
+import com.attentive.androidsdk.events.Cart
+import com.attentive.androidsdk.events.CustomEvent
+import com.attentive.androidsdk.events.Event
+import com.attentive.androidsdk.events.Item
+import com.attentive.androidsdk.events.Order
+import com.attentive.androidsdk.events.Price
+import com.attentive.androidsdk.events.ProductViewEvent
+import com.attentive.androidsdk.events.PurchaseEvent
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import kotlinx.coroutines.runBlocking
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.Buffer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.MockedStatic
+import org.mockito.Mockito
+import java.math.BigDecimal
+import java.net.URLDecoder
+import java.util.Collections
+import java.util.Currency
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Byte-level parity between the two event paths: legacy `/e` on `events.attentivemobile.com`
+ * (query parameters) and `/mobile` on `mobile.attentivemobile.com` (an
+ * `application/x-www-form-urlencoded` body carrying the event JSON as `d`).
+ *
+ * These back [MSDK-473](https://attentivemobile.atlassian.net/browse/MSDK-473): flipping
+ * `AttentiveConfig.apiVersion` to `NEW` by default has to be invisible to customers, which means
+ * every field a customer's reports depend on must arrive with the same value on both paths.
+ *
+ * The tests drive the real `AttentiveApi` against a real `OkHttpClient` whose interceptor records
+ * the request and short-circuits it, so what is asserted is what would go on the wire — the
+ * encoding included.
+ */
+class AttentiveApiPayloadParityTest {
+    private lateinit var base64Mock: MockedStatic<android.util.Base64>
+
+    @Before
+    fun setUp() {
+        // `unitTests.returnDefaultValues` makes android.util.Base64 return null, which would make
+        // every identifier assertion vacuous. Stand in the JDK encoder, which produces the same
+        // bytes as Base64.NO_WRAP.
+        base64Mock = Mockito.mockStatic(android.util.Base64::class.java)
+        base64Mock.`when`<String> {
+            android.util.Base64.encodeToString(Mockito.any(), Mockito.anyInt())
+        }.thenAnswer { invocation ->
+            java.util.Base64.getEncoder().encodeToString(invocation.getArgument<ByteArray>(0))
+        }
+    }
+
+    @After
+    fun tearDown() {
+        base64Mock.close()
+    }
+
+    // -- Purchase --
+
+    @Test
+    fun purchase_sendsTheSameOrderAndProductFieldsOnBothPaths() {
+        val event = purchaseEvent(items = listOf(itemWithAllFields(), secondItem()))
+
+        val legacy = legacyMetadata(sendLegacy(event, expectedRequests = 3), "p")
+        val orderConfirmed = legacyMetadata(sendLegacy(event, expectedRequests = 3), "oc")
+        val modern = modernPayload(sendModern(event))
+        val metadata = modern.getAsJsonObject("eventMetadata")
+
+        assertEquals(legacy.string("orderId"), metadata.string("orderId"))
+        assertEquals(legacy.string("currency"), metadata.string("currency"))
+        // The legacy path splits a purchase into one request per item plus an OrderConfirmed; the
+        // /mobile path sends one request and the backend's PurchaseProcessor performs the same
+        // split, so the item-level fields are compared against the products array.
+        assertEquals(orderConfirmed.string("cartTotal"), metadata.string("orderTotal"))
+
+        val products = metadata.getAsJsonArray("products")
+        assertEquals(2, products.size())
+        val firstProduct = products[0].asJsonObject
+        assertEquals(legacy.string("productId"), firstProduct.string("productId"))
+        assertEquals(legacy.string("subProductId"), firstProduct.string("variantId"))
+        assertEquals(legacy.string("name"), firstProduct.string("name"))
+        assertEquals(legacy.string("image"), firstProduct.string("imageUrl"))
+        assertEquals(legacy.string("price"), firstProduct.string("price"))
+        assertEquals(legacy.string("quantity"), firstProduct.get("quantity").asString)
+        assertEquals(
+            legacy.string("category"),
+            firstProduct.getAsJsonArray("categories").single().asString,
+        )
+    }
+
+    @Test
+    fun purchase_sendsTheSameCartFieldsOnBothPaths() {
+        val event =
+            purchaseEvent(
+                items = listOf(itemWithAllFields()),
+                cart =
+                    Cart.Builder()
+                        .cartId("cart-1")
+                        .cartCoupon("SAVE10")
+                        .cartDiscount("1.00")
+                        .cartTotal("99.99")
+                        .build(),
+            )
+
+        val legacy = legacyMetadata(sendLegacy(event, expectedRequests = 2), "p")
+        val cart =
+            modernPayload(sendModern(event))
+                .getAsJsonObject("eventMetadata")
+                .getAsJsonObject("cart")
+
+        assertEquals(legacy.string("cartId"), cart.string("cartId"))
+        assertEquals(legacy.string("cartCoupon"), cart.string("cartCoupon"))
+        assertEquals(legacy.string("cartDiscount"), cart.string("cartDiscount"))
+        assertEquals(legacy.string("cartTotal"), cart.string("cartTotal"))
+    }
+
+    /**
+     * A host-supplied cart total is authoritative on the legacy path — it replaces the summed item
+     * prices on both the Purchase and the OrderConfirmed request. The /mobile path used to report
+     * the computed sum as `orderTotal` regardless, which understated any order whose total includes
+     * shipping or tax.
+     */
+    @Test
+    fun purchase_hostSuppliedCartTotalWinsOverTheComputedSumOnBothPaths() {
+        val event =
+            purchaseEvent(
+                items = listOf(itemWithAllFields()), // 15.99
+                cart = Cart.Builder().cartId("cart-1").cartTotal("99.99").build(),
+            )
+
+        val legacy = legacyMetadata(sendLegacy(event, expectedRequests = 2), "oc")
+        val metadata = modernPayload(sendModern(event)).getAsJsonObject("eventMetadata")
+
+        assertEquals("99.99", legacy.string("cartTotal"))
+        assertEquals("99.99", metadata.string("orderTotal"))
+        assertEquals("99.99", metadata.getAsJsonObject("cart").string("cartTotal"))
+    }
+
+    @Test
+    fun purchase_withoutACartTotal_fallsBackToTheSummedItemPricesOnBothPaths() {
+        val event = purchaseEvent(items = listOf(itemWithAllFields(), secondItem())) // 15.99 + 20.00
+
+        val legacy = legacyMetadata(sendLegacy(event, expectedRequests = 3), "oc")
+        val metadata = modernPayload(sendModern(event)).getAsJsonObject("eventMetadata")
+
+        assertEquals("35.99", legacy.string("cartTotal"))
+        assertEquals("35.99", metadata.string("orderTotal"))
+    }
+
+    /**
+     * `cartId` is optional on iOS and carries no `required` marker in the backend's `Cart` schema,
+     * so a cart with only a coupon has to survive both paths rather than being rejected at
+     * construction time.
+     */
+    @Test
+    fun purchase_withACartThatHasNoId_isSentOnBothPaths() {
+        val event =
+            purchaseEvent(
+                items = listOf(itemWithAllFields()),
+                cart = Cart.Builder().cartCoupon("SAVE10").build(),
+            )
+
+        val legacy = legacyMetadata(sendLegacy(event, expectedRequests = 2), "p")
+        val cart =
+            modernPayload(sendModern(event))
+                .getAsJsonObject("eventMetadata")
+                .getAsJsonObject("cart")
+
+        assertNull(legacy.string("cartId"))
+        assertNull(cart.string("cartId"))
+        assertEquals("SAVE10", cart.string("cartCoupon"))
+    }
+
+    // -- ProductView / AddToCart --
+
+    @Test
+    fun productView_sendsTheSameProductFieldsOnBothPaths() {
+        val event = ProductViewEvent.Builder().items(listOf(itemWithAllFields())).build()
+
+        val legacy = legacyMetadata(sendLegacy(event, expectedRequests = 1), "d")
+        val metadata = modernPayload(sendModern(event)).getAsJsonObject("eventMetadata")
+        val product = metadata.getAsJsonObject("product")
+
+        assertEquals(legacy.string("currency"), metadata.string("currency"))
+        assertEquals(legacy.string("productId"), product.string("productId"))
+        assertEquals(legacy.string("subProductId"), product.string("variantId"))
+        assertEquals(legacy.string("name"), product.string("name"))
+        assertEquals(legacy.string("image"), product.string("imageUrl"))
+        assertEquals(legacy.string("price"), product.string("price"))
+        assertEquals(legacy.string("category"), product.getAsJsonArray("categories").single().asString)
+    }
+
+    @Test
+    fun addToCart_sendsTheSameProductFieldsOnBothPaths() {
+        val event = AddToCartEvent.Builder().items(listOf(itemWithAllFields())).build()
+
+        val legacy = legacyMetadata(sendLegacy(event, expectedRequests = 1), "c")
+        val metadata = modernPayload(sendModern(event)).getAsJsonObject("eventMetadata")
+        val product = metadata.getAsJsonObject("product")
+
+        assertEquals(legacy.string("currency"), metadata.string("currency"))
+        assertEquals(legacy.string("productId"), product.string("productId"))
+        assertEquals(legacy.string("subProductId"), product.string("variantId"))
+        assertEquals(legacy.string("name"), product.string("name"))
+        assertEquals(legacy.string("image"), product.string("imageUrl"))
+        assertEquals(legacy.string("price"), product.string("price"))
+    }
+
+    /**
+     * The legacy path carries the deeplink as the `pd` query parameter, which the backend
+     * deserialises straight into the event's `locationHref`. The /mobile path therefore has to put
+     * it in `locationHref` and, like the legacy path, send no referrer of its own.
+     */
+    @Test
+    fun productView_deeplinkArrivesAsPdOnLegacyAndLocationHrefOnModern() {
+        val event =
+            ProductViewEvent.Builder()
+                .items(listOf(itemWithAllFields()))
+                .deeplink(DEEPLINK)
+                .build()
+
+        val legacyUrl = legacyUrl(sendLegacy(event, expectedRequests = 1), "d")
+        val modern = modernPayload(sendModern(event))
+
+        assertEquals(DEEPLINK, legacyUrl.queryParameter("pd"))
+        assertNull(legacyUrl.queryParameter("r"))
+        assertEquals(DEEPLINK, modern.string("locationHref"))
+        assertEquals("", modern.string("referrer"))
+    }
+
+    @Test
+    fun addToCart_deeplinkArrivesAsPdOnLegacyAndLocationHrefOnModern() {
+        val event =
+            AddToCartEvent.Builder()
+                .items(listOf(itemWithAllFields()))
+                .deeplink(DEEPLINK)
+                .build()
+
+        val legacyUrl = legacyUrl(sendLegacy(event, expectedRequests = 1), "c")
+        val modern = modernPayload(sendModern(event))
+
+        assertEquals(DEEPLINK, legacyUrl.queryParameter("pd"))
+        assertNull(legacyUrl.queryParameter("r"))
+        assertEquals(DEEPLINK, modern.string("locationHref"))
+        assertEquals("", modern.string("referrer"))
+    }
+
+    @Test
+    fun productView_withoutADeeplink_sendsNoPdAndNoLocationHref() {
+        val event = ProductViewEvent.Builder().items(listOf(itemWithAllFields())).build()
+
+        val legacyUrl = legacyUrl(sendLegacy(event, expectedRequests = 1), "d")
+        val modern = modernPayload(sendModern(event))
+
+        assertNull(legacyUrl.queryParameter("pd"))
+        assertTrue(modern.get("locationHref").isJsonNull)
+    }
+
+    // -- Custom event --
+
+    /**
+     * The backend turns a custom event's declared type into `CustomEvent.customEventType`. On the
+     * legacy path it reads the `type` metadata entry; on /mobile it reads the metadata's `type`
+     * field, so dropping it would collapse every custom event to the same name.
+     */
+    @Test
+    fun customEvent_sendsTheHostSuppliedTypeOnBothPaths() {
+        val event = CustomEvent.Builder("Concert Viewed", mapOf("artist" to "Nils Frahm")).build()
+
+        val legacy = legacyMetadata(sendLegacy(event, expectedRequests = 1), "ce")
+        val metadata = modernPayload(sendModern(event)).getAsJsonObject("eventMetadata")
+
+        assertEquals("Concert Viewed", legacy.string("type"))
+        assertEquals("Concert Viewed", metadata.string("type"))
+        assertEquals("MobileCustomEvent", metadata.string("eventType"))
+    }
+
+    @Test
+    fun customEvent_sendsTheSamePropertiesOnBothPaths() {
+        val properties = mapOf("artist" to "Nils Frahm", "venue" to "Barbican")
+        val event = CustomEvent.Builder("Concert Viewed", properties).build()
+
+        val legacy = legacyMetadata(sendLegacy(event, expectedRequests = 1), "ce")
+        val metadata = modernPayload(sendModern(event)).getAsJsonObject("eventMetadata")
+
+        val legacyProperties = legacyCustomProperties(legacy)
+        val modernProperties = metadata.getAsJsonObject("customProperties")
+        for ((key, value) in properties) {
+            assertEquals(value, legacyProperties.string(key))
+            assertEquals(value, modernProperties.string(key))
+        }
+    }
+
+    // -- Metadata discriminator --
+
+    /**
+     * `EventMetadata` is a sealed hierarchy, so kotlinx writes a polymorphic discriminator into
+     * every `eventMetadata` object. It has to be named and valued the way the events backend
+     * declares it (`eventType`, short event name) - not kotlinx's default of `type` set to a Kotlin
+     * FQCN, which both leaks an off-schema field and takes the `type` key custom events need.
+     */
+    @Test
+    fun modernMetadata_isDiscriminatedByTheShortEventTypeName() {
+        val expected =
+            mapOf(
+                "Purchase" to purchaseEvent(listOf(itemWithAllFields())),
+                "ProductView" to ProductViewEvent.Builder().items(listOf(itemWithAllFields())).build(),
+                "AddToCart" to AddToCartEvent.Builder().items(listOf(itemWithAllFields())).build(),
+                "MobileCustomEvent" to CustomEvent.Builder("Concert Viewed", mapOf("a" to "b")).build(),
+            )
+
+        for ((eventType, event) in expected) {
+            val metadata = modernPayload(sendModern(event)).getAsJsonObject("eventMetadata")
+
+            assertEquals(eventType, metadata.string("eventType"))
+            assertFalse(
+                "eventMetadata should not carry a Kotlin class name: $metadata",
+                metadata.entrySet().any { (_, value) ->
+                    value.isJsonPrimitive && value.asJsonPrimitive.isString &&
+                        value.asString.startsWith("com.attentive.")
+                },
+            )
+        }
+    }
+
+    // -- Visitor ID, identifiers and tag version --
+
+    @Test
+    fun bothPaths_reportTheSameVisitorId() {
+        for (event in ALL_EVENT_TYPES) {
+            val legacyUrl = sendLegacy(event.event, event.legacyRequestCount)[0].request.url
+            val modern = modernPayload(sendModern(event.event))
+
+            assertEquals(VISITOR_ID, legacyUrl.queryParameter("u"))
+            assertEquals(VISITOR_ID, modern.string("visitorId"))
+        }
+    }
+
+    @Test
+    fun bothPaths_reportTheSameDomain() {
+        for (event in ALL_EVENT_TYPES) {
+            val legacyUrl = sendLegacy(event.event, event.legacyRequestCount)[0].request.url
+            val modern = modernPayload(sendModern(event.event))
+
+            assertEquals(DOMAIN, legacyUrl.queryParameter("c"))
+            assertEquals(DOMAIN, modern.string("attentiveDomain"))
+        }
+    }
+
+    /**
+     * The tag version ends up on the event's `request.sdkVersion`, which several backend services
+     * compare against the literal `"mobile-app"` to recognise mobile-app traffic — the
+     * purchase-blocking exemption and the app-specific cart link among them. Sending the SDK's
+     * semver on /mobile would reclassify those events as web-tag traffic.
+     */
+    @Test
+    fun bothPaths_reportTheSameTagVersion() {
+        for (event in ALL_EVENT_TYPES) {
+            val legacyUrl = sendLegacy(event.event, event.legacyRequestCount)[0].request.url
+            val modern = modernPayload(sendModern(event.event))
+
+            assertEquals("mobile-app", legacyUrl.queryParameter("v"))
+            assertEquals("mobile-app", modern.string("version"))
+        }
+    }
+
+    @Test
+    fun bothPaths_carryTheSameContactInfoAndVendorIds() {
+        val event = AddToCartEvent.Builder().items(listOf(itemWithAllFields())).build()
+
+        val legacyUrl = legacyUrl(sendLegacy(event, expectedRequests = 1), "c")
+        val identifiers = modernPayload(sendModern(event)).getAsJsonObject("identifiers")
+
+        val legacyMetadata = JsonParser.parseString(legacyUrl.queryParameter("m")).asJsonObject
+        assertEquals(EMAIL, legacyMetadata.string("email"))
+        assertEquals(PHONE, legacyMetadata.string("phone"))
+        assertEquals(base64(EMAIL), identifiers.string("encryptedEmail"))
+        assertEquals(base64(PHONE), identifiers.string("encryptedPhone"))
+
+        // The legacy path sends the vendor identifiers as `evs`; /mobile sends the same three as
+        // typed entries in `otherIdentifiers`.
+        val vendorIds = JsonParser.parseString(legacyUrl.queryParameter("evs")).asJsonArray
+        assertEquals(3, vendorIds.size())
+        val otherIdentifiers = identifiers.getAsJsonArray("otherIdentifiers")
+        assertEquals(3, otherIdentifiers.size())
+        assertEquals(
+            setOf(CLIENT_USER_ID, SHOPIFY_ID, KLAVIYO_ID),
+            vendorIds.map { it.asJsonObject.string("id") }.toSet(),
+        )
+        assertEquals(
+            mapOf(
+                "ClientUserId" to CLIENT_USER_ID,
+                "ShopifyId" to SHOPIFY_ID,
+                "KlaviyoId" to KLAVIYO_ID,
+            ),
+            otherIdentifiers.associate { it.asJsonObject.string("idType")!! to it.asJsonObject.string("value") },
+        )
+    }
+
+    // -- Encoding --
+
+    /**
+     * The class of bug MSDK-441 fixed on iOS: a form-encoded body whose value keeps `&`, `=` or `+`
+     * literal is truncated at the first one, silently dropping the event. Retrofit hands the field
+     * to OkHttp's `FormBody`, which percent-encodes all three and writes UTF-8, so the whole
+     * payload has to survive a strict decode.
+     */
+    @Test
+    fun modernBody_isASingleFormEncodedFieldThatSurvivesSeparatorsAndEmoji() {
+        val event = AddToCartEvent.Builder().items(listOf(awkwardItem())).build()
+
+        val captured = sendModern(event)
+        val body = captured.body
+
+        assertEquals("application/x-www-form-urlencoded", captured.request.body?.contentType()?.toString())
+        assertTrue("body should be the single field d=…, was: $body", body.startsWith("d="))
+        // A single field: any `&` or `=` from the payload that leaked through unescaped would split
+        // the body and truncate the event server-side. The only `=` allowed is the `d=` separator.
+        val encodedValue = body.removePrefix("d=")
+        assertEquals(1, body.split("&").size)
+        assertEquals(1, encodedValue.split("=").size)
+
+        val json = JsonParser.parseString(URLDecoder.decode(encodedValue, "UTF-8")).asJsonObject
+        val product = json.getAsJsonObject("eventMetadata").getAsJsonObject("product")
+        assertEquals(AWKWARD_NAME, product.string("name"))
+        assertEquals(AWKWARD_CATEGORY, product.getAsJsonArray("categories").single().asString)
+        assertEquals(AWKWARD_PRODUCT_ID, product.string("productId"))
+    }
+
+    @Test
+    fun legacyQuery_survivesTheSameSeparatorsAndEmoji() {
+        val event = AddToCartEvent.Builder().items(listOf(awkwardItem())).build()
+
+        val legacyUrl = legacyUrl(sendLegacy(event, expectedRequests = 1), "c")
+        val metadata = JsonParser.parseString(legacyUrl.queryParameter("m")).asJsonObject
+
+        // The raw query must not contain the literal separators — OkHttp percent-encodes them, and
+        // `queryParameter` reading them back proves the round trip rather than the encoding alone.
+        val rawName = legacyUrl.encodedQuery!!
+        assertFalse("unescaped '&' in the query would truncate the value", rawName.contains("Grab &"))
+        assertEquals(AWKWARD_NAME, metadata.string("name"))
+        assertEquals(AWKWARD_CATEGORY, metadata.string("category"))
+        assertEquals(AWKWARD_PRODUCT_ID, metadata.string("productId"))
+    }
+
+    @Test
+    fun customEvent_withSeparatorsAndEmojiInTheTypeAndProperties_survivesBothPaths() {
+        // CustomEvent rejects quotes and brackets in `type`, so this exercises the characters a
+        // host can actually send: the form-encoding separators and multi-byte text.
+        val type = "Grab & Go = 1+1 🛒"
+        val properties = mapOf("promo & code" to AWKWARD_NAME)
+        val event = CustomEvent.Builder(type, properties).build()
+
+        val legacy = legacyMetadata(sendLegacy(event, expectedRequests = 1), "ce")
+        val metadata = modernPayload(sendModern(event)).getAsJsonObject("eventMetadata")
+
+        assertEquals(type, legacy.string("type"))
+        assertEquals(type, metadata.string("type"))
+        assertEquals(AWKWARD_NAME, legacyCustomProperties(legacy).string("promo & code"))
+        assertEquals(AWKWARD_NAME, metadata.getAsJsonObject("customProperties").string("promo & code"))
+    }
+
+    // -- Harness --
+
+    private data class CapturedRequest(val request: Request, val body: String)
+
+    private data class EventUnderTest(val event: Event, val legacyRequestCount: Int)
+
+    /**
+     * Records every request an [AttentiveApi] built on a recording client produces, short-circuiting
+     * each one with a 204 so nothing leaves the test.
+     */
+    private fun capture(
+        expectedRequests: Int,
+        send: (AttentiveApi) -> Unit
+    ): List<CapturedRequest> {
+        val captured = Collections.synchronizedList(mutableListOf<CapturedRequest>())
+        val latch = CountDownLatch(expectedRequests)
+        val client =
+            OkHttpClient.Builder()
+                .addInterceptor { chain ->
+                    val request = chain.request()
+                    val buffer = Buffer()
+                    request.body?.writeTo(buffer)
+                    captured.add(CapturedRequest(request, buffer.readUtf8()))
+                    latch.countDown()
+                    Response.Builder()
+                        .request(request)
+                        .protocol(Protocol.HTTP_1_1)
+                        .code(204)
+                        .message("No Content")
+                        .body("".toResponseBody())
+                        .build()
+                }
+                .build()
+
+        send(AttentiveApi(client, DOMAIN))
+
+        assertTrue(
+            "timed out waiting for $expectedRequests request(s), saw ${captured.size}",
+            latch.await(5, TimeUnit.SECONDS),
+        )
+        return captured.toList()
+    }
+
+    private fun sendLegacy(
+        event: Event,
+        expectedRequests: Int
+    ): List<CapturedRequest> = capture(expectedRequests) { api -> api.sendEvent(event, USER_IDENTIFIERS, DOMAIN) }
+
+    private fun sendModern(event: Event): CapturedRequest =
+        capture(1) { api ->
+            val result = runBlocking { api.recordEvent(event, USER_IDENTIFIERS, DOMAIN) }
+            assertTrue("recordEvent failed: ${result.exceptionOrNull()?.message}", result.isSuccess)
+        }.single()
+
+    private fun legacyUrl(
+        captured: List<CapturedRequest>,
+        eventType: String
+    ): HttpUrl =
+        captured.map { it.request.url }
+            .first { it.queryParameter("t") == eventType }
+
+    private fun legacyMetadata(
+        captured: List<CapturedRequest>,
+        eventType: String
+    ): JsonObject = JsonParser.parseString(legacyUrl(captured, eventType).queryParameter("m")).asJsonObject
+
+    private fun modernPayload(captured: CapturedRequest): JsonObject {
+        assertEquals(AttentiveApi.ATTENTIVE_MOBILE_ENDPOINT_HOST, captured.request.url.host)
+        val encodedJson = captured.body.removePrefix("d=")
+        return JsonParser.parseString(URLDecoder.decode(encodedJson, "UTF-8")).asJsonObject
+    }
+
+    /**
+     * The legacy path nests the custom-event properties as a *stringified* JSON map (see
+     * `CustomEventMetadataDto`), where /mobile sends `customProperties` as a real object. Both
+     * shapes are what the backend expects on each path, so the parity check is on the entries.
+     */
+    private fun legacyCustomProperties(metadata: JsonObject): JsonObject =
+        JsonParser.parseString(metadata.string("properties")).asJsonObject
+
+    private fun JsonObject.string(name: String): String? = get(name)?.takeUnless { it.isJsonNull }?.asString
+
+    private fun base64(value: String): String = java.util.Base64.getEncoder().encodeToString(value.toByteArray())
+
+    private fun purchaseEvent(
+        items: List<Item>,
+        cart: Cart? = null
+    ): PurchaseEvent {
+        val builder = PurchaseEvent.Builder(items, Order.Builder().orderId("order-1").build())
+        cart?.let { builder.cart(it) }
+        return builder.build()
+    }
+
+    private fun itemWithAllFields(): Item =
+        Item.Builder("prod-1", "variant-1", price("15.99"))
+            .name("Sweater")
+            .category("Tops")
+            .productImage("https://example.com/sweater.png")
+            .quantity(2)
+            .build()
+
+    private fun secondItem(): Item =
+        Item.Builder("prod-2", "variant-2", price("20.00"))
+            .name("Scarf")
+            .category("Accessories")
+            .build()
+
+    private fun awkwardItem(): Item =
+        Item.Builder(AWKWARD_PRODUCT_ID, "variant & 1", price("15.99"))
+            .name(AWKWARD_NAME)
+            .category(AWKWARD_CATEGORY)
+            .build()
+
+    private fun price(amount: String): Price = Price.Builder().price(BigDecimal(amount)).currency(Currency.getInstance("USD")).build()
+
+    private val ALL_EVENT_TYPES: List<EventUnderTest>
+        get() =
+            listOf(
+                EventUnderTest(purchaseEvent(listOf(itemWithAllFields())), legacyRequestCount = 2),
+                EventUnderTest(
+                    ProductViewEvent.Builder().items(listOf(itemWithAllFields())).build(),
+                    legacyRequestCount = 1,
+                ),
+                EventUnderTest(
+                    AddToCartEvent.Builder().items(listOf(itemWithAllFields())).build(),
+                    legacyRequestCount = 1,
+                ),
+                EventUnderTest(
+                    CustomEvent.Builder("Concert Viewed", mapOf("artist" to "Nils Frahm")).build(),
+                    legacyRequestCount = 1,
+                ),
+            )
+
+    private fun JsonArray.single() = get(0)
+
+    companion object {
+        private const val DOMAIN = "someDomain"
+        private const val VISITOR_ID = "someVisitorId"
+        private const val EMAIL = "Youknow@email.com"
+        private const val PHONE = "+15556667777"
+        private const val CLIENT_USER_ID = "someClientUserId"
+        private const val SHOPIFY_ID = "someShopifyId"
+        private const val KLAVIYO_ID = "someKlaviyoId"
+        private const val DEEPLINK = "myapp://products/sweater?colour=blue&size=M"
+
+        // Every character that breaks a naively encoded form body, plus multi-byte text.
+        private const val AWKWARD_NAME = "Grab & Go = 1+1 'best' \"deal\" 🛒🎉"
+        private const val AWKWARD_CATEGORY = "Tops & Knits"
+        private const val AWKWARD_PRODUCT_ID = "prod=1&2+3"
+
+        private val USER_IDENTIFIERS =
+            UserIdentifiers.Builder()
+                .withVisitorId(VISITOR_ID)
+                .withClientUserId(CLIENT_USER_ID)
+                .withShopifyId(SHOPIFY_ID)
+                .withKlaviyoId(KLAVIYO_ID)
+                .withEmail(EMAIL)
+                .withPhone(PHONE)
+                .build()
+    }
+}

--- a/attentive-android-sdk/src/test/java/com/attentive/androidsdk/BaseEventRequestMapperTest.kt
+++ b/attentive-android-sdk/src/test/java/com/attentive/androidsdk/BaseEventRequestMapperTest.kt
@@ -201,8 +201,11 @@ class BaseEventRequestMapperTest {
 
         // Assert
         assertEquals(1, result.size)
-        assertEquals("app://product/123", result[0].referrer)
         assertEquals("app://product/123", result[0].locationHref)
+        // The legacy /e path only sends the deeplink as `pd` (locationHref) and leaves the referrer
+        // empty, so /mobile has to as well. The backend's RequestResolver already prefers
+        // locationHref over referrer for ProductView.
+        assertEquals("", result[0].referrer)
     }
 
     @Test(expected = IllegalArgumentException::class)
@@ -275,8 +278,9 @@ class BaseEventRequestMapperTest {
 
         // Assert
         assertEquals(1, result.size)
-        assertEquals("app://cart", result[0].referrer)
         assertEquals("app://cart", result[0].locationHref)
+        // Same as ProductView: the deeplink rides in locationHref only, matching legacy `pd`.
+        assertEquals("", result[0].referrer)
     }
 
     // Test mapCustomEvent
@@ -558,8 +562,9 @@ class BaseEventRequestMapperTest {
         assertNotNull(metadata.cart)
         assertEquals("999.99", metadata.cart?.cartTotal)
         assertEquals("5.00", metadata.cart?.cartDiscount)
-        // orderTotal stays as the SDK-computed item sum (15.99), independent of host cartTotal
-        assertEquals("15.99", metadata.orderTotal)
+        // orderTotal follows the host cartTotal too: the backend's PurchaseProcessor turns it into
+        // the OrderConfirmed billing total, which the legacy path reports as the host cartTotal.
+        assertEquals("999.99", metadata.orderTotal)
     }
 
     @Test

--- a/bonni/src/main/java/com/attentive/bonni/settings/SettingsViewModel.kt
+++ b/bonni/src/main/java/com/attentive/bonni/settings/SettingsViewModel.kt
@@ -131,7 +131,9 @@ class SettingsViewModel : ViewModel() {
             putString(ATTENTIVE_ENDPOINT_PREFS, newApiVersion.name)
         }
 
-        // Update the runtime config so it takes effect immediately
+        // Update the runtime config so it takes effect immediately. Bonni is the debug tooling
+        // this deprecated hook exists for, so the warning is expected here.
+        @Suppress("DEPRECATION")
         AttentiveEventTracker.instance.config.changeApiVersion(newApiVersion)
 
         val endPointString =


### PR DESCRIPTION
Closes [MSDK-473](https://attentivemobile.atlassian.net/browse/MSDK-473).

Audits the `/mobile` (v2) payload against the legacy `/e` payload and against what the events backend actually reads, so that flipping `AttentiveConfig.apiVersion` to `NEW` by default (MSDK-471 / #198) is invisible to customers.

> **Stacked on #264** (`bugfix/MSDK-470-guard-noop-user-updates`). Review that one first; this PR's diff is the single commit `61948c2`.

## Divergences found and fixed

| # | Field | Legacy `/e` | `/mobile` before | Impact if we'd flipped as-is |
|---|---|---|---|---|
| 1 | `eventMetadata` discriminator | n/a | `"type": "com.attentive.androidsdk…Metadata"` | Off-schema field on **every** v2 event; occupies the `type` key custom events need |
| 2 | custom event name | `type` metadata entry | **absent** | Every custom event collapses to the literal `MobileCustomEvent` |
| 3 | `version` | `"mobile-app"` | SDK version string (`2.2.1`) | Misses purchase-event gating and app cart links |
| 4 | Purchase `orderTotal` | host cart total | always the summed item prices | Wrong revenue when a host passes `Cart.cartTotal` |
| 5 | `referrer` (ProductView/AddToCart) | empty (deeplink only in `pd`) | duplicated the deeplink | Spurious referrer attribution |

### 1. The metadata discriminator

`EventMetadata` is a `sealed class`, so kotlinx writes a polymorphic discriminator into every `eventMetadata` object. Nobody had named it, so it defaulted to `"type"` with a Kotlin FQCN as its value:

```json
"eventMetadata": {
  "type": "com.attentive.androidsdk.internal.network.events.AddToCartMetadata",
  "eventType": "AddToCart",
  ...
}
```

The events backend declares that discriminator as `eventType` (`lib-analytics-event/schemas.yaml`, `discriminator: propertyName: eventType`), so this now names it to match and drops the hand-written duplicate `eventType` property from each of the 15 subclasses. Result:

```json
"eventMetadata": { "eventType": "AddToCart", ... }
```

### 2. Custom event names

Adds `MobileCustomEventMetadata.type`, carrying `CustomEvent.type` — matching `ATTNMobileCustomEventMetadata.type` on iOS. This is what freed up the `type` key in (1).

⚠️ **This needs a backend change to take effect.** `MobileCustomEventProcessor` sets `customEventType = metadata.getEventType()`, which is always the literal `"MobileCustomEvent"`. Until it reads `type`, custom event names still won't survive v2 — **hard blocker on flipping the default for anyone using custom events.**

### 3. `version`

Several backend services compare `request.sdkVersion` against the exact literal `"mobile-app"` — `PurchaseProcessor.shouldIgnorePurchaseEvent` and `DeviceSpecificCartLinkService.isMobileAppEvent`. v1 sent it; v2 sent the SDK version instead. Now centralised as `AttentiveApi.TAG_VERSION_MOBILE_APP` and used on both paths.

⚠️ **iOS has the same gap** — `ATTNConstants.sdkVersion` is sent where the backend expects `"mobile-app"`. Worth a sibling ticket.

## Other checklist items

- **(a) MSDK-443 shipped publicly** — ✅ `c1d4dfe`, in 2.2.0/2.2.1 on Maven Central + GH Releases.
- **(b) MSDK-441 encoding bug class** — ✅ Not present. Retrofit's `@FormUrlEncoded @Field("d")` hands the value to OkHttp's `FormBody`, which percent-encodes `&`, `=`, `+` and writes UTF-8. Structurally immune, unlike the hand-built body iOS had to fix.
- **(c) `pd` deeplink** — ✅ Present as `locationHref`; see (5) above for the `referrer` half.
- **(d) `Cart.cartId`** — Now optional. `ATTNCart.cartId` is `String?` on iOS and the backend `Cart` schema declares no required properties, so Android was the strict outlier and threw where iOS didn't.
- **(f) Session token / visitor ID** — ✅ Parity, trivially: Android has no session concept on either path. Visitor ID and all six identifiers (Base64 email/phone included) verified identical.
- **(g) `changeApiVersion`** — Still public, now `@Deprecated` with `ReplaceWith` pointing at `Builder.apiVersion(...)`, kept for one major. Bonni's call site suppresses the warning.

## Tests

New `AttentiveApiPayloadParityTest` (20 tests) sends every event type down **both** paths through a recording interceptor and diffs the wire payloads: order/product/cart fields, cart-total precedence, deeplinks, custom event type and properties, visitor ID, tag version, contact info and vendor ids, plus `& = + ' "` and emoji in names, ids, categories and custom properties.

Three `BaseEventRequestMapperTest` cases pinned the old v2 behaviour for (4) and (5) and were updated with a comment explaining why the new value is the correct one.

248 unit tests pass; instrumented and bonni sources compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-473]: https://attentivemobile.atlassian.net/browse/MSDK-473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ