### PR TITLE
MSDK-485: Fix release job auth so it can open the release PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,6 +288,22 @@ jobs:
       # from the environment — so `install` is enough and `setup` would re-auth needlessly.
       - github-cli/install:
           version: "2.97.0"
+      # Diagnostic: `gh pr create` failed the 2.2.2 release with
+      # "GraphQL: must be a collaborator (createPullRequest)" even though the
+      # Attentive Mobile SDK App has read/write on code and pull requests for
+      # this repo, so the token is not the identity we think it is. Runs before
+      # any mutation and never fails the job; prints scope, never the token.
+      - run:
+          name: Verify token identity and scope
+          command: |
+            echo "Repos this installation token can see:"
+            gh api /installation/repositories --jq '.repositories[].full_name' || true
+            echo
+            echo "This repo's permissions for the token (expect push: true):"
+            gh api repos/attentive-mobile/attentive-android-sdk --jq '.permissions' || true
+            echo
+            echo "Authenticated as:"
+            gh api user --jq '.login' || echo "(no user — expected for an installation token)"
       - run:
           name: Switch git remote to HTTPS with App token
           command: |
@@ -334,12 +350,26 @@ jobs:
               git commit -m "Set version to $RELEASE_VERSION"
               git push --force origin "$BRANCH"
 
-              gh pr create \
+              # The PR is bookkeeping; the Maven Central publish below is the release.
+              # Never abort here: the branch is already pushed, so a failure would strand
+              # the release half-done — version bumped on the branch, nothing published.
+              if PR_OUTPUT=$(gh pr create \
                 --repo attentive-mobile/attentive-android-sdk \
                 --title "Release v$RELEASE_VERSION" \
                 --body "Automated release PR. Maven Central publish and GitHub Release are performed from this branch by CircleCI. Merge into main once verified." \
                 --head "$BRANCH" \
-                --base main
+                --base main 2>&1); then
+                echo "$PR_OUTPUT"
+              else
+                echo "$PR_OUTPUT"
+                echo
+                echo "WARNING: could not open the release PR — continuing with the publish."
+                echo "'must be a collaborator' means GITHUB_TOKEN has no push access here."
+                echo "See the 'Verify token identity and scope' step above for what the"
+                echo "token can actually see — the App itself does have code + PR write."
+                echo "Open the PR manually:"
+                echo "  https://github.com/attentive-mobile/attentive-android-sdk/compare/main...$BRANCH?expand=1"
+              fi
             fi
       - run:
           name: Clean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,26 +284,56 @@ jobs:
           github_app_private_key_base64: ${GITHUB_APP_PRIVATE_KEY_BASE64}
           github_app_installation_id: ${GITHUB_APP_INSTALLATION_ID}
       # cimg/android does not bundle the gh CLI, and `gh pr create` / `gh release create`
-      # below need it. Auth comes from GITHUB_TOKEN, already minted above, which gh reads
-      # from the environment — so `install` is enough and `setup` would re-auth needlessly.
+      # below need it. `install` is enough; `setup` would run a redundant gh auth login.
       - github-cli/install:
           version: "2.97.0"
-      # Diagnostic: `gh pr create` failed the 2.2.2 release with
-      # "GraphQL: must be a collaborator (createPullRequest)" even though the
-      # Attentive Mobile SDK App has read/write on code and pull requests for
-      # this repo, so the token is not the identity we think it is. Runs before
-      # any mutation and never fails the job; prints scope, never the token.
+      # Do NOT let gh fall back to GITHUB_TOKEN. The org-global context defines it as a
+      # classic PAT for the machine user circleci-attentive, which is read-only here
+      # (pull: true, push: false), so gh pr create fails with "must be a collaborator"
+      # and gh release create fails with a misleading "workflow scope may be required".
+      # That is what broke the 2.2.2 release (MSDK-485).
+      #
+      # The step above does mint a proper App installation token — the App has code and
+      # pull request write on this repo — but exports it under its own variable name.
+      # Rather than hardcode that name, find it by prefix: ghs_ is an App installation
+      # token, ghp_/gho_/ghu_/github_pat_ are user tokens. Hand it to gh as GH_TOKEN,
+      # which gh prefers over GITHUB_TOKEN.
       - run:
-          name: Verify token identity and scope
+          name: Select the App token for gh and verify write access
           command: |
-            echo "Repos this installation token can see:"
-            gh api /installation/repositories --jq '.repositories[].full_name' || true
-            echo
-            echo "This repo's permissions for the token (expect push: true):"
-            gh api repos/attentive-mobile/attentive-android-sdk --jq '.permissions' || true
-            echo
-            echo "Authenticated as:"
-            gh api user --jq '.login' || echo "(no user — expected for an installation token)"
+            echo "GitHub tokens visible in the environment (name and type prefix only):"
+            APP_TOKEN_VAR=""
+            for name in $(compgen -v); do
+              val="${!name-}"
+              case "$val" in
+                ghs_*)
+                  echo "  $name = ghs_… (App installation token)"
+                  [ -n "$APP_TOKEN_VAR" ] || APP_TOKEN_VAR="$name"
+                  ;;
+                ghp_*|gho_*|ghu_*|github_pat_*)
+                  echo "  $name = ${val%%_*}_… (user token — not usable for the release)"
+                  ;;
+              esac
+            done
+
+            if [ -z "$APP_TOKEN_VAR" ]; then
+              echo "ERROR: no App installation token (ghs_…) found in the environment."
+              echo "The 'Generate ephemeral app-based github token' step should provide one."
+              exit 1
+            fi
+
+            echo "Using \$$APP_TOKEN_VAR as GH_TOKEN"
+            export GH_TOKEN="${!APP_TOKEN_VAR}"
+            echo "export GH_TOKEN=\"\$$APP_TOKEN_VAR\"" >> "$BASH_ENV"
+
+            # Fail here rather than after publishing: a read-only token previously got
+            # as far as pushing a tag and uploading to Maven Central before dying.
+            PUSH=$(gh api repos/attentive-mobile/attentive-android-sdk --jq '.permissions.push' 2>/dev/null || echo "unknown")
+            echo "push access for this repo: $PUSH"
+            if [ "$PUSH" != "true" ]; then
+              echo "ERROR: token cannot write to this repo; aborting before any mutation."
+              exit 1
+            fi
       - run:
           name: Switch git remote to HTTPS with App token
           command: |
@@ -364,9 +394,8 @@ jobs:
                 echo "$PR_OUTPUT"
                 echo
                 echo "WARNING: could not open the release PR — continuing with the publish."
-                echo "'must be a collaborator' means GITHUB_TOKEN has no push access here."
-                echo "See the 'Verify token identity and scope' step above for what the"
-                echo "token can actually see — the App itself does have code + PR write."
+                echo "See 'Select the App token for gh and verify write access' above for"
+                echo "which token gh is using and whether it has write access here."
                 echo "Open the PR manually:"
                 echo "  https://github.com/attentive-mobile/attentive-android-sdk/compare/main...$BRANCH?expand=1"
               fi


### PR DESCRIPTION
## Ticket
[MSDK-485](https://attentivemobile.atlassian.net/browse/MSDK-485)

## Summary

The 2.2.2 release pushed `release/2.2.2`, then died before publishing anything:

```
pull request create failed: GraphQL: must be a collaborator (createPullRequest)
```

**Root cause:** in the release job `gh` authenticates as the machine user `circleci-attentive`, whose rights on this repo are `pull: true, push: false`. `GITHUB_TOKEN` in the `org-global` context is that user's classic PAT. The `attentive/app-based-github-token` step *does* mint a valid App installation token — it logs `Successfully extracted token from response` — but exports it under its own variable name, so `gh` fell through to `GITHUB_TOKEN`.

The clincher was the `Create GitHub Release` failure: `! Failed to create release, "workflow" scope may be required.` A *scope* message only ever comes from a classic PAT — App installation tokens have no scopes.

**The GitHub App is not misconfigured.** Its installation has code + pull request write and this repo is in scope, so no App permission change is needed. Nor is a context edit: granting `circleci-attentive` write would widen a shared machine user's access, against the intent of the July SECENG-4851 hardening.

Two things kept this hidden since June:

- **The `git push` never exercised the App token.** The job sets an HTTPS remote so the `extraheader` token is used, but CircleCI's `checkout` installs a global `url."ssh://git@github.com".insteadOf "https://github.com"` rewrite — the log confirms `To ssh://github.com/...`. Pushes go out under the SSH deploy key, which *does* have write. Green push, untested token.
- **The 2.2.1 release skipped the step.** `curl` became `gh` in `0c9532f` (SECENG-4851). For 2.2.1 `main` was already at `VERSION_NAME=2.2.1`, so the `git diff --cached --quiet` guard took the skip branch and `gh pr create` never ran. 2.2.2 was the first release whose target differed from `main`.

### Changes

- **`3a60adc`** — PR creation is no longer fatal. The PR is bookkeeping; the publish is the release. Failing *after* pushing the branch but *before* publishing is the worst outcome available, so it now logs the error plus a compare URL and continues. This is why 2.2.2 reached Maven Central at all.
- **`fd573d0`** — find the App token by prefix (`ghs_` = installation token; `ghp_`/`gho_`/`ghu_`/`github_pat_` = user tokens) and export it as `GH_TOKEN`, which `gh` prefers over `GITHUB_TOKEN`. The orb is private and its source isn't readable, so keying on the prefix avoids hardcoding its variable name. Then assert `.permissions.push` **before anything mutates** — a read-only token previously got as far as pushing a tag and uploading to Maven Central before dying.

Only variable *names* and 4-character type prefixes are logged; `BASH_ENV` receives `export GH_TOKEN="$VAR"` (indirect), so no token value is written to that file.

`gh release create` is deliberately left fatal: it runs after the publish, so a red build there signals an incomplete release without putting anything at risk.

## Test plan

CI on this branch runs `build-and-test`, not `release` (the `release` workflow is gated on the `run_release` pipeline parameter), so **this PR's checks do not exercise either change.**

Verified locally instead, by extracting the step from the YAML and running it under CircleCI's `#!/bin/bash -eo pipefail`:

- [x] YAML parses; release job step order unchanged apart from the new step
- [x] App token present + `push: true` → selects it, exports `GH_TOKEN`, proceeds
- [x] Only a user PAT present → exits 1, listing every GitHub token variable and its type
- [x] App token present but `push: false` → exits 1 before any mutation
- [x] PR-creation failure path (stub `gh` reproducing the exact GraphQL error) → prints warning + compare URL, exits 0, reaches the publish
- [x] PR-creation success path → unchanged behavior
- [x] No secret values in any output; `BASH_ENV` holds only an indirect reference

Post-merge, on the next real release:

- [ ] `Select the App token for gh and verify write access` reports `push access for this repo: true`
- [ ] `gh pr create` opens the release PR, authored by the App rather than `circleci-attentive`
- [ ] `Create GitHub Release` succeeds

**Note on fail-fast:** if the orb turns out to export its token outside the environment, the next release will abort at step 4 rather than half-complete. That's intended — it publishes nothing and prints the token inventory needed to finish the fix.

## Follow-ups (not in this PR)

- GitHub Release for 2.2.2 is missing (tag `2.2.2` exists at `6d53557`)
- `main` is still at `VERSION_NAME=2.2.1` while 2.2.2 is live on Maven Central
- Dead code: the HTTPS remote + `extraheader` steps never take effect under the `insteadOf` rewrite
- Cherry-pick to `develop` after merge (also missing `fe4096d`)

Generated with [Claude Code](https://claude.com/claude-code)


[MSDK-485]: https://attentivemobile.atlassian.net/browse/MSDK-485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ